### PR TITLE
fix: Korean food blog #59 enriched per Issue #15

### DIFF
--- a/story/dataclinic-report-59-koreanfood-story-pb/ko/index.html
+++ b/story/dataclinic-report-59-koreanfood-story-pb/ko/index.html
@@ -25,6 +25,7 @@
     <meta property="og:image" content="https://blog.pebblous.ai/story/image/dataclinic-report-59-koreanfood-story-pb.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="한국 이미지(음식) 데이터셋 DataClinic 진단 — 150개 클래스 15만 장 데이터 품질 분석">
     <meta property="og:site_name" content="Pebblous Blog">
     <meta property="og:locale" content="ko_KR">
     <meta property="article:published_time" content="2026-03-16">
@@ -34,6 +35,7 @@
     <meta name="twitter:title" content="150가지 한국 음식, 데이터로 해부하다 — 한국 이미지(음식) DataClinic 진단기">
     <meta name="twitter:description" content="한식 150개 클래스·15만 장을 DataClinic으로 진단. 품질점수 71점(보통). 송편이 AI에게 가장 전형적인 음식인 이유는?">
     <meta name="twitter:image" content="https://blog.pebblous.ai/story/image/dataclinic-report-59-koreanfood-story-pb.png">
+    <meta name="twitter:image:alt" content="한국 이미지(음식) 데이터셋 DataClinic 진단 — 150개 클래스 15만 장 데이터 품질 분석">
 
     <!-- Favicon -->
     <link rel="icon" href="/image/favicon.ico" sizes="any">
@@ -73,7 +75,7 @@
             }
         },
         "datePublished": "2026-03-16",
-        "dateModified": "2026-03-16",
+        "dateModified": "2026-03-17",
         "keywords": ["dataclinic","한국음식","한식","데이터품질","컴퓨터비전","koreanfood","AI","딥러닝","페블러스","DataClinic"]
     }
     </script>
@@ -87,42 +89,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
 
     <style>
-        :root {
-            --bg-primary: #ffffff;
-            --bg-secondary: #f8fafc;
-            --bg-card: rgba(255, 255, 255, 0.95);
-            --text-primary: #0f172a;
-            --text-secondary: #334155;
-            --text-muted: #64748b;
-            --accent-color: #F86825;
-            --teal-color: #0d9488;
-            --border-color: #e2e8f0;
-        }
-
-        [data-theme="dark"] {
-            --bg-primary: #0f172a;
-            --bg-secondary: #1e293b;
-            --bg-card: rgba(30, 41, 59, 0.95);
-            --text-primary: #f1f5f9;
-            --text-secondary: #cbd5e1;
-            --text-muted: #94a3b8;
-            --accent-color: #F86825;
-            --teal-color: #14b8a6;
-            --border-color: #334155;
-        }
-
-        [data-theme="beige"] {
-            --bg-primary: #f5f1e8;
-            --bg-secondary: #ebe3d5;
-            --bg-card: rgba(245, 241, 232, 0.95);
-            --text-primary: #2d2a26;
-            --text-secondary: #5a534a;
-            --text-muted: #78716c;
-            --accent-color: #F86825;
-            --teal-color: #0d9488;
-            --border-color: #d6cec0;
-        }
-
         body {
             font-family: var(--font-sans, 'Pretendard Variable', sans-serif);
             background-color: var(--bg-primary);
@@ -222,6 +188,70 @@
             font-size: 1rem;
         }
 
+        .cluster-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0; }
+        .cluster-card {
+            border-radius: 1rem;
+            padding: 1.25rem;
+            border: 2px solid var(--border-color);
+            background-color: var(--bg-card);
+        }
+        .cluster-card.soup { border-color: #0d9488; }
+        .cluster-card.dry  { border-color: #F86825; }
+        .cluster-card .cluster-title { font-size: 1rem; font-weight: 700; margin-bottom: 0.5rem; }
+        .cluster-card.soup .cluster-title { color: #0d9488; }
+        .cluster-card.dry  .cluster-title { color: #F86825; }
+        .cluster-card .cluster-desc { font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem; }
+        .cluster-foods { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }
+        .cluster-tag {
+            font-size: 0.75rem;
+            padding: 0.2rem 0.5rem;
+            border-radius: 1rem;
+            background-color: var(--bg-secondary);
+            color: var(--text-muted);
+            border: 1px solid var(--border-color);
+        }
+
+        .category-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 0.75rem;
+            margin: 1.5rem 0;
+        }
+        @media (min-width: 640px) { .category-grid { grid-template-columns: repeat(4, 1fr); } }
+        .category-card {
+            border-radius: 0.75rem;
+            padding: 1rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            text-align: center;
+        }
+        .category-card .cat-icon { font-size: 1.75rem; margin-bottom: 0.5rem; }
+        .category-card .cat-name { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); }
+        .category-card .cat-examples { font-size: 0.7rem; color: var(--text-muted); margin-top: 0.35rem; line-height: 1.5; }
+
+        .density-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 0.75rem;
+            margin: 1.5rem 0;
+        }
+        @media (min-width: 768px) { .density-grid { grid-template-columns: repeat(3, 1fr); } }
+        .density-card {
+            border-radius: 0.75rem;
+            overflow: hidden;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+        }
+        .density-card img { width: 100%; display: block; }
+        .density-card .den-info { padding: 0.5rem 0.75rem 0.65rem; }
+        .density-card .den-name { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); }
+        .density-card .den-note { font-size: 0.72rem; color: var(--text-muted); margin-top: 0.2rem; line-height: 1.4; }
+
+        .summary-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1rem 0; }
+        .summary-table th, .summary-table td { padding: 0.75rem; border-bottom: 1px solid var(--border-color); text-align: left; }
+        .summary-table th { font-weight: 600; color: var(--text-primary); background-color: var(--bg-secondary); }
+        .summary-table td { color: var(--text-secondary); }
+
         .fade-in-card {
             opacity: 0;
             transform: translateY(20px);
@@ -243,6 +273,7 @@
         <nav class="hidden lg:block sticky top-24 h-fit w-56 pr-8 text-sm">
             <h4 class="font-semibold themeable-heading mb-4">목차</h4>
             <ul id="toc-links" class="space-y-2 themeable-muted">
+                <li><a href="#한국음식-이야기" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">한국 음식 이야기</a></li>
                 <li><a href="#executive-summary" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">Executive Summary</a></li>
                 <li><a href="#데이터셋-소개" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">데이터셋 소개</a></li>
                 <li><a href="#종합-진단-결과" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">종합 진단 결과</a></li>
@@ -251,6 +282,7 @@
                 <li><a href="#level-3-도메인-특화-분석" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">Level 3: 도메인 특화 분석</a></li>
                 <li><a href="#이상치-분석" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">이상치 분석</a></li>
                 <li><a href="#개선-제안" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">개선 제안</a></li>
+                <li><a href="#결론" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">결론</a></li>
             </ul>
         </nav>
 
@@ -261,16 +293,55 @@
             <header class="text-center mb-12">
                 <h1 id="page-h1-title"></h1>
                 <p class="text-sm themeable-muted mt-4">2026.03 · (주)페블러스 데이터 커뮤니케이션팀</p>
-                <p class="text-sm themeable-muted mt-1">읽는 시간: ~15분 · <a href="../en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
+                <p class="text-sm themeable-muted mt-1">읽는 시간: ~20분 · <a href="../en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
             </header>
+
+            <!-- 한국 음식 이야기 — Cultural Intro -->
+            <section id="한국음식-이야기" class="mb-16 fade-in-card">
+                <div class="section-header">
+                    <div class="icon-wrapper">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+                        </svg>
+                    </div>
+                    <h2>한국 음식 이야기 — AI가 발견한 국물 문화</h2>
+                </div>
+                <div class="themeable-card rounded-xl p-6">
+                    <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
+                        <p>"<strong>국물도 없다(Guk-mul-do eop-da)</strong>" — 직역하면 "국물도 없다"이지만 실제 뜻은 "아무것도 없다", "한 푼도 없다"는 한국 관용구입니다. 한국 문화에서 국물(broth)은 가장 기본적으로 나눠야 할 것, 식사의 최소 단위라는 인식에서 나온 표현입니다. 이 관용구 하나가 한식의 본질을 담고 있습니다.</p>
+
+                        <p>전통 한국 식탁은 <strong>밥(bap) + 국(guk) + 반찬(banchan)</strong>의 삼각형 구조로 이루어집니다. 갈비탕, 삼계탕, 된장찌개, 미역국… 아무리 간소한 식사도 국 한 그릇은 갖추는 것이 한국의 식사 예의입니다. 한식 데이터셋 150개 클래스 중 상당수가 국물 음식인 것은 우연이 아닙니다. 그리고 이 사실은, 우리가 나중에 보게 될 것처럼, AI에도 고스란히 반영됩니다.</p>
+
+                        <p>K-팝과 K-드라마의 세계적 확산(한류, Hallyu)은 한국 음식에 대한 관심을 폭발적으로 키웠습니다. 드라마 속 삼겹살을 구우며 소주를 기울이는 장면, 새벽에 라면 한 그릇을 끓여 먹는 장면은 이제 전 세계 팬들에게도 익숙합니다. 넷플릭스 드라마 한 편이 특정 한국 음식의 전 세계 검색량을 수십 배 끌어올리는 시대, 음식 인식 AI에서 한식 카테고리는 더 이상 선택이 아닙니다.</p>
+
+                        <div class="mt-4 p-4 rounded-lg" style="background-color: var(--bg-secondary); border: 1px solid var(--border-color);">
+                            <p class="text-sm font-semibold themeable-heading mb-2">🌍 한국 음식이 처음인 분들을 위한 안내</p>
+                            <ul class="text-sm themeable-muted space-y-1 mt-2">
+                                <li>• <strong>반찬(Banchan)</strong> — 메인 요리 옆에 놓이는 작은 사이드 디시들. 한 끼 식사에 3~10가지. 깻잎장아찌처럼 독립 접시에 담기면 낯설게 보이는 이유입니다.</li>
+                                <li>• <strong>국물 문화(Guk-mul Culture)</strong> — 국·탕·찌개는 한국 식사의 필수 요소. 범용 AI가 한식을 두 덩어리로 나누는 이유가 바로 이것입니다.</li>
+                                <li>• <strong>계절 음식(Seasonal Foods)</strong> — 송편은 추석(한국 추수감사절)에만 먹는 음식. 반달 모양·파스텔 색상의 정형화된 사진이 반복되어 AI에게 '가장 전형적'이 됩니다.</li>
+                                <li>• <strong>조리 상태(Cooking State)</strong> — 삼겹살은 날것(분홍), 굽는 중(연기), 완성(갈색)이 모두 동일 클래스. 가장 많은 이상치가 나오는 구조적 이유입니다.</li>
+                            </ul>
+                        </div>
+
+                        <h3>🤖 AI 연구자를 위한 관점: 왜 한식 데이터는 흥미로운가</h3>
+                        <p>한식 이미지 인식은 컴퓨터 비전의 여러 어려운 문제를 한 데이터셋에 압축한 것과 같습니다.</p>
+                        <ul>
+                            <li><strong>Fine-grained 분류의 극한</strong> — 물냉면과 비빔냉면은 같은 냉면이지만 국물 유무로 외관이 완전히 달라집니다. 된장찌개와 김치찌개는 비슷한 그릇 구도이지만 색상이 다릅니다. ImageNet 수준의 범용 모델만으로는 부족한 이유입니다.</li>
+                            <li><strong>클래스 내 분산 불균형</strong> — 송편(매우 낮은 내부 분산) vs. 김밥(매우 높은 내부 분산)처럼, 클래스당 이미지 수가 거의 같아도 학습 난이도는 극단적으로 다릅니다. 균형 잡힌 데이터셋이 반드시 균형 잡힌 학습을 보장하지 않는다는 교훈입니다.</li>
+                            <li><strong>도메인 특화의 효과</strong> — 범용 렌즈(L2)에서 2개 클러스터가 도메인 특화 렌즈(L3)에서 1개로 통합됩니다. 한식 전문 백본이 만드는 피처 공간은 근본적으로 다른 구조를 가집니다.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
 
             <!-- Executive Summary -->
             <section id="executive-summary" class="mb-16 fade-in-card">
                 <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                 <div class="key-insight">
                     <p class="themeable-text leading-relaxed mb-4">본 포스팅은 페블러스 <a href="https://dataclinic.ai" class="text-orange-500 font-semibold hover:text-orange-400">데이터클리닉</a>을 이용한 한국 이미지(음식) 데이터셋의 <a href="https://dataclinic.ai/en/report/59" class="text-orange-500 font-semibold hover:text-orange-400">품질 진단보고서 #59</a>에 대한 핵심 인사이트를 담고 있습니다.</p>
-                    <p class="themeable-text leading-relaxed mb-4">한국 이미지(음식) 데이터셋은 갈비탕부터 후라이드치킨까지 150개 클래스, 총 150,507장의 이미지로 구성된 대규모 한식 데이터셋입니다. <a href="https://dataclinic.ai/data-clinic/skill" class="text-orange-500 font-semibold hover:text-orange-400">L1</a>(기초 품질) DataClinic 종합 진단 결과 <strong>품질점수 71점(보통)</strong>을 기록했습니다. 클래스 균형 측면에서는 최소 992장~최대 1,125장으로 표준편차 16.8에 불과한 교과서적 분포를 보여줍니다.</p>
-                    <p class="themeable-text leading-relaxed mb-4"><a href="https://dataclinic.ai/data-clinic/skill" class="text-orange-500 font-semibold hover:text-orange-400">L2</a>(특징 공간 분석) Wolfram ImageIdentify Net V2(1,280차원)에서는 범용 AI가 한식을 <strong>국물 있는 음식군과 건식 음식군</strong>이라는 두 클러스터로 구분하는 흥미로운 패턴이 발견되었습니다. 반면 <a href="https://dataclinic.ai/data-clinic/skill" class="text-orange-500 font-semibold hover:text-orange-400">L3</a>(도메인 최적화 분석, 129차원 한식 특화)에서는 이 두 클러스터가 하나의 한식 공간으로 통합됩니다.</p>
+                    <p class="themeable-text leading-relaxed mb-4">한국 이미지(음식) 데이터셋은 갈비탕부터 후라이드치킨까지 150개 클래스, 총 150,507장의 이미지로 구성된 대규모 한식 데이터셋입니다. DataClinic 종합 진단 결과 <strong>품질점수 71점(보통)</strong>을 기록했습니다. 클래스 균형 측면에서는 최소 992장~최대 1,125장으로 표준편차 16.8에 불과한 교과서적 분포를 보여줍니다.</p>
+                    <p class="themeable-text leading-relaxed mb-4"><a href="https://dataclinic.ai/data-clinic/skill" class="text-orange-500 font-semibold hover:text-orange-400">L2</a>(특징 공간 분석) Wolfram ImageIdentify Net V2(1,280차원)에서는 범용 AI가 한식을 <strong>국물 있는 음식군과 건식 음식군</strong>이라는 두 클러스터로 구분하는 패턴이 발견되었습니다. 반면 <a href="https://dataclinic.ai/data-clinic/skill" class="text-orange-500 font-semibold hover:text-orange-400">L3</a>(도메인 최적화 분석, 129차원)에서는 이 두 클러스터가 하나의 한식 공간으로 통합됩니다.</p>
                     <p class="themeable-text leading-relaxed">가장 '전형적인' 음식은 <strong>송편</strong>이었으며, 가장 이질적인 이미지는 <strong>김밥</strong>에서 발견되었습니다. 시각적 다양성이 낮은 클래스를 대상으로 Data Diet(중복 제거)가 권장됩니다.</p>
                 </div>
             </section>
@@ -287,26 +358,57 @@
                 </div>
                 <div class="themeable-card rounded-xl p-6">
                     <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
-                        <p>한국 이미지(음식) 데이터셋은 <a href="https://www.aihub.or.kr/aihubdata/data/view.do?currMenu=115&topMenu=100&aihubDataSe=realm&dataSetSn=79" class="text-orange-400 hover:text-orange-300" target="_blank" rel="noopener">AI Hub</a>에서 공개된 한국 전통 음식부터 현대 분식까지 <strong>150개 클래스, 총 150,507장</strong>의 이미지로 구성된 대규모 한식 비전 데이터셋입니다. 상업적 이용도 가능하여 AI 기반 음식 인식 서비스 개발에 즉시 활용할 수 있습니다.</p>
+                        <p>한국 이미지(음식) 데이터셋은 한국 전통 음식부터 현대 분식까지 <strong>150개 클래스, 총 150,507장</strong>의 이미지로 구성된 대규모 한식 비전 데이터셋입니다. AIHub에서 제공하며 상업적 이용도 가능하여 AI 기반 음식 인식 서비스 개발에 즉시 활용할 수 있습니다.</p>
 
-                        <p>150개 클래스는 한국 음식 문화의 풍경을 고스란히 담고 있습니다:</p>
-                        <ul>
-                            <li><strong>국·탕·찌개류</strong> — 갈비탕, 물냉면, 삼계탕, 추어탕, 육개장, 닭계장, 무국</li>
-                            <li><strong>구이류</strong> — 갈비구이, 삼겹살, 갈치구이, 고등어구이</li>
-                            <li><strong>조림·볶음류</strong> — 가지볶음, 깻잎장아찌, 간장게장, 갈비찜</li>
-                            <li><strong>분식류</strong> — 김밥, 라면, 만두, 떡볶이, 순대</li>
-                            <li><strong>전통 떡류</strong> — 송편, 경단, 꿀떡, 한과</li>
-                            <li><strong>해산물류</strong> — 멍게, 과메기, 젓갈</li>
-                            <li><strong>기타</strong> — 후라이드치킨(한국식), 짜장면, 짬뽕 등 외래 음식의 한국화 버전도 포함</li>
-                        </ul>
-
-                        <p>음식 이름 하나하나가 한국 음식 문화의 맥락을 가집니다. 멍게(우렁쉥이)는 특유의 비린향과 주홍색 때문에 AI 모델이 인식하기 어려운 음식 중 하나이며, 과메기는 포항 지역 겨울 제철 음식으로 시각적으로는 일반 생선포와 구분이 쉽지 않습니다. 이런 '도메인 지식이 필요한 음식들'이 데이터 품질에 어떤 영향을 미치는지가 이번 진단의 핵심입니다.</p>
+                        <p>150개 클래스는 한국 음식 문화의 풍경을 고스란히 담고 있습니다. 아래는 주요 카테고리별 분류입니다:</p>
                     </div>
 
-                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-1/english/collage.png"
-                             alt="한국 음식 데이터셋 — 150종 한식 대표 이미지 콜라주"
-                             class="max-w-[560px] max-h-[480px] object-contain mx-auto w-full rounded-lg my-4">
-                        <p class="text-xs themeable-muted text-center">한국 음식 데이터셋 — 150종 한식 대표 이미지 콜라주 (DataClinic L1 분석)</p>
+                    <!-- 150-class Category Cards -->
+                    <div class="category-grid mt-4">
+                        <div class="category-card">
+                            <div class="cat-icon">🍲</div>
+                            <div class="cat-name">국·탕·찌개류</div>
+                            <div class="cat-examples">갈비탕, 삼계탕, 추어탕<br>육개장, 된장찌개, 무국<br>시래기국, 북어국 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🍜</div>
+                            <div class="cat-name">면·밥류</div>
+                            <div class="cat-examples">물냉면, 비빔냉면, 라면<br>짜장면, 짬뽕<br>콩나물국밥 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🥩</div>
+                            <div class="cat-name">구이류</div>
+                            <div class="cat-examples">삼겹살, 갈비구이<br>갈치구이, 고등어구이<br>닭갈비 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🥘</div>
+                            <div class="cat-name">조림·볶음류</div>
+                            <div class="cat-examples">갈비찜, 장조림<br>메추리알장조림, 가지볶음<br>간장게장 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🌿</div>
+                            <div class="cat-name">김치·절임류</div>
+                            <div class="cat-examples">깻잎장아찌, 겉절이<br>열무김치, 깍두기<br>배추김치 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🍡</div>
+                            <div class="cat-name">분식류</div>
+                            <div class="cat-examples">김밥, 떡볶이, 순대<br>만두, 라볶이<br>후라이드치킨 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🍮</div>
+                            <div class="cat-name">떡·한과류</div>
+                            <div class="cat-examples">송편, 경단, 꿀떡<br>한과, 약식<br>인절미 등</div>
+                        </div>
+                        <div class="category-card">
+                            <div class="cat-icon">🦑</div>
+                            <div class="cat-name">해산물·젓갈류</div>
+                            <div class="cat-examples">멍게, 과메기, 젓갈<br>홍어, 꼬막<br>전복구이 등</div>
+                        </div>
+                    </div>
+
+                    <div class="themeable-text leading-relaxed prose prose-sm max-w-none mt-4">
+                        <p>음식 이름 하나하나가 한국 음식 문화의 맥락을 가집니다. <strong>멍게(우렁쉥이)</strong>는 특유의 비린향과 주홍색 때문에 AI 모델이 인식하기 어려운 음식 중 하나이며, <strong>과메기</strong>는 포항 지역 겨울 제철 음식으로 시각적으로는 일반 생선포와 구분이 쉽지 않습니다. <strong>후라이드치킨</strong>은 한국식으로 재해석된 외래 음식입니다. 이런 '도메인 지식이 필요한 음식들'이 데이터 품질에 어떤 영향을 미치는지가 이번 진단의 핵심 관전 포인트입니다.</p>
                     </div>
 
                     <!-- 대표 이미지: L1 클래스 평균 이미지 그리드 -->
@@ -336,7 +438,7 @@
                             <div class="food-name">멍게</div>
                         </div>
                     </div>
-                    <p class="text-xs themeable-muted text-center mt-2">▲ 클래스 평균 이미지 — 각 클래스의 1,000여 장을 픽셀 단위로 평균한 결과. 시각적 일관성이 높을수록 선명하게 나타납니다.</p>
+                    <p class="text-xs themeable-muted text-center mt-2">▲ 클래스 평균 이미지 — 각 클래스의 약 1,000장을 픽셀 단위로 평균한 결과. 선명할수록 시각적 일관성이 높습니다. 경단·꿀떡은 선명, 김밥은 상대적으로 흐릿한 점을 주목하세요.</p>
                 </div>
             </section>
 
@@ -378,7 +480,25 @@
                             </div>
                         </div>
 
-                        <p>종합 71점은 <strong>'보통' 등급</strong>으로, 대규모 공개 데이터셋 중에서는 상위권에 해당합니다. 클래스 균형이라는 근본 체력은 탁월하지만, 일부 클래스에서의 시각적 다양성 부족이 점수를 끌어내립니다. 상업적 이용이 허가되어 있어 실전 AI 개발에 바로 투입할 수 있는 수준의 데이터셋입니다.</p>
+                        <p>종합 71점은 <strong>'보통' 등급</strong>으로, 대규모 공개 데이터셋 중에서는 상위권에 해당합니다. 클래스 균형이라는 근본 체력은 탁월하지만, 일부 클래스에서의 시각적 다양성 부족이 점수를 제한합니다. 상업적 이용이 허가되어 있어 실전 AI 개발에 바로 투입할 수 있는 수준의 데이터셋입니다.</p>
+
+                        <table class="summary-table">
+                            <thead>
+                                <tr>
+                                    <th>진단 항목</th>
+                                    <th>결과</th>
+                                    <th>비고</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr><td>클래스 균형</td><td>✅ 좋음</td><td>표준편차 16.8 (교과서적)</td></tr>
+                                <tr><td>결측치</td><td>✅ 좋음</td><td>0.07% (103장/150,610장)</td></tr>
+                                <tr><td>채널 구성</td><td>✅ 좋음</td><td>99.42% RGB</td></tr>
+                                <tr><td>이미지 해상도</td><td>⚠️ 보통</td><td>121×91px ~ 6,048×4,032px</td></tr>
+                                <tr><td>클래스 내 다양성</td><td>⚠️ 보통</td><td>송편·물냉면 등 중복 밀집</td></tr>
+                                <tr><td>상업적 이용</td><td>✅ 허가</td><td>AIHub 출처</td></tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
             </section>
@@ -400,18 +520,20 @@
                         <h3>✅ 클래스 균형: 교과서적 수준</h3>
                         <p>150개 클래스의 이미지 수는 <strong>최소 992장 ~ 최대 1,125장</strong>으로, 표준편차가 단 <strong>16.8</strong>에 불과합니다. 이는 인위적으로 균형을 맞춘 수준의 분포입니다. 비교 대상으로, WikiArt 데이터셋의 클래스 균형 표준편차는 수천에 달합니다. AI 모델 학습 시 특정 음식에 편향될 위험이 극히 낮다는 의미입니다.</p>
 
+                        <p>단, 숫자의 균형이 학습의 균형을 보장하지는 않습니다. 송편 1,003장과 김밥 1,003장은 같은 수지만, 송편은 거의 모든 이미지가 비슷하고 김밥은 촬영 각도마다 전혀 다릅니다. 클래스 내 다양성(intra-class variance)은 L2/L3에서 더 자세히 드러납니다.</p>
+
                         <h3>⚠️ 이미지 해상도: 광범위한 스펙트럼</h3>
-                        <p>이미지 크기는 <strong>최소 121×91px에서 최대 6,048×4,032px</strong>까지 매우 넓게 분포합니다. 스마트폰 스냅샷부터 DSLR 전문 촬영까지 다양한 출처에서 수집된 흔적입니다. AI 학습을 위해서는 입력 해상도를 표준화하는 전처리가 필수입니다. 특히 최소 해상도인 121×91px 이미지는 ResNet-50(224×224px 입력 요구) 등 표준 모델에서 업스케일링이 필요합니다.</p>
+                        <p>이미지 크기는 <strong>최소 121×91px에서 최대 6,048×4,032px</strong>까지 매우 넓게 분포합니다. 스마트폰 스냅샷부터 DSLR 전문 촬영까지 다양한 출처에서 수집된 흔적입니다. AI 학습을 위해서는 입력 해상도를 표준화하는 전처리가 필수입니다. 최소 해상도인 121×91px 이미지는 ResNet-50(224×224px 입력 요구) 등 표준 모델에서 업스케일링이 필요합니다.</p>
 
                         <h3>✅ 채널 구성: 안정적</h3>
-                        <p>전체 이미지의 <strong>99.42%</strong>가 표준 RGB 3채널입니다. 0.33%는 알파 채널 포함 RGBa, 0.25%는 기타 포맷으로, 전처리 시 알파 채널 제거 혹은 RGB 변환이 필요한 이미지는 전체의 0.58%에 불과합니다.</p>
+                        <p>전체 이미지의 <strong>99.42%</strong>가 표준 RGB 3채널입니다. 0.33%는 알파 채널 포함 RGBa, 0.25%는 기타 포맷으로, 전처리 시 알파 채널 제거 또는 RGB 변환이 필요한 이미지는 전체의 0.58%에 불과합니다.</p>
 
                         <h3>✅ 결측치: 무시 가능한 수준</h3>
-                        <p>원본 150,610장 중 <strong>103장(0.07%)</strong>이 누락되어 150,507장이 실제 진단에 사용됐습니다. 0.07%는 대규모 웹 크롤링 기반 데이터셋 기준으로 매우 낮은 수준입니다. 실질적으로 무시 가능합니다.</p>
+                        <p>원본 150,610장 중 <strong>103장(0.07%)</strong>이 누락되어 150,507장이 실제 진단에 사용됐습니다. 0.07%는 대규모 웹 크롤링 기반 데이터셋 기준으로 매우 낮은 수준입니다.</p>
 
                         <div class="mt-6 p-4 rounded-lg" style="background-color: var(--bg-secondary); border: 1px solid var(--border-color);">
-                            <p class="text-sm font-semibold themeable-heading mb-2">🔍 도메인 인사이트: 클래스 평균 이미지가 말해주는 것</p>
-                            <p class="text-sm themeable-muted">위 평균 이미지들을 보면, 경단과 꿀떡은 선명하게 나타나는 반면 김밥은 약간 흐릿합니다. 이는 경단·꿀떡이 시각적으로 일관된 음식(비슷한 색, 형태, 배치)임을 의미하며, 김밥은 단면 컷·롤 형태·접시 배치 등 촬영 방식이 다양함을 시사합니다. 평균 이미지의 선명도가 곧 클래스 내 시각적 일관성의 지표입니다.</p>
+                            <p class="text-sm font-semibold themeable-heading mb-2">🔍 평균 이미지가 말해주는 것</p>
+                            <p class="text-sm themeable-muted">클래스 평균 이미지의 선명도는 클래스 내 시각적 일관성의 직접적인 지표입니다. 경단과 꿀떡이 선명하게 나타나는 반면 김밥이 흐릿한 이유는 — 경단·꿀떡은 색과 형태가 일관된 반면, 김밥은 단면 컷·롤 형태·접시 배치 등 촬영 방식이 다양하기 때문입니다. 이 선명도 차이는 나중에 이상치 분석에서 다시 등장합니다.</p>
                         </div>
                     </div>
                 </div>
@@ -429,14 +551,47 @@
                 </div>
                 <div class="themeable-card rounded-xl p-6">
                     <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
-                        <p>Level 2는 <strong>Wolfram ImageIdentify Net V2</strong>(1,280차원 특징 벡터)로 전체 데이터셋의 특징을 추출하고 분포를 분석합니다. 이 신경망은 음식 도메인에 특화되지 않은 범용 이미지 인식 모델입니다. 즉, 요리사가 아닌 일반인의 시선으로 한식을 바라보는 것과 같습니다.</p>
+                        <p>Level 2는 <strong>Wolfram ImageIdentify Net V2</strong>(1,280차원 특징 벡터)로 전체 데이터셋의 특징을 추출하고 분포를 분석합니다. 이 신경망은 음식 도메인에 특화되지 않은 범용 이미지 인식 모델입니다. 즉, 한식의 맥락을 모르는 외국인의 시선으로 사진을 바라보는 것과 같습니다.</p>
 
                         <h3>🌊 두 개의 클러스터: 국물 vs. 건식</h3>
-                        <p>PCA와 밀도 지형도 분석 결과, 범용 렌즈에서 한식은 <strong>두 개의 뚜렷한 클러스터</strong>로 나뉩니다. 분석 결과를 도메인 지식으로 해석하면:</p>
-                        <ul>
-                            <li><strong>클러스터 A (건식 음식군)</strong> — 구이, 볶음, 떡, 전, 분식. 단단한 형태와 진한 색감이 특징</li>
-                            <li><strong>클러스터 B (국물 음식군)</strong> — 국, 탕, 찌개, 면류. 넓은 그릇에 담긴 액체 형태가 특징</li>
-                        </ul>
+                        <p>PCA와 밀도 지형도 분석 결과, 범용 렌즈에서 한식은 <strong>두 개의 뚜렷한 클러스터</strong>로 나뉩니다. 도메인 지식으로 해석하면:</p>
+                    </div>
+
+                    <!-- Cluster Cards -->
+                    <div class="cluster-grid">
+                        <div class="cluster-card soup">
+                            <div class="cluster-title">🍜 클러스터 B — 국물 음식군</div>
+                            <div class="cluster-desc">넓은 그릇에 담긴 액체 형태. 열기·증기·배경 국물이 시각적 특징.</div>
+                            <div class="cluster-foods">
+                                <span class="cluster-tag">물냉면</span>
+                                <span class="cluster-tag">비빔냉면</span>
+                                <span class="cluster-tag">갈비탕</span>
+                                <span class="cluster-tag">삼계탕</span>
+                                <span class="cluster-tag">육개장</span>
+                                <span class="cluster-tag">된장찌개</span>
+                                <span class="cluster-tag">무국</span>
+                                <span class="cluster-tag">라면</span>
+                                <span class="cluster-tag">짬뽕</span>
+                            </div>
+                        </div>
+                        <div class="cluster-card dry">
+                            <div class="cluster-title">🥩 클러스터 A — 건식 음식군</div>
+                            <div class="cluster-desc">단단한 형태, 진한 색감, 접시 위 고체 구성물이 시각적 특징.</div>
+                            <div class="cluster-foods">
+                                <span class="cluster-tag">삼겹살</span>
+                                <span class="cluster-tag">갈비구이</span>
+                                <span class="cluster-tag">김밥</span>
+                                <span class="cluster-tag">송편</span>
+                                <span class="cluster-tag">경단</span>
+                                <span class="cluster-tag">한과</span>
+                                <span class="cluster-tag">만두</span>
+                                <span class="cluster-tag">순대</span>
+                                <span class="cluster-tag">떡볶이</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
                         <p>이것이 바로 한식 특유의 <strong>'국물 문화'</strong>가 이미지 데이터에도 고스란히 반영된다는 증거입니다. 범용 AI가 레시피나 재료를 알지 못해도, 시각적 구조만으로 '국물 있음/없음'을 자연스럽게 학습합니다.</p>
 
                         <p>아래 PCA 시각화에서 클래스별 평균 특징의 분포를 확인할 수 있습니다:</p>
@@ -445,28 +600,69 @@
                              class="max-w-[560px] max-h-[480px] object-contain mx-auto w-full rounded-lg my-4" loading="lazy">
 
                         <h3>📊 분포: 종형(Bell-shaped) — 양호</h3>
-                        <p>전체 밀도 분포는 <strong>종형 곡선</strong>을 유지합니다. 대부분의 이미지가 특징 공간 중심부에 밀집하고, 양 극단에 소수 이상치가 분포합니다. 이는 정규 분포에 가까운 건강한 데이터 구조입니다.</p>
+                        <p>전체 밀도 분포는 <strong>종형 곡선</strong>을 유지합니다. 대부분의 이미지가 특징 공간 중심부에 밀집하고, 양 극단에 소수 이상치가 분포합니다. 정규 분포에 가까운 건강한 데이터 구조입니다.</p>
 
                         <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/gXYZ5.png"
                              alt="L2 전체 밀도 플롯 — 한국 이미지(음식)"
                              class="max-w-[560px] max-h-[480px] object-contain mx-auto w-full rounded-lg my-4" loading="lazy">
 
-                        <h3>🔬 클래스별 밀도 비교: 라면 vs. 멍게</h3>
-                        <p>클래스별 밀도 분포를 비교해 보면 흥미로운 차이가 나타납니다. 라면은 밀도 분포가 좁고 높은 피크를 형성하는 반면, 멍게는 상대적으로 넓고 낮은 분포를 보입니다. 라면은 빨간 국물+면+파 조합이라는 시각적 일관성이 높지만, 멍게는 날것·손질 후·플레이팅 등 다양한 상태로 촬영되기 때문입니다.</p>
+                        <h3>🔬 클래스별 밀도 비교 — 6가지 음식의 초상</h3>
+                        <p>클래스별 밀도 분포를 비교하면 음식마다 극적으로 다른 패턴이 나타납니다. 아래 6개 클래스는 고밀도(시각적으로 일관된)부터 저밀도(다양한)까지의 스펙트럼을 보여줍니다:</p>
+                    </div>
 
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 my-4">
-                            <div>
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EB%9D%BC%EB%A9%B4.png"
-                                     alt="라면 클래스 밀도 분포" class="w-full rounded-lg" loading="lazy">
-                                <p class="text-xs themeable-muted text-center mt-1">라면 — 밀도 분포가 좁고 집중적</p>
+                    <!-- L2 Classwise Density Grid -->
+                    <div class="density-grid">
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EC%86%A1%ED%8E%B8.png"
+                                 alt="송편 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">송편 🍡</div>
+                                <div class="den-note">반달 모양·파스텔 색상 반복 → 피크가 좁고 높음. 가장 '전형적' 음식</div>
                             </div>
-                            <div>
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EB%A9%8D%EA%B2%8C.png"
-                                     alt="멍게 클래스 밀도 분포" class="w-full rounded-lg" loading="lazy">
-                                <p class="text-xs themeable-muted text-center mt-1">멍게 — 밀도 분포가 넓고 다양</p>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EB%AC%BC%EB%83%89%EB%A9%B4.png"
+                                 alt="물냉면 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">물냉면 🍜</div>
+                                <div class="den-note">그릇+맑은 국물 구도 일관 → 국물 클러스터 내 높은 밀도</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EB%9D%BC%EB%A9%B4.png"
+                                 alt="라면 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">라면 🍜</div>
+                                <div class="den-note">빨간 국물+면+파 조합이 시각적으로 고정 → 좁고 집중적인 분포</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EC%82%BC%EA%B2%B9%EC%82%B4.png"
+                                 alt="삼겹살 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">삼겹살 🥩</div>
+                                <div class="den-note">날것·굽는 중·완성 3단계가 혼재 → 분포가 두 봉우리로 갈라짐</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EB%A9%8D%EA%B2%8C.png"
+                                 alt="멍게 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">멍게 🦑</div>
+                                <div class="den-note">날것·손질 후·플레이팅 등 다양 → 넓고 낮은 분포</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-2/Lens-1.6/english/densityPlot/%EA%B9%80%EB%B0%A5.png"
+                                 alt="김밥 L2 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">김밥 🍱</div>
+                                <div class="den-note">단면·측면·접시 등 앵글 다양 → 가장 넓은 저밀도 분포</div>
                             </div>
                         </div>
                     </div>
+
+                    <p class="text-xs themeable-muted text-center mt-2">▲ L2 클래스별 밀도 분포. 피크가 좁고 높을수록 시각적으로 일관된 음식, 넓고 낮을수록 촬영 다양성이 큰 음식입니다.</p>
                 </div>
             </section>
 
@@ -495,12 +691,69 @@
                              class="max-w-[560px] max-h-[480px] object-contain mx-auto w-full rounded-lg my-4" loading="lazy">
 
                         <h3>📈 분포: 여전히 종형 — 안정적</h3>
-                        <p>도메인 특화 렌즈에서도 전체 분포는 <strong>종형(Bell-shaped)</strong>을 유지합니다. 클러스터가 통합되면서도 분포의 건강한 형태는 유지되었다는 것은, 도메인 특화가 단순히 압축이 아니라 의미 있는 표현 학습임을 보여줍니다.</p>
+                        <p>도메인 특화 렌즈에서도 전체 분포는 종형을 유지합니다. 클러스터가 통합되면서도 분포의 건강한 형태가 유지된 것은 도메인 특화가 단순 압축이 아닌 의미 있는 표현 학습임을 보여줍니다.</p>
 
                         <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/gXYZ5.png"
                              alt="L3 전체 밀도 플롯 — 한식 도메인 특화"
                              class="max-w-[560px] max-h-[480px] object-contain mx-auto w-full rounded-lg my-4" loading="lazy">
+
+                        <h3>🔬 L3 클래스별 밀도 — 도메인 렌즈가 바꾼 것들</h3>
+                        <p>L2에서 L3로 넘어가면서 클래스별 분포가 어떻게 바뀌었을까요? 주목할 변화를 6개 클래스로 확인합니다:</p>
                     </div>
+
+                    <!-- L3 Classwise Density Grid -->
+                    <div class="density-grid">
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EC%86%A1%ED%8E%B8.png"
+                                 alt="송편 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">송편 🍡</div>
+                                <div class="den-note">L3에서도 고밀도 유지. 한식 렌즈에서도 추석 대표 음식의 일관성은 변하지 않음</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EB%AC%BC%EB%83%89%EB%A9%B4.png"
+                                 alt="물냉면 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">물냉면 🍜</div>
+                                <div class="den-note">두 냉면(물·비빔)이 한식 공간에서 더 가깝게 묶임</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EB%9D%BC%EB%A9%B4.png"
+                                 alt="라면 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">라면 🍜</div>
+                                <div class="den-note">라면 특유의 빨간 국물이 한식 렌즈에서 탁월한 식별자로 작동</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EC%82%BC%EA%B2%B9%EC%82%B4.png"
+                                 alt="삼겹살 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">삼겹살 🥩</div>
+                                <div class="den-note">조리 상태 차이에 따른 분산이 L3에서도 지속. 고기 도메인 특성</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EB%A9%8D%EA%B2%8C.png"
+                                 alt="멍게 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">멍게 🦑</div>
+                                <div class="den-note">한식 전문 렌즈에서도 독특한 형태로 인해 분포가 넓게 유지됨</div>
+                            </div>
+                        </div>
+                        <div class="density-card">
+                            <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/koreanfood/level-3.2/Lens-1.6/english/densityPlot/%EA%B9%80%EB%B0%A5.png"
+                                 alt="김밥 L3 클래스 밀도 분포" loading="lazy">
+                            <div class="den-info">
+                                <div class="den-name">김밥 🍱</div>
+                                <div class="den-note">L3에서 저밀도 패턴 지속. 앵글 다양성은 도메인 특화로도 해소되지 않음</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <p class="text-xs themeable-muted text-center mt-2">▲ L3 클래스별 밀도 분포. L2와 비교해 전체 클러스터는 통합되었으나, 개별 클래스의 내부 분산 패턴은 음식의 고유한 특성에 따라 유지됩니다.</p>
                 </div>
             </section>
 
@@ -521,14 +774,14 @@
                         <h3>🏆 고밀도 샘플 — AI가 인식하는 '전형적 한식'</h3>
                         <p>고밀도 샘플, 즉 특징 공간에서 가장 중심에 위치한 이미지들에는 <strong>송편과 물냉면</strong>이 주를 이룹니다. 이는 우연이 아닙니다.</p>
 
-                        <p><strong>송편</strong>은 시각적으로 매우 일관된 음식입니다:</p>
+                        <p><strong>송편</strong>은 한국의 추석(Chuseok, 음력 8월 15일) 명절 음식으로, 쌀가루 반죽 안에 깨·팥·밤을 넣어 반달 모양으로 빚어 솔잎 위에 쪄서 만듭니다. 시각적으로 매우 일관된 음식입니다:</p>
                         <ul>
                             <li>반달 모양의 동일한 실루엣</li>
-                            <li>흰색·분홍색·초록색의 정해진 색상 팔레트</li>
+                            <li>흰색·분홍색·초록색의 정형화된 색상 팔레트</li>
                             <li>접시 위에 가지런히 놓인 정형화된 구도</li>
                             <li>배경이 단순하고 조명이 균일한 경우가 많음</li>
                         </ul>
-                        <p>AI 입장에서 송편은 "예측 가능한" 이미지입니다. 거의 모든 송편 사진이 비슷한 특징 벡터를 가지기 때문에 밀도가 높게 측정됩니다.</p>
+                        <p>AI 입장에서 송편은 "예측 가능한" 이미지입니다. 거의 모든 송편 사진이 비슷한 특징 벡터를 가지기 때문에 밀도가 높게 측정됩니다. 역설적으로 이 '전형성'이 Data Diet 대상 1순위이기도 합니다.</p>
 
                         <div class="outlier-grid">
                             <div class="outlier-card">
@@ -564,10 +817,10 @@
                         <h3>⚠️ 저밀도 샘플 — 이상치의 정체</h3>
                         <p>저밀도 이상치로는 <strong>김밥, 순대, 깻잎장아찌, 삼겹살</strong>이 상위권을 차지합니다. 이들의 공통점은 촬영 각도, 플레이팅 방식, 조리 상태가 제각각이라는 것입니다:</p>
                         <ul>
-                            <li><strong>김밥</strong> — 단면 노출(단무지·계란 구성 노출) vs. 옆면(원통형 외관)으로 전혀 다른 이미지가 섞임</li>
-                            <li><strong>삼겹살</strong> — 구워지기 전 분홍빛 vs. 구워진 후 갈색빛으로 색상이 크게 달라짐</li>
-                            <li><strong>깻잎장아찌</strong> — 접시에 단독으로 담긴 형태 vs. 쌈으로 활용된 형태</li>
-                            <li><strong>순대</strong> — 통째로 vs. 잘린 단면 노출 형태</li>
+                            <li><strong>김밥</strong> — 단면 노출(단무지·계란 구성 노출) vs. 옆면(원통형 외관). 외국인들이 종종 일본 마키롤과 혼동하지만, 김밥은 참기름을 바른 밥과 한국식 재료를 사용하는 전혀 다른 음식입니다. 이 시각적 다양성이 낮은 밀도의 원인입니다.</li>
+                            <li><strong>삼겹살</strong> — 구워지기 전 분홍빛 vs. 구워진 후 갈색빛. 색상이 극단적으로 달라집니다.</li>
+                            <li><strong>깻잎장아찌</strong> — 접시에 단독으로 담긴 형태 vs. 쌈으로 활용된 형태. 전형적인 반찬의 딜레마.</li>
+                            <li><strong>순대</strong> — 통째로 vs. 잘린 단면 노출 형태.</li>
                         </ul>
 
                         <div class="outlier-grid">
@@ -601,25 +854,27 @@
                             </div>
                         </div>
 
-                        <h3>↔️ 가장 다른 쌍: 한과 vs. 김밥·육개장</h3>
-                        <p>유사도 분석에서 특징 공간상 가장 거리가 먼 이미지 쌍이 발견되었습니다. <strong>한과</strong>와 <strong>김밥/육개장</strong>의 조합이 대표적입니다. 한과는 황금색·갈색의 건조하고 정형화된 과자 형태인 반면, 김밥은 흑백 원통형에 알록달록한 단면, 육개장은 붉은 국물이 가득한 그릇 형태로—색상, 질감, 형태 모든 면에서 대극적입니다.</p>
+                        <h3>↔️ 가장 다른 쌍: 한과 vs. 김밥</h3>
+                        <p>유사도 분석에서 특징 공간상 가장 거리가 먼 이미지 쌍이 발견되었습니다. <strong>한과</strong>와 <strong>김밥</strong>의 조합이 대표적입니다. 한과는 황금색·갈색의 건조하고 정형화된 과자 형태인 반면, 김밥은 흑백 원통형에 알록달록한 단면으로 — 색상, 질감, 형태 모든 면에서 대극적입니다.</p>
+
+                        <p>한과(Korean confectionery)는 쌀·콩·꿀로 만든 전통 과자로, 혼례·제사 등 의례에 빠지지 않는 음식입니다. 외관이 정갈하고 형태가 정형화되어 있어 AI에게는 고밀도 음식입니다. 반면 김밥은 어떤 각도로 찍느냐에 따라 완전히 다른 이미지가 됩니다.</p>
 
                         <div class="comparison-pair">
                             <div class="text-center">
                                 <img src="https://cdn.dataclinic.ai/datasets/koreanfood/train/%ED%95%9C%EA%B3%BC/Img_145_0915.jpg" alt="한과 — 가장 거리가 먼 쌍 기준 이미지" loading="lazy">
-                                <p class="text-xs themeable-muted mt-1">한과</p>
+                                <p class="text-xs themeable-muted mt-1">한과 (Korean confectionery)</p>
                             </div>
                             <div class="text-center vs-badge">VS</div>
                             <div class="text-center">
                                 <img src="https://cdn.dataclinic.ai/datasets/koreanfood/train/%EA%B9%80%EB%B0%A5/Img_069_0888.jpg" alt="김밥 — 한과와 가장 거리가 먼 이미지" loading="lazy">
-                                <p class="text-xs themeable-muted mt-1">김밥</p>
+                                <p class="text-xs themeable-muted mt-1">김밥 (Gimbap)</p>
                             </div>
                         </div>
                         <p class="text-xs themeable-muted text-center">▲ 특징 공간에서 가장 멀리 떨어진 쌍. 색상·질감·형태 모든 면에서 대극적입니다.</p>
 
                         <div class="mt-4 p-4 rounded-lg" style="background-color: var(--bg-secondary); border: 1px solid var(--border-color);">
                             <p class="text-sm font-semibold themeable-heading mb-2">💡 이상치 분석의 실전 활용</p>
-                            <p class="text-sm themeable-muted">저밀도 이상치는 두 가지 의미를 가집니다. ① 레이블 오류 가능성 — 해당 클래스에 속하지 않는 이미지가 잘못 레이블링된 경우, ② 다양성 풍부한 샘플 — 비전형적이지만 실제 촬영 환경에서 자주 등장하는 변형. 두 번째 경우는 오히려 모델 강건성(Robustness)을 높이는 데 중요합니다. DataClinic 이상치 샘플을 수동으로 검토하여 오류와 다양성을 구분하는 것이 품질 개선의 첫 단계입니다.</p>
+                            <p class="text-sm themeable-muted">저밀도 이상치는 두 가지 의미를 가집니다. ① <strong>레이블 오류 가능성</strong> — 해당 클래스에 속하지 않는 이미지가 잘못 레이블링된 경우. ② <strong>다양성 풍부한 샘플</strong> — 비전형적이지만 실제 촬영 환경에서 자주 등장하는 변형. 두 번째 경우는 오히려 모델 강건성(Robustness)을 높이는 데 중요합니다. DataClinic 이상치 샘플을 수동으로 검토하여 오류와 다양성을 구분하는 것이 품질 개선의 첫 단계입니다.</p>
                         </div>
                     </div>
                 </div>
@@ -637,15 +892,15 @@
                 </div>
                 <div class="themeable-card rounded-xl p-6">
                     <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
-                        <p>DataClinic은 이 데이터셋에 <strong>Data Diet(데이터 다이어트)</strong>를 권장합니다. 품질점수 71점(보통)이라는 점수는 클래스 균형의 교과서적 품질에도 불구하고, 특정 클래스의 시각적 다양성 부족이 발목을 잡고 있기 때문입니다.</p>
+                        <p>DataClinic은 이 데이터셋에 <strong>Data Diet(데이터 다이어트)</strong>를 권장합니다. 품질점수 71점(보통)은 클래스 균형의 교과서적 품질에도 불구하고, 특정 클래스의 시각적 다양성 부족이 발목을 잡고 있기 때문입니다.</p>
 
                         <h3>🥗 Data Diet란?</h3>
                         <p>Data Diet는 단순히 데이터를 줄이는 것이 아닙니다. 고밀도 영역에 밀집한 <strong>거의 동일한 이미지를 식별하고 중복을 제거</strong>하여 모델이 더 다양한 패턴을 학습할 수 있도록 돕습니다.</p>
 
                         <ul>
-                            <li><strong>송편</strong> — 반달 모양·파스텔 색상의 이미지가 밀집. 다양한 조명 조건·러스틱 스타일·빚는 장면 등 비전형적 이미지 추가 권장</li>
-                            <li><strong>물냉면</strong> — 그릇 중앙 구도가 반복적. 더 다양한 앵글과 플레이팅 스타일 보강 권장</li>
-                            <li><strong>고밀도 클래스 전반</strong> — 중복 이미지 제거 후 다양한 촬영 환경(식당·가정·길거리) 이미지로 대체 권장</li>
+                            <li><strong>송편</strong> — 반달 모양·파스텔 색상의 이미지가 밀집. 빚는 장면, 러스틱 스타일, 다양한 조명 조건의 이미지를 보강하면 모델이 실제 환경에서 더 강건하게 작동합니다.</li>
+                            <li><strong>물냉면</strong> — 그릇 중앙 구도가 반복적. 다양한 앵글과 플레이팅 스타일 보강을 권장합니다.</li>
+                            <li><strong>고밀도 클래스 전반</strong> — 중복 이미지 제거 후 식당·가정·길거리 등 다양한 촬영 환경 이미지로 대체하는 것이 이상적입니다.</li>
                         </ul>
 
                         <h3>💊 Data Bulkup(데이터 보강)은 필요없나요?</h3>
@@ -668,6 +923,77 @@
                 </div>
             </section>
 
+            <!-- 결론 -->
+            <section id="결론" class="mb-12">
+                <div class="section-header">
+                    <div class="icon-wrapper">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+                        </svg>
+                    </div>
+                    <h2>결론 — 150가지 한식, 데이터로 본 세 가지 발견</h2>
+                </div>
+                <div class="themeable-card rounded-xl p-6">
+                    <div class="themeable-text leading-relaxed prose prose-sm max-w-none">
+                        <p>한국 이미지(음식) 데이터셋 #59 진단에서 우리는 세 가지 핵심 발견을 얻었습니다.</p>
+
+                        <p><strong>첫째, 국물 문화는 데이터에도 나타난다.</strong> 범용 AI(Wolfram ImageIdentify Net V2)가 한식을 학습했을 때 자연스럽게 국물 음식군과 건식 음식군이라는 두 클러스터를 형성했습니다. 레시피나 재료 정보 없이, 순수한 시각적 패턴만으로 한국 음식 문화의 본질적 구조를 포착한 것입니다. 한식을 한 번도 먹어본 적 없는 AI가 "한식에는 항상 국물이 있다"는 사실을 스스로 발견했습니다.</p>
+
+                        <p><strong>둘째, 도메인 특화는 단절이 아닌 통합을 만든다.</strong> 한식 특화 렌즈(L3, 129차원)를 적용했을 때 두 클러스터가 하나로 통합되었습니다. 이는 도메인 지식이 데이터를 어떻게 재해석하는지를 잘 보여줍니다. 한식을 아는 렌즈는 갈비탕과 삼겹살의 시각적 차이보다 둘이 모두 '한식'이라는 공통성을 더 중요하게 봅니다.</p>
+
+                        <p><strong>셋째, 균형 잡힌 수가 균형 잡힌 학습을 보장하지 않는다.</strong> 표준편차 16.8이라는 교과서적 클래스 균형에도 불구하고, 송편(내부 분산 극히 낮음)과 김밥(내부 분산 극히 높음) 사이의 학습 난이도 차이는 엄청납니다. Data Diet로 고밀도 중복을 제거하면 71점에서 80점대로의 점수 향상이 예상됩니다.</p>
+
+                        <div class="mt-6 p-5 rounded-xl" style="background: linear-gradient(135deg, rgba(248,104,37,0.07), rgba(13,148,136,0.07)); border: 1px solid var(--border-color);">
+                            <p class="text-sm font-semibold themeable-heading mb-3">📊 진단 결과 한눈에</p>
+                            <table class="summary-table">
+                                <thead>
+                                    <tr>
+                                        <th>레벨</th>
+                                        <th>핵심 발견</th>
+                                        <th>시사점</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>L1</strong></td>
+                                        <td>클래스 균형 표준편차 16.8</td>
+                                        <td>편향 학습 위험 극히 낮음</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>L2</strong></td>
+                                        <td>범용 AI가 국물/건식 2클러스터 형성</td>
+                                        <td>범용 백본 사용 시 국물-비국물 혼동 가능</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>L3</strong></td>
+                                        <td>한식 특화 렌즈에서 클러스터 통합</td>
+                                        <td>도메인 특화 피처 추출기 도입 효과 확실</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>이상치</strong></td>
+                                        <td>송편 고밀도, 김밥 저밀도</td>
+                                        <td>Data Diet 타겟: 고밀도 클래스 중복 제거</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                            <div class="mt-4 text-center">
+                                <a href="https://dataclinic.ai/en/report/59"
+                                   class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-semibold text-sm text-white"
+                                   style="background: linear-gradient(135deg, #F86825, #ff8a50);">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                                    </svg>
+                                    DataClinic 리포트 #59 전체 보기
+                                </a>
+                            </div>
+                        </div>
+
+                        <p class="mt-4 text-sm">더 많은 데이터셋 진단 사례와 DataClinic 활용법은 <a href="https://dataclinic.ai" class="text-orange-500 font-semibold hover:text-orange-400">dataclinic.ai</a>에서 확인하세요.</p>
+                    </div>
+                </div>
+            </section>
+
             <!-- FAQ: auto-injected by PebblousPage via config.faqs -->
 
         </main>
@@ -678,33 +1004,28 @@
     <!-- Scripts -->
     <script src="/scripts/common-utils.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', async function() {
-            const config = {
-                mainTitle: "150가지 한국 음식, 데이터로 해부하다",
-                subtitle: "한국 이미지(음식) DataClinic 진단기 — 품질점수 71점(보통)의 진실",
-                pageTitle: "150가지 한국 음식, 데이터로 해부하다 — 한국 이미지(음식) DataClinic 진단기 | 페블러스",
-                category: "story",
-                publishDate: "2026-03-16",
-                publisher: "(주)페블러스 데이터 커뮤니케이션팀",
-                articlePath: "story/dataclinic-report-59-koreanfood-story-pb/ko/",
-                defaultTheme: "light",
-                tags: ["dataclinic", "한국음식", "한식", "데이터품질", "컴퓨터비전", "koreanfood", "AI", "딥러닝", "페블러스", "DataClinic"],
-                faqs: [
-                    { question: "한국 이미지(음식) 데이터셋이란 무엇인가요?", answer: "한국 음식 이미지로 구성된 대규모 컴퓨터 비전 데이터셋으로, 갈비탕·송편·김밥 등 150개 클래스, 총 150,507장의 이미지를 포함합니다. 상업적 이용이 허가되어 있어 음식 인식 AI 서비스 개발에 즉시 활용할 수 있습니다." },
-                    { question: "이 데이터셋의 DataClinic 종합 점수는 얼마인가요?", answer: "품질점수 71점(보통)입니다. 클래스 균형(표준편차 16.8)은 교과서적 수준으로 탁월하지만, 송편 등 일부 클래스의 시각적 다양성 부족이 점수를 제한합니다. Data Diet(중복 제거)를 적용하면 80점대로 상승 가능합니다." },
-                    { question: "DataClinic L1/L2/L3 진단이 의미하는 것은 무엇인가요?", answer: "L1은 픽셀 수준 기초 품질(RGB 채널, 결측값, 클래스 불균형), L2는 범용 AI 모델(Wolfram ImageIdentify Net V2, 1,280차원) 기반 특징 공간 분석, L3는 해당 데이터셋에 특화된 도메인 최적화 렌즈(129차원) 기반 정밀 분석입니다." },
-                    { question: "범용 AI가 한식을 두 클러스터로 나누는 이유는 무엇인가요?", answer: "Wolfram ImageIdentify Net V2와 같은 범용 비전 모델은 시각적 구조를 기반으로 이미지를 분류합니다. 한식에서는 '국물 있는 음식(국·탕·면류)'과 '건식 음식(구이·볶음·떡·분식)'이 가장 큰 시각적 차이를 만들기 때문에 두 클러스터로 구분됩니다. 이는 한국 음식 문화의 '국물 문화'가 이미지 데이터에도 반영된 결과입니다." },
-                    { question: "왜 송편이 AI에게 가장 '전형적인' 음식인가요?", answer: "송편은 반달 모양의 일관된 실루엣, 흰색·분홍색·초록색의 정형화된 색상, 가지런히 놓인 배치로 시각적 일관성이 매우 높습니다. AI 모델은 유사한 특징 벡터를 가진 이미지들을 '전형적'으로 인식하는데, 송편의 대부분 이미지가 비슷한 특성을 보이기 때문에 고밀도(density 0.69~) 샘플에 집중됩니다." },
-                    { question: "저밀도 이상치(김밥, 삼겹살 등)는 제거해야 하나요?", answer: "반드시 제거해야 하는 것은 아닙니다. 저밀도 이상치는 두 가지 의미를 가집니다: ① 레이블 오류(해당 클래스에 속하지 않는 이미지) 또는 ② 다양한 촬영 조건의 비전형적 샘플. 두 번째 경우는 오히려 모델 강건성(Robustness)을 높이는 데 중요합니다. 수동 검토로 오류와 다양성을 구분하는 것이 권장됩니다." },
-                    { question: "Data Diet란 무엇이고 왜 이 데이터셋에 권장되나요?", answer: "Data Diet는 고밀도 영역에 밀집한 거의 동일한(중복) 이미지를 제거하여 데이터셋의 다양성을 높이는 방법입니다. 한국 이미지(음식) 데이터셋에서는 송편·물냉면 등이 유사한 이미지를 과도하게 포함하고 있어, 중복 제거 후 다양한 촬영 환경의 이미지로 대체하면 모델이 더 다양한 패턴을 학습할 수 있습니다." },
-                    { question: "DataClinic 원본 보고서는 어디서 확인할 수 있나요?", answer: "DataClinic 리포트 #59 (한국 이미지(음식)) 전체 결과는 dataclinic.ai/en/report/59에서 확인하실 수 있습니다. L1~L3 상세 차트, 150개 클래스별 밀도 분석, 이상치 샘플 갤러리 등 풍부한 시각화 도구를 제공합니다." }
-                ]
-            };
-
-            if (typeof PebblousPage !== 'undefined') {
-                await PebblousPage.init(config);
-            }
-        });
+        const config = {
+            mainTitle: "150가지 한국 음식, 데이터로 해부하다",
+            subtitle: "한국 이미지(음식) DataClinic 진단기 — 품질점수 71점(보통)의 진실",
+            pageTitle: "150가지 한국 음식, 데이터로 해부하다 — 한국 이미지(음식) DataClinic 진단기 | 페블러스",
+            category: "story",
+            publishDate: "2026-03-16",
+            publisher: "(주)페블러스 데이터 커뮤니케이션팀",
+            articlePath: "story/dataclinic-report-59-koreanfood-story-pb/ko/",
+            defaultTheme: "light",
+            tags: ["dataclinic", "한국음식", "한식", "데이터품질", "컴퓨터비전", "koreanfood", "AI", "딥러닝", "페블러스", "DataClinic"],
+            faqs: [
+                { question: "한국 이미지(음식) 데이터셋이란 무엇인가요?", answer: "한국 음식 이미지로 구성된 대규모 컴퓨터 비전 데이터셋으로, 갈비탕·송편·김밥 등 150개 클래스, 총 150,507장의 이미지를 포함합니다. AIHub에서 제공하며 상업적 이용이 허가되어 있어 음식 인식 AI 서비스 개발에 즉시 활용할 수 있습니다." },
+                { question: "이 데이터셋의 DataClinic 종합 점수는 얼마인가요?", answer: "품질점수 71점(보통)입니다. 클래스 균형(표준편차 16.8)은 교과서적 수준으로 탁월하지만, 송편 등 일부 클래스의 시각적 다양성 부족이 점수를 제한합니다. Data Diet(중복 제거)를 적용하면 80점대로 상승 가능합니다." },
+                { question: "DataClinic L1/L2/L3 진단이 의미하는 것은 무엇인가요?", answer: "L1은 픽셀 수준 기초 품질(RGB 채널, 결측값, 클래스 불균형), L2는 범용 AI 모델(Wolfram ImageIdentify Net V2, 1,280차원) 기반 특징 공간 분석, L3는 해당 데이터셋에 특화된 도메인 최적화 렌즈(129차원) 기반 정밀 분석입니다." },
+                { question: "범용 AI가 한식을 두 클러스터로 나누는 이유는 무엇인가요?", answer: "Wolfram ImageIdentify Net V2와 같은 범용 비전 모델은 시각적 구조를 기반으로 이미지를 분류합니다. 한식에서는 '국물 있는 음식(국·탕·면류)'과 '건식 음식(구이·볶음·떡·분식)'이 가장 큰 시각적 차이를 만들기 때문에 두 클러스터로 구분됩니다. 이는 한국 음식 문화의 '국물 문화'가 이미지 데이터에도 반영된 결과입니다." },
+                { question: "왜 송편이 AI에게 가장 '전형적인' 음식인가요?", answer: "송편은 반달 모양의 일관된 실루엣, 흰색·분홍색·초록색의 정형화된 색상, 가지런히 놓인 배치로 시각적 일관성이 매우 높습니다. AI 모델은 유사한 특징 벡터를 가진 이미지들을 '전형적'으로 인식하는데, 송편의 대부분 이미지가 비슷한 특성을 보이기 때문에 고밀도(density 0.69~) 샘플에 집중됩니다." },
+                { question: "저밀도 이상치(김밥, 삼겹살 등)는 제거해야 하나요?", answer: "반드시 제거해야 하는 것은 아닙니다. 저밀도 이상치는 두 가지 의미를 가집니다: ① 레이블 오류(해당 클래스에 속하지 않는 이미지) 또는 ② 다양한 촬영 조건의 비전형적 샘플. 두 번째 경우는 오히려 모델 강건성(Robustness)을 높이는 데 중요합니다. 수동 검토로 오류와 다양성을 구분하는 것이 권장됩니다." },
+                { question: "Data Diet란 무엇이고 왜 이 데이터셋에 권장되나요?", answer: "Data Diet는 고밀도 영역에 밀집한 거의 동일한(중복) 이미지를 제거하여 데이터셋의 다양성을 높이는 방법입니다. 한국 이미지(음식) 데이터셋에서는 송편·물냉면 등이 유사한 이미지를 과도하게 포함하고 있어, 중복 제거 후 다양한 촬영 환경의 이미지로 대체하면 모델이 더 다양한 패턴을 학습할 수 있습니다." },
+                { question: "DataClinic 원본 보고서는 어디서 확인할 수 있나요?", answer: "DataClinic 리포트 #59 (한국 이미지(음식)) 전체 결과는 dataclinic.ai/en/report/59에서 확인하실 수 있습니다. L1~L3 상세 차트, 150개 클래스별 밀도 분석, 이상치 샘플 갤러리 등 풍부한 시각화 도구를 제공합니다." }
+            ]
+        };
+        PebblousPage.init(config);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Closes #15
- 704 → 1,031 lines with rich cultural and technical content

## Changes

**새로운 섹션**
- `한국음식-이야기`: 국물 문화 스토리 + 외국인 안내 callout + AI 연구자 관점
- `결론`: 3대 발견 서사 + 진단 결과 요약 테이블 + DataClinic CTA 버튼

**확장된 섹션**
- `데이터셋-소개`: 150개 클래스 카테고리 카드 8종 (emoji icons)
- `Level 2`: 클러스터 카드 UI (국물 vs 건식) + L2 클래스별 밀도 그리드 6종
- `Level 3`: L3 클래스별 밀도 그리드 6종
- `종합-진단-결과`: 진단 항목 요약 표 추가

**버그 수정 (Issue #15 요구사항)**
- `og:image:alt` / `twitter:image:alt` 메타 태그 추가
- 인라인 `:root` / `[data-theme]` CSS 변수 블록 제거 (theme-variables.css 활용)
- `PebblousPage.init`: DOMContentLoaded 래퍼 및 typeof 가드 제거 → 직접 호출
- `dateModified` → 2026-03-17 갱신

## Test plan

- [ ] TOC `id="toc-links"` 확인 및 모든 앵커 링크 동작
- [ ] 새 섹션들(`#한국음식-이야기`, `#결론`) 앵커 이동 정상 확인
- [ ] 클러스터 카드, 카테고리 카드 렌더링 확인
- [ ] L2/L3 density grid 6x2 이미지 로드 확인
- [ ] `PebblousPage.init` 직접 호출 — 헤더/푸터/FAQ 정상 주입 확인
- [ ] `og:image:alt` / `twitter:image:alt` 메타 태그 존재 확인
- [ ] 다크/라이트/베이지 테마 전환 시 CSS 변수 정상 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)