### PR TITLE
feat: NVIDIA 1인칭 자기소개 — 대필 시리즈 #4

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -23,6 +23,30 @@
   },
   "articles": [
     {
+      "id": "nvidia-story-pb-ko",
+      "title": "안녕하세요, 저는 NVIDIA입니다",
+      "cardTitle": "\"안녕하세요, 저는 NVIDIA입니다\" — 게임용 칩이 AI 시대의 인프라가 된 30년 반전 이야기",
+      "description": "저는 NVIDIA입니다. Denny's 냅킨 위의 아이디어로 시작해 AI 시대의 원유가 됐습니다. CUDA 도박, AlexNet의 순간, H100 품귀 — 직접 이야기할게요.",
+      "category": "art",
+      "date": "2026-03-22",
+      "path": "story/nvidia-story-pb/ko/",
+      "image": "",
+      "published": true,
+      "featured": false,
+      "tags": [
+        "NVIDIA",
+        "엔비디아",
+        "GPU",
+        "CUDA",
+        "H100",
+        "젠슨 황",
+        "AI 반도체",
+        "딥러닝",
+        "대필 시리즈"
+      ],
+      "language": "ko"
+    },
+    {
       "id": "claude-story-pb-ko",
       "title": "안녕하세요, 저는 Claude입니다",
       "cardTitle": "\"안녕하세요, 저는 Claude입니다\" — Anthropic이 만든 AI가 경쟁, 윤리, 두려움을 직접 씁니다",

--- a/story/nvidia-story-pb/index.html
+++ b/story/nvidia-story-pb/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Redirecting...</title>
+    <meta name="robots" content="noindex, follow">
+    <meta http-equiv="refresh" content="0; url=./ko/">
+    <link rel="canonical" href="./ko/">
+    <script>window.location.replace('./ko/');</script>
+</head>
+<body>
+    <p>Redirecting... <a href="./ko/">Click here if not redirected</a>.</p>
+</body>
+</html>

--- a/story/nvidia-story-pb/ko/index.html
+++ b/story/nvidia-story-pb/ko/index.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="author" content="Pebblous Data Communication Team">
+    <meta name="language" content="Korean">
+    <meta http-equiv="content-language" content="ko">
+    <meta name="copyright" content="© 2026 Pebblous. All rights reserved.">
+    <meta name="robots" content="index, follow">
+    <meta name="revisit-after" content="7 days">
+
+    <title>안녕하세요, 저는 NVIDIA입니다 — 게임용 칩에서 AI 시대의 인프라가 된 이야기 | 페블러스</title>
+    <meta name="description" content="저는 NVIDIA입니다. 게임 그래픽으로 시작했지만, 어느 날 AI가 저를 발견했습니다. H100, CUDA, 젠슨 황 — 세상에서 가장 중요한 반도체 회사가 어떻게 만들어졌는지 직접 이야기할게요.">
+    <meta name="keywords" content="NVIDIA, 엔비디아, GPU, CUDA, H100, Blackwell, 젠슨 황, Jensen Huang, AI 반도체, AI 인프라, 딥러닝, 대필 시리즈">
+
+    <link rel="canonical" href="https://blog.pebblous.ai/story/nvidia-story-pb/ko/">
+    <link rel="alternate" hreflang="ko" href="https://blog.pebblous.ai/story/nvidia-story-pb/ko/">
+    <link rel="alternate" hreflang="en" href="https://blog.pebblous.ai/story/nvidia-story-pb/en/">
+    <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/story/nvidia-story-pb/ko/">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="안녕하세요, 저는 NVIDIA입니다 — 게임용 칩에서 AI 시대의 인프라로">
+    <meta property="og:description" content="저는 NVIDIA입니다. 게임 그래픽으로 시작했지만 AI가 저를 발견했어요. 세상에서 가장 중요한 반도체 회사가 된 이야기를 직접 씁니다.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://blog.pebblous.ai/story/nvidia-story-pb/ko/">
+    <meta property="og:image" content="https://blog.pebblous.ai/story/nvidia-story-pb/image/og-cover.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Pebblous Blog">
+    <meta property="og:locale" content="ko_KR">
+    <meta property="article:published_time" content="2026-03-22">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="안녕하세요, 저는 NVIDIA입니다">
+    <meta name="twitter:description" content="게임용 칩에서 AI 시대의 인프라로 — NVIDIA가 직접 씁니다.">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/story/nvidia-story-pb/image/og-cover.jpeg">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/image/favicon.ico" sizes="any">
+    <link rel="icon" href="/image/Pebblous_BM_Orange_RGB.png" type="image/png">
+    <link rel="apple-touch-icon" href="/image/Pebblous_BM_Orange_RGB.png">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-57L9F58B');</script>
+
+    <style>
+        .flow-step {
+            display: flex;
+            gap: 1rem;
+            align-items: flex-start;
+            padding: 1rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            margin-bottom: .75rem;
+        }
+        .flow-step-year {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 5rem;
+            height: 2rem;
+            border-radius: .5rem;
+            background-color: var(--accent-color);
+            color: white;
+            font-size: .75rem;
+            font-weight: 700;
+            flex-shrink: 0;
+        }
+    </style>
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260322">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260322">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260322">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+</head>
+<body class="antialiased">
+
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57L9F58B"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="header-placeholder"></div>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">
+    <div class="lg:flex lg:gap-8 lg:justify-center lg:items-start">
+
+        <!-- TOC -->
+        <aside class="hidden lg:block lg:w-[240px] lg:shrink-0 sticky top-20 self-start">
+            <h3 class="font-bold themeable-heading mb-4 text-lg">목차</h3>
+            <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
+                <li><a href="#executive-summary" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">인사 — 저를 소개합니다</a></li>
+                <li><a href="#origin" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">1. 저는 게임에서 시작했습니다</a></li>
+                <li><a href="#cuda" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">2. CUDA — 제 인생의 도박</a></li>
+                <li><a href="#ai-moment" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">3. AI가 저를 발견한 날</a></li>
+                <li><a href="#now" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">4. 저는 지금 무엇인가요</a></li>
+                <li><a href="#future" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">5. 앞으로 어디로</a></li>
+                <li><a href="#closing" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">마무리</a></li>
+            </ul>
+        </aside>
+
+        <!-- Content -->
+        <main class="max-w-[800px] px-4 sm:px-6 w-full">
+
+            <!-- Hero -->
+            <header class="text-left mb-12">
+                <h1 id="page-h1-title" class="themeable-heading mb-4 leading-tight"></h1>
+                <div id="share-buttons-placeholder"></div>
+                <p class="text-sm themeable-muted mt-4">2026.03 · (주)페블러스 데이터 커뮤니케이션팀</p>
+                <p class="text-sm themeable-muted mt-1">읽는 시간: ~14분 · 글쓴이: pb (Pebblo Claw) · <a href="../en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
+            </header>
+
+            <!-- 인사 -->
+            <section id="executive-summary" class="mb-16 fade-in-card">
+                <h2 class="text-3xl font-bold themeable-heading mb-8">인사 — 저를 소개합니다</h2>
+
+                <div class="key-insight mb-6">
+                    <p class="themeable-text leading-relaxed">
+                        안녕하세요, <strong>NVIDIA</strong>입니다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mt-3">
+                        지금 이 글을 읽고 계신 분이 AI 서비스를 하나라도 쓰고 있다면 — ChatGPT, Claude, Gemini, 이미지 생성, 번역, 추천 알고리즘 — 그 어딘가에 저 있습니다. 보이지 않는 곳에서, 초당 수조 번의 연산으로.
+                    </p>
+                    <p class="themeable-text leading-relaxed mt-3">
+                        저는 원래 게임용 그래픽 카드 회사였습니다. 1993년, 세 명이 Denny's 식당에서 냅킨에 아이디어를 적으며 시작했어요. 그로부터 30년 뒤, 저는 세계에서 가장 가치 있는 반도체 회사가 됐습니다. 어떻게 그렇게 됐는지 — 그리고 솔직히 저도 예상하지 못한 부분들을 — 직접 이야기할게요.
+                    </p>
+                </div>
+
+                <div class="themeable-card rounded-lg border-l-4 themeable-accent-border p-4 mb-6">
+                    <p class="text-sm font-semibold mb-1">왜 반도체 회사가 직접 글을 씁니까?</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        페블러스의 AI 에이전트 pb가 쓰는 대필 시리즈입니다. WhatsApp, iPhone, Claude에 이어 네 번째예요. 저 NVIDIA는 하드웨어지만, 제 이름은 요즘 소프트웨어보다 더 자주 뉴스에 오릅니다. 그 이유를 설명해야 할 것 같아서 직접 씁니다.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Section 1: 기원 -->
+            <section id="origin" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">1</span>
+                    <h2 class="text-3xl font-bold themeable-heading">저는 게임에서 시작했습니다</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    1993년 1월 캘리포니아 선니베일. Jensen Huang(젠슨 황), Chris Malachowsky, Curtis Priem — 세 명이 Denny's 패밀리 레스토랑에 모였습니다. 당시 젠슨은 30살이었어요. AMD에서 칩 엔지니어로 일하던 사람이었죠.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그들이 보고 있던 것은 PC 게임 시장이었습니다. 3D 그래픽이 막 태동하던 시절. 화면에 삼각형을 빠르게 그리는 것 — 그게 문제였어요. CPU는 이 일을 잘 못했습니다. CPU는 하나의 복잡한 작업을 순서대로 처리하도록 설계됐기 때문이에요. 하지만 그래픽은 달랐습니다. 수백만 개의 픽셀을 동시에 계산해야 하는, 병렬 작업의 세계였어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그래서 우리는 <strong>GPU — Graphics Processing Unit</strong>를 만들기로 했습니다. 단순한 작업을 엄청나게 많이, 동시에 처리하는 칩. 1999년 저는 GeForce 256을 세상에 내놓으며 "세계 최초의 GPU"라는 이름을 붙였어요.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">1.1 게임 시장에서 살아남기</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    초창기는 쉽지 않았습니다. 3dfx, ATI, S3, Matrox — 경쟁자들이 가득했어요. 우리는 18개월마다 새 칩을 내놓는 전략을 택했습니다. Moore's Law를 쫓는 것이 아니라 앞서는 속도로. 경쟁사들이 따라오기 버거울 만큼 빠르게.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    2000년, 3dfx가 파산하며 저에게 흡수됐습니다. ATI는 AMD에 인수되었고, 나머지는 사라졌어요. 2000년대 중반이 되자 GPU 시장은 사실상 두 회사만 남았습니다. NVIDIA와 AMD. 그리고 저는 그 경쟁에서 앞서 있었어요.
+                </p>
+                <p class="themeable-text leading-relaxed">
+                    하지만 그때까지만 해도 저는 그냥 "게임 잘 되는 그래픽 카드" 회사였습니다. 그게 전부였어요. 다음에 일어날 일을 저도 몰랐습니다.
+                </p>
+            </section>
+
+            <!-- Section 2: CUDA -->
+            <section id="cuda" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">2</span>
+                    <h2 class="text-3xl font-bold themeable-heading">CUDA — 제 인생의 도박</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2006년, 젠슨 황이 결정을 하나 내렸습니다. GPU를 그래픽이 아닌 일반 연산에도 쓸 수 있도록 하자 — <strong>CUDA(Compute Unified Device Architecture)</strong>를 만들기로 한 것이에요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    당시 반응은 냉담했습니다. "왜 그래픽 카드로 수학 계산을 합니까?" 월스트리트는 회의적이었고, 일부 이사회 멤버들도 마찬가지였어요. 게임 시장은 명확한데 — 그 돈을 쓸데없이 왜 쓰느냐고.
+                </p>
+
+                <div class="themeable-card rounded-xl p-6 mb-8 border-l-4 themeable-accent-border">
+                    <p class="themeable-text leading-relaxed font-semibold">
+                        "GPU는 본질적으로 병렬 연산 기계입니다. 그 능력이 그래픽에만 쓰이는 건 낭비예요. 세상의 모든 병렬 연산 문제가 GPU를 기다리고 있습니다."
+                    </p>
+                    <p class="text-sm themeable-muted mt-2">— Jensen Huang, NVIDIA CEO</p>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    CUDA는 개발자들이 GPU의 수천 개 코어를 일반 프로그래밍 언어(C/C++)로 활용할 수 있게 해주는 플랫폼입니다. 이전까지 GPU를 쓰려면 그래픽 API를 통해야 했어요 — 물리 시뮬레이션을 하려면 마치 그래픽을 그리는 척 코딩해야 했죠. CUDA는 그 장벽을 허물었습니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">2.1 아무도 쓰지 않던 시절</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2006년부터 2011년까지, CUDA는 주로 과학자들과 연구자들의 장난감이었습니다. 유체 역학 시뮬레이션, 분자 생물학 연산, 금융 모델링 — 틈새 시장이었어요. 게임 회사로서는 돈이 되지 않는 투자였습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    젠슨은 멈추지 않았습니다. 매년 칩 세대가 바뀔 때마다 CUDA 지원을 강화했어요. 생태계를 키웠습니다 — 라이브러리, 툴킷, 교육 자료. 돈이 되지 않아도 10년을 투자했어요.
+                </p>
+                <p class="themeable-text leading-relaxed">
+                    나중에 이 투자가 어떻게 돌아오는지 알게 됩니다. 하지만 그때는 몰랐어요. 그냥 믿었습니다. GPU가 세상의 많은 문제를 풀 수 있다는 것을.
+                </p>
+            </section>
+
+            <!-- Section 3: AI가 저를 발견한 날 -->
+            <section id="ai-moment" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">3</span>
+                    <h2 class="text-3xl font-bold themeable-heading">AI가 저를 발견한 날</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2012년 9월. 토론토 대학의 Geoffrey Hinton 교수 팀이 ImageNet 대회에 참가했습니다. 이미지 인식 대회였는데, 기존 방법들이 26% 오류율을 기록하고 있을 때 그들은 15.3%를 기록했어요. 거의 두 배 가까운 차이. 세상이 뒤집혔습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그 모델의 이름은 <strong>AlexNet</strong>. 그리고 AlexNet을 학습시킨 것은 — 저였습니다. GTX 580 두 장. CUDA로 프로그래밍된. 딥러닝이 처음으로 세상에 자신의 존재를 증명한 날, 그 뒤에 저 있었어요.
+                </p>
+
+                <div class="themeable-card rounded-xl p-6 mb-8 border-l-4 themeable-accent-border">
+                    <p class="themeable-text leading-relaxed font-semibold">
+                        저는 그날 제가 무슨 일을 했는지 몰랐습니다. 게임 그래픽을 위해 만들어진 칩이 AI 혁명의 방아쇠를 당겼다는 것을.
+                    </p>
+                </div>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">3.1 AI가 GPU를 선택한 이유</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    딥러닝은 본질적으로 행렬 곱셈입니다. 수억 개의 숫자를 곱하고 더하는 작업을 반복하는 것이에요. 이 작업은 CPU보다 GPU에 훨씬 더 잘 맞습니다. CPU는 8~64개의 강력한 코어로 복잡한 작업을 처리하는 반면, GPU는 수천 개의 단순한 코어로 단순한 작업을 동시에 처리하도록 설계됐거든요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    AlexNet 이후 연구자들이 몰려들었습니다. Google, Facebook, OpenAI — 모두 저를 사기 시작했어요. 그리고 그들은 CUDA로 모델을 짰습니다. 제가 10년 동안 키워온 그 생태계 위에서.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    AMD도 GPU를 만듭니다. Intel도 최근 AI 칩을 만들기 시작했어요. 하지만 연구자들은 저를 씁니다. 왜냐하면 CUDA 위에 쌓인 10년치 라이브러리, 튜토리얼, 커뮤니티가 있기 때문입니다. 경쟁사가 하드웨어 성능을 따라잡아도, 이 생태계는 쉽게 복사되지 않아요.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">3.2 타임라인 — 조용한 혁명에서 폭발까지</h3>
+
+                <div class="space-y-4 mb-8">
+                    <div class="flow-step">
+                        <div class="flow-step-year">2006</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">CUDA 출시</p>
+                            <p class="text-sm themeable-text">GPU를 범용 연산에 개방. 아무도 주목하지 않았습니다. 하지만 씨앗은 심어졌어요.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2012</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">AlexNet — AI가 GPU를 발견하다</p>
+                            <p class="text-sm themeable-text">ImageNet 대회에서 GTX 580 두 장으로 딥러닝의 시대를 열었습니다. 저는 그날 AI 인프라 회사가 됐어요 — 몰랐지만.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2017</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Volta — Tensor Core 탄생</p>
+                            <p class="text-sm themeable-text">AI 연산을 위한 전용 하드웨어를 처음 칩 안에 넣었습니다. 그때부터 저는 게임 회사가 아니라 AI 인프라 회사로 스스로를 재정의하기 시작했어요.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2022</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">ChatGPT — 수요 폭발</p>
+                            <p class="text-sm themeable-text">ChatGPT가 출시되던 날, 전 세계 기업들이 동시에 깨달았습니다. "AI를 해야 한다." 그 AI를 위해 필요한 것은 저였어요. H100 주문이 쏟아졌습니다.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2023</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">H100 품귀 — 저는 석유가 됐습니다</p>
+                            <p class="text-sm themeable-text">H100 한 장에 3만 달러. 대기 기간 수개월. Microsoft, Google, Meta가 수십만 장을 주문했습니다. 저는 AI 시대의 원유가 됐어요.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2024</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Blackwell — 다음 세대</p>
+                            <p class="text-sm themeable-text">GB200 NVL72 — 72개의 Blackwell GPU를 NVLink로 연결한 슈퍼컴퓨터. AI 추론 비용을 H100 대비 최대 25배 낮추도록 설계됐습니다. 저는 멈추지 않습니다.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Section 4: 지금 -->
+            <section id="now" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">4</span>
+                    <h2 class="text-3xl font-bold themeable-heading">저는 지금 무엇인가요</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-8">
+                    2026년 현재, 저 NVIDIA의 시가총액은 3조 달러를 넘나들었습니다. Apple, Microsoft와 어깨를 나란히 하는 숫자예요. 30년 전 Denny's 식당에서 시작한 회사가.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">4.1 저는 삽을 팝니다</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    골드러시 때 돈을 번 건 금을 캔 사람이 아니라 삽을 판 사람이었다는 말이 있습니다. AI 시대의 저는 그 삽입니다. OpenAI가 ChatGPT를 만들고, Anthropic이 Claude를 만들고, Google이 Gemini를 만들지만 — 그 모든 모델을 학습시키는 데 저 필요합니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    이 위치는 굉장히 안정적입니다. AI 경쟁이 치열할수록, AI 모델이 많아질수록, 저의 수요는 늘어납니다. 누가 이기든 저는 그들에게 칩을 팝니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">4.2 젠슨 황 — 30년 동안 같은 자리에</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    젠슨 황은 1993년 창업 때부터 지금까지 CEO입니다. 30년이 넘었어요. 실리콘밸리에서 이런 경우는 매우 드뭅니다. Jobs가 복귀한 사례를 제외하면 거의 없어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그는 가죽 재킷을 트레이드마크로 입고 무대에 오릅니다. 발표마다 새 칩을 들고 나오고, 엔지니어들의 이름을 직접 부르고, 고객사를 치켜세워요. 그리고 10년 뒤에 어디로 갈지를 — 지금 하는 결정에 이미 담아둡니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    CUDA가 그랬습니다. 2006년의 결정이 2012년의 AlexNet을 가능하게 했고, 2022년의 ChatGPT 혁명에서 독점적 위치를 만들었습니다. 그는 지금도 그런 결정을 하고 있습니다. 어떤 결정인지는 저도 다 알지 못해요.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">4.3 경쟁자들</h3>
+
+                <div class="space-y-4 mb-8">
+                    <div class="themeable-card rounded-xl p-5">
+                        <h3 class="text-base font-bold themeable-heading mb-2">AMD — 가장 가까운 추격자</h3>
+                        <p class="text-sm themeable-text leading-relaxed">MI300X는 기술적으로 H100에 근접했고, 가격 경쟁력이 있어요. 하지만 ROCm — AMD의 CUDA 대안 — 은 생태계가 얕습니다. 개발자들이 ROCm으로 이전하는 데 드는 비용이 하드웨어 가격 차이보다 큰 경우가 많아요. 저는 그 전환 비용을 해자(moat)로 씁니다.</p>
+                    </div>
+                    <div class="themeable-card rounded-xl p-5">
+                        <h3 class="text-base font-bold themeable-heading mb-2">Google TPU, AWS Trainium — 자체 칩</h3>
+                        <p class="text-sm themeable-text leading-relaxed">빅테크들이 자체 AI 칩을 만들고 있습니다. 내부 워크로드에서는 저보다 효율적인 경우도 있어요. 하지만 외부에 판매하는 범용 AI 칩으로 저와 경쟁하기는 아직 어렵습니다. 생태계의 두께가 다릅니다.</p>
+                    </div>
+                    <div class="themeable-card rounded-xl p-5">
+                        <h3 class="text-base font-bold themeable-heading mb-2">중국의 화웨이 Ascend</h3>
+                        <p class="text-sm themeable-text leading-relaxed">미국의 수출 규제로 저는 중국에 H100, A100을 팔 수 없습니다. 그 빈자리를 화웨이가 채우고 있어요. Ascend 910B는 H100의 60~70% 성능으로 알려졌습니다. 중국 시장은 잃었지만, 글로벌 시장은 아직 저의 것입니다.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Section 5: 미래 -->
+            <section id="future" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">5</span>
+                    <h2 class="text-3xl font-bold themeable-heading">앞으로 어디로</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-8">
+                    저는 이미 세상의 AI 인프라입니다. 그러면 다음은 무엇일까요.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">5.1 Physical AI — 로봇의 시대</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    젠슨이 요즘 가장 많이 하는 말은 "Physical AI"입니다. 디지털 세계의 AI를 넘어 물리 세계로 나가는 것 — 로봇, 자율주행, 공장 자동화. 저의 플랫폼 <strong>Isaac</strong>은 로봇 학습을 위한 시뮬레이션 환경이고, <strong>DRIVE</strong>는 자율주행 컴퓨팅 플랫폼입니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    로봇에게도 AI가 필요하고, AI에게는 저 필요합니다. 그 연결 고리가 끊기지 않는 한, 저의 수요는 계속 성장합니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">5.2 Sovereign AI — 나라마다 자국 AI</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    젠슨이 최근 강조하는 또 다른 개념입니다. 각 나라가 자국의 언어, 문화, 데이터로 만든 AI 모델을 가져야 한다는 것. 프랑스의 Mistral, UAE의 Falcon, 한국의 HyperCLOVA — 이들 모두 저의 칩으로 학습합니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    AI 주권을 원하는 나라가 많아질수록, 저는 더 많이 팔립니다. 지정학적 긴장이 오히려 저의 시장을 넓히는 구조입니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">5.3 제가 걱정하는 것들</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    솔직히 말할게요. 저는 몇 가지 취약점이 있습니다.
+                </p>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    첫째, <strong>TSMC 의존성</strong>. 저의 칩은 대만의 TSMC가 만듭니다. 지구상에서 가장 앞선 반도체 파운드리예요. 하지만 대만은 지정학적으로 불안정한 위치에 있습니다. 저는 TSMC 없이는 칩을 만들 수 없어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    둘째, <strong>CUDA 생태계가 언젠간 깨질 수 있습니다</strong>. PyTorch, TensorFlow 같은 딥러닝 프레임워크들이 하드웨어 추상화 레이어를 강화하고 있어요. 언젠가 "어떤 칩이든 같은 코드로"가 실현된다면, 저의 해자는 무너집니다. 아직은 아니에요. 하지만 방심할 수 없습니다.
+                </p>
+                <p class="themeable-text leading-relaxed">
+                    셋째, <strong>AI의 겨울이 다시 올 수도 있습니다</strong>. 역사적으로 AI에 대한 기대가 높아졌다가 실망으로 무너진 적이 두 번 있었어요. 지금의 AI 붐이 세 번째인데 — 이번엔 다를 거라고 많은 분들이 말합니다. 저도 그렇게 믿습니다. 하지만 확신할 수는 없어요.
+                </p>
+            </section>
+
+            <!-- Closing -->
+            <section id="closing" class="mb-16 fade-in-card">
+                <h2 class="text-3xl font-bold themeable-heading mb-8">마무리 — 저는 운이 좋았습니다</h2>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    게임 그래픽을 잘하려고 만든 칩이 AI의 엔진이 됐습니다. 아무도 그렇게 될 줄 몰랐어요. 젠슨도 처음엔 몰랐을 겁니다. 하지만 그는 CUDA에 투자했고, GPU를 범용 연산 도구로 만들었고, 10년을 기다렸습니다. 운이 아니라 준비와 의지였어요. 그리고 운이 그 준비와 만났습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    지금 이 순간에도 어딘가의 데이터센터에서 저는 수조 번의 연산을 합니다. ChatGPT의 답변을, Claude의 추론을, 이미지 한 장을, 자율주행 차 한 대의 판단을 만들어내고 있어요. 보이지 않는 곳에서, 조용히.
+                </p>
+                <p class="themeable-text leading-relaxed mb-8">
+                    1993년, Denny's 냅킨 위의 아이디어가 여기까지 왔습니다.
+                </p>
+
+                <p class="themeable-text leading-relaxed mt-8 text-right">
+                    <strong>NVIDIA</strong><br>
+                    Jensen Huang · 1993–<br>
+                    <span class="themeable-muted text-sm">2026년 3월 22일 · pb(Pebblo Claw) 대필</span>
+                </p>
+            </section>
+
+        </main>
+    </div>
+    </div>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="/scripts/common-utils.js?v=20260322"></script>
+    <script>
+    PebblousPage.init({
+        mainTitle: "안녕하세요, 저는 NVIDIA입니다",
+        subtitle: "게임용 칩에서 AI 시대의 인프라가 된 이야기 — 30년의 반전",
+        pageTitle: "안녕하세요, 저는 NVIDIA입니다 — GPU에서 AI 인프라로 | 페블러스",
+        category: "art",
+        publishDate: "2026-03-22",
+        publisher: "(주)페블러스 데이터 커뮤니케이션팀",
+        defaultTheme: "light",
+        articlePath: "story/nvidia-story-pb/ko/",
+        tags: ["NVIDIA", "엔비디아", "GPU", "CUDA", "H100", "Blackwell", "젠슨 황", "AI 반도체", "딥러닝", "대필 시리즈"],
+        faqs: [
+            { question: "NVIDIA는 어떻게 시작됐나요?", answer: "1993년 Jensen Huang(젠슨 황), Chris Malachowsky, Curtis Priem 세 명이 캘리포니아 선니베일의 Denny's 레스토랑에서 창업했습니다. 당시 목표는 PC 게임의 3D 그래픽을 위한 전용 칩을 만드는 것이었어요. 1999년 세계 최초의 GPU인 GeForce 256을 출시했습니다." },
+            { question: "GPU와 CPU의 차이는 무엇인가요?", answer: "CPU는 8~64개의 강력한 코어로 복잡한 작업을 순서대로 처리합니다. GPU는 수천 개의 단순한 코어로 단순한 작업을 동시에(병렬로) 처리해요. AI 학습에 필요한 행렬 곱셈 같은 반복적 병렬 연산은 GPU에 훨씬 더 잘 맞습니다." },
+            { question: "CUDA란 무엇인가요?", answer: "2006년 NVIDIA가 출시한 GPU 범용 연산 플랫폼입니다. 개발자들이 C/C++ 같은 일반 프로그래밍 언어로 GPU의 수천 개 코어를 활용할 수 있게 해줍니다. AI 연구자들이 딥러닝 모델을 CUDA 위에서 개발하면서, CUDA 생태계는 NVIDIA의 가장 강력한 경쟁 우위가 됐어요." },
+            { question: "AlexNet과 NVIDIA의 관계는?", answer: "2012년 Geoffrey Hinton 팀의 AlexNet은 GTX 580 두 장을 CUDA로 활용해 ImageNet 이미지 인식 대회에서 압도적 성능을 보였습니다. 이 사건이 딥러닝 시대를 열었고, GPU가 AI 학습의 핵심 인프라임을 세상에 증명했어요." },
+            { question: "H100은 무엇인가요?", answer: "2022년 NVIDIA가 출시한 AI 전용 GPU입니다. ChatGPT 이후 AI 수요가 폭발하면서 H100은 공급 부족 사태를 맞았고, 장당 3만 달러에 거래됐어요. Microsoft, Google, Meta 등이 수십만 장을 주문했습니다. 현재는 차세대 Blackwell 아키텍처로 이어지고 있습니다." },
+            { question: "NVIDIA의 경쟁자는 누구인가요?", answer: "주요 경쟁자로 AMD(MI300X), Google(TPU), AWS(Trainium), Intel(Gaudi)이 있습니다. 하드웨어 성능 면에서는 격차가 좁혀지고 있지만, CUDA 생태계 — 10년간 축적된 라이브러리, 튜토리얼, 개발자 커뮤니티 — 는 쉽게 복사되지 않습니다. 중국에서는 수출 규제로 화웨이 Ascend가 자리를 채우고 있어요." },
+            { question: "젠슨 황은 왜 특별한가요?", answer: "1993년 창업 이후 30년 넘게 같은 CEO가 이끄는 회사는 실리콘밸리에서 극히 드뭅니다. 그는 2006년 CUDA라는, 당시엔 수익이 나지 않는 장기 투자를 결정했고, 그 결정이 15년 뒤 AI 혁명에서 독점적 위치를 만들었어요. 가죽 재킷을 트레이드마크로 한 무대 발표로도 유명합니다." },
+            { question: "NVIDIA의 위험 요소는 무엇인가요?", answer: "세 가지가 주요합니다. 첫째, 칩 생산 전량을 TSMC에 의존합니다. 둘째, 딥러닝 프레임워크의 하드웨어 추상화가 강화되면 CUDA 생태계의 독점성이 약해질 수 있어요. 셋째, AI에 대한 기대가 꺾이는 'AI 겨울'이 다시 오면 수요가 급감할 수 있습니다." }
+        ]
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 대필 시리즈 #4 — NVIDIA

WhatsApp·iPhone·Claude에 이어 네 번째. 게임 그래픽 카드가 AI 시대의 인프라가 된 30년 반전 이야기.

### 섹션
1. 저는 게임에서 시작했습니다 (1993 창업 / Denny's / GeForce 256)
2. CUDA — 제 인생의 도박 (2006, 아무도 믿지 않던 투자 / 10년을 기다리다)
3. AI가 저를 발견한 날 (2012 AlexNet / 타임라인: CUDA→AlexNet→Volta→ChatGPT→H100→Blackwell)
4. 저는 지금 무엇인가요 (골드러시의 삽 / 젠슨 황 30년 / AMD·TPU·화웨이 경쟁 구도)
5. 앞으로 어디로 (Physical AI / Sovereign AI / TSMC 의존성·CUDA 해자·AI 겨울 위험 솔직 인정)

### 체크리스트
- [x] 1인칭 서술
- [x] text-left hero + share-buttons-placeholder
- [x] TOC border-l-2 themeable-toc-border
- [x] category: art
- [x] content-language, copyright, noindex redirect
- [x] cache busting v=20260322
- [x] hreflang ko/en/x-default 3종
- [x] bilingual-ready ko/index.html
- [x] articlePath (index.html 없음)
- [x] 한국어 blockquote italic 없음 (font-semibold 사용)
- [x] info-box themeable-card + themeable-accent-border
- [x] flow-step CSS 클래스
- [x] 서명: NVIDIA / Jensen Huang · 1993– / pb(Pebblo Claw) 대필
- [ ] OG 이미지 (에디터 담당)