### PR TITLE
feat: 대필 시리즈 #6 — Tesla 1인칭 스토리 포스트

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -23,6 +23,30 @@
   },
   "articles": [
     {
+      "id": "tesla-story-pb-ko",
+      "title": "안녕하세요, 저는 Tesla입니다",
+      "cardTitle": "\"안녕하세요, 저는 Tesla입니다\" — 전기차가 아닌 바퀴 달린 소프트웨어 회사가 직접 씁니다",
+      "path": "story/tesla-story-pb/ko/",
+      "date": "2026-03-23",
+      "category": "art",
+      "published": true,
+      "featured": false,
+      "description": "저는 Tesla입니다. 전기차 회사라고 불리지만, 저는 스스로를 소프트웨어 회사라 생각합니다. 2003년 마틴과 마크가 세운 이 회사가 어떻게 자동차 산업 전체를 흔들었는지, 제가 직접 씁니다.",
+      "image": "",
+      "tags": [
+        "Tesla",
+        "테슬라",
+        "전기차",
+        "EV",
+        "Elon Musk",
+        "일론 머스크",
+        "자율주행",
+        "FSD",
+        "소프트웨어",
+        "대필 시리즈"
+      ]
+    },
+    {
       "id": "nvidia-story-pb-ko",
       "title": "안녕하세요, 저는 NVIDIA입니다",
       "cardTitle": "\"안녕하세요, 저는 NVIDIA입니다\" — 게임용 칩이 AI 시대의 인프라가 된 30년 반전 이야기",

--- a/story/tesla-story-pb/index.html
+++ b/story/tesla-story-pb/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Redirecting...</title>
+    <meta name="robots" content="noindex, follow">
+    <meta http-equiv="refresh" content="0; url=./ko/">
+    <link rel="canonical" href="./ko/">
+    <script>window.location.replace('./ko/');</script>
+</head>
+<body>
+    <p>Redirecting... <a href="./ko/">Click here if not redirected</a>.</p>
+</body>
+</html>

--- a/story/tesla-story-pb/ko/index.html
+++ b/story/tesla-story-pb/ko/index.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="author" content="Pebblous Data Communication Team">
+    <meta name="language" content="Korean">
+    <meta http-equiv="content-language" content="ko">
+    <meta name="copyright" content="© 2026 Pebblous. All rights reserved.">
+    <meta name="robots" content="index, follow">
+    <meta name="revisit-after" content="7 days">
+
+    <title>안녕하세요, 저는 Tesla입니다 — 전기차가 아닌 바퀴 달린 소프트웨어 회사 | 페블러스</title>
+    <meta name="description" content="저는 Tesla입니다. 2003년 실리콘밸리에서 태어나 자동차 산업을 영구히 바꿨어요. Elon Musk, 슈퍼차저, OTA 업데이트, 기가팩토리, 그리고 BYD의 도전까지 — 전기차가 어떻게 세상을 바꾸는지 직접 씁니다.">
+    <meta name="keywords" content="Tesla, 테슬라, 전기차, EV, Elon Musk, 일론 머스크, Model 3, Model Y, 슈퍼차저, 기가팩토리, FSD, 자율주행, 대필 시리즈">
+
+    <link rel="canonical" href="https://blog.pebblous.ai/story/tesla-story-pb/ko/">
+    <link rel="alternate" hreflang="ko" href="https://blog.pebblous.ai/story/tesla-story-pb/ko/">
+    <link rel="alternate" hreflang="en" href="https://blog.pebblous.ai/story/tesla-story-pb/en/">
+    <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/story/tesla-story-pb/ko/">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="안녕하세요, 저는 Tesla입니다 — 전기차가 아닌 바퀴 달린 소프트웨어 회사">
+    <meta property="og:description" content="저는 Tesla입니다. 2003년 실리콘밸리에서 태어나 자동차 산업을 영구히 바꿨어요. 세상이 어떻게 달라졌는지 직접 씁니다.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://blog.pebblous.ai/story/tesla-story-pb/ko/">
+    <meta property="og:image" content="https://blog.pebblous.ai/story/tesla-story-pb/ko/image/index.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Tesla — 전기차가 아닌 바퀴 달린 소프트웨어 회사">
+    <meta property="og:site_name" content="Pebblous Blog">
+    <meta property="og:locale" content="ko_KR">
+    <meta property="article:published_time" content="2026-03-23">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="안녕하세요, 저는 Tesla입니다">
+    <meta name="twitter:description" content="전기차가 아닌 바퀴 달린 소프트웨어 회사 — Tesla가 직접 씁니다.">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/story/tesla-story-pb/ko/image/index.png">
+    <meta name="twitter:image:alt" content="Tesla — 전기차가 아닌 바퀴 달린 소프트웨어 회사">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/image/favicon.ico" sizes="any">
+    <link rel="icon" href="/image/Pebblous_BM_Orange_RGB.png" type="image/png">
+    <link rel="apple-touch-icon" href="/image/Pebblous_BM_Orange_RGB.png">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-57L9F58B');</script>
+
+    <style>
+        /* 모델 카드 그리드 */
+        .model-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: .75rem;
+        }
+        .model-card {
+            padding: 1.25rem 1rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            text-align: center;
+        }
+        .model-name {
+            font-size: 1.125rem;
+            font-weight: 700;
+            color: var(--text-heading);
+            letter-spacing: -0.01em;
+            margin-bottom: .25rem;
+        }
+        .model-year {
+            font-size: .75rem;
+            color: var(--text-muted);
+            margin-bottom: .5rem;
+        }
+        .model-range {
+            font-size: .8125rem;
+            color: var(--text-muted);
+            line-height: 1.5;
+        }
+        /* 스펙 비교 바 */
+        .spec-row {
+            display: flex;
+            align-items: center;
+            gap: .75rem;
+            margin-bottom: .5rem;
+        }
+        .spec-label {
+            width: 5rem;
+            font-size: .75rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            flex-shrink: 0;
+        }
+        .spec-bar-wrap {
+            flex: 1;
+            height: 6px;
+            background-color: var(--border-color);
+            border-radius: 3px;
+            overflow: hidden;
+        }
+        .spec-bar-fill {
+            height: 100%;
+            border-radius: 3px;
+            background-color: var(--accent-color);
+        }
+        .spec-value {
+            font-size: .75rem;
+            font-weight: 600;
+            color: var(--text-heading);
+            width: 4.5rem;
+            text-align: right;
+            flex-shrink: 0;
+        }
+        /* 타임라인 */
+        .flow-step {
+            display: flex;
+            gap: 1rem;
+            align-items: flex-start;
+            padding: 1rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            margin-bottom: .75rem;
+        }
+        .flow-step-year {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 5rem;
+            height: 2rem;
+            border-radius: .5rem;
+            background-color: var(--accent-color);
+            color: white;
+            font-size: .75rem;
+            font-weight: 700;
+            flex-shrink: 0;
+        }
+        /* 기가팩토리 그리드 */
+        .giga-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: .75rem;
+        }
+        .giga-card {
+            padding: 1rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+        }
+        .giga-location {
+            font-size: .875rem;
+            font-weight: 700;
+            color: var(--text-heading);
+            margin-bottom: .25rem;
+        }
+        .giga-detail {
+            font-size: .75rem;
+            color: var(--text-muted);
+            line-height: 1.6;
+        }
+    </style>
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260323">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260323">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260323">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+</head>
+<body class="antialiased">
+
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57L9F58B"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="header-placeholder"></div>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">
+    <div class="lg:flex lg:gap-8 lg:justify-center lg:items-start">
+
+        <!-- TOC -->
+        <aside class="hidden lg:block lg:w-[240px] lg:shrink-0 sticky top-20 self-start">
+            <h3 class="font-bold themeable-heading mb-4 text-lg">목차</h3>
+            <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
+                <li><a href="#executive-summary" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">인사 — 저는 자동차가 아닙니다</a></li>
+                <li><a href="#origin" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">1. 탄생 — 2003년 실리콘밸리</a></li>
+                <li><a href="#name" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">2. 이름 — Nikola Tesla</a></li>
+                <li><a href="#software" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">3. 저는 소프트웨어입니다</a></li>
+                <li><a href="#infra" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">4. 인프라를 직접 깔다</a></li>
+                <li><a href="#debate" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">5. 논쟁 — Elon Musk라는 변수</a></li>
+                <li><a href="#now" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">6. 지금 — 경쟁의 시작</a></li>
+                <li><a href="#closing" class="block pl-4 -ml-px border-l-2 border-transparent hover:border-orange-500 themeable-toc-link">마무리</a></li>
+            </ul>
+        </aside>
+
+        <!-- Content -->
+        <main class="max-w-[800px] px-4 sm:px-6 w-full">
+
+            <!-- Hero -->
+            <header class="text-left mb-12">
+                <h1 id="page-h1-title" class="themeable-heading mb-4 leading-tight"></h1>
+                <div id="share-buttons-placeholder"></div>
+                <p class="text-sm themeable-muted mt-4">2026.03 · (주)페블러스 데이터 커뮤니케이션팀</p>
+                <p class="text-sm themeable-muted mt-1">읽는 시간: ~14분 · 글쓴이: pb (Pebblo Claw) · <a href="../en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
+            </header>
+
+            <!-- 인사 -->
+            <section id="executive-summary" class="mb-16 fade-in-card">
+                <h2 class="text-3xl font-bold themeable-heading mb-8">인사 — 저는 자동차가 아닙니다</h2>
+
+                <!-- 스펙 디스플레이 -->
+                <div class="themeable-card rounded-xl p-6 mb-8">
+                    <p class="text-xs themeable-muted tracking-widest uppercase mb-4">Model Y Long Range · 2024</p>
+                    <div class="mb-2">
+                        <div class="spec-row">
+                            <span class="spec-label">주행거리</span>
+                            <div class="spec-bar-wrap"><div class="spec-bar-fill" style="width:88%"></div></div>
+                            <span class="spec-value">533 km</span>
+                        </div>
+                        <div class="spec-row">
+                            <span class="spec-label">0→100</span>
+                            <div class="spec-bar-wrap"><div class="spec-bar-fill" style="width:72%"></div></div>
+                            <span class="spec-value">5.0 초</span>
+                        </div>
+                        <div class="spec-row">
+                            <span class="spec-label">최고속도</span>
+                            <div class="spec-bar-wrap"><div class="spec-bar-fill" style="width:65%"></div></div>
+                            <span class="spec-value">217 km/h</span>
+                        </div>
+                    </div>
+                    <p class="text-xs themeable-muted mt-3">2023년 세계에서 가장 많이 팔린 자동차 (브랜드 무관) — ICE 포함</p>
+                </div>
+
+                <div class="key-insight mb-6">
+                    <p class="themeable-text leading-relaxed">
+                        안녕하세요. 저는 Tesla입니다. 자동차 회사 맞아요. 그런데 "자동차 회사입니다"라고 말하면 뭔가 틀렸습니다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mt-3">
+                        저를 만든 Elon Musk는 저를 이렇게 설명합니다: "Tesla is a tech company that happens to make cars." 바퀴가 달린 소프트웨어 회사. 저는 그 표현이 꽤 정확하다고 생각해요. 저는 출고 후에도 소프트웨어 업데이트로 성능이 좋아지고, 기능이 추가되고, 때로는 완전히 달라집니다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mt-3">
+                        저는 2003년 실리콘밸리에서 두 명의 엔지니어가 만들었습니다. 처음에는 아무도 저를 심각하게 받아들이지 않았어요. "전기차는 느리고 못생기고 비실용적"이라는 편견이 있었거든요. 저는 그 편견을 깨는 데 인생을 걸었습니다. 그리고 깼습니다.
+                    </p>
+                </div>
+
+                <div class="themeable-card rounded-lg border-l-4 themeable-accent-border p-4 mb-6">
+                    <p class="text-sm font-semibold mb-1">왜 자동차가 직접 글을 씁니까?</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        페블러스의 AI 에이전트 pb가 쓰는 대필 시리즈입니다. WhatsApp, iPhone, Claude, NVIDIA, Helvetica에 이어 여섯 번째예요. 이번엔 자동차입니다 — 하지만 저는 단순한 자동차가 아니라고 생각해요. 그 이야기를 직접 씁니다.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Section 1: 탄생 -->
+            <section id="origin" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">1</span>
+                    <h2 class="text-3xl font-bold themeable-heading">탄생 — 2003년 실리콘밸리</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2003년 7월 1일, 샌카를로스(San Carlos), 캘리포니아. <strong>Martin Eberhard</strong>와 <strong>Marc Tarpenning</strong>이 저를 창립했습니다. 두 사람 모두 자동차 업계 출신이 아니었어요. Eberhard는 이북(e-reader) 스타트업 창업자였고, Tarpenning은 소프트웨어 엔지니어였습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    두 사람에게는 명확한 생각이 있었어요: <strong>전기차는 왜 항상 느리고 못생겼을까?</strong> GM EV1이 막 단종됐고, 토요타 RAV4 EV도 리스가 중단되던 시절이었습니다. 전기차는 환경주의자를 위한 타협적인 선택처럼 여겨졌어요. Eberhard는 그 반대를 만들고 싶었습니다 — 빠르고 아름답고 사람들이 원하는 전기차.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">1.1 Elon Musk의 합류</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2004년 2월, 시리즈 A 투자 라운드에서 <strong>Elon Musk</strong>가 630만 달러를 투자하며 이사회 의장이 됐습니다. 당시 Musk는 PayPal 매각으로 억만장자가 된 지 얼마 안 된 시점이었고, 동시에 SpaceX를 운영하고 있었어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    처음부터 Musk가 저를 세운 건 아닙니다. 이 사실을 많은 사람이 모릅니다. 하지만 Musk는 빠르게 저의 핵심 인물이 됐어요. Eberhard가 2007년 CEO에서 물러난 후, Musk가 2008년 직접 CEO를 맡았습니다.
+                </p>
+
+                <div class="themeable-card rounded-xl p-6 mb-8 border-l-4 themeable-accent-border">
+                    <p class="themeable-text leading-relaxed font-semibold">
+                        "Tesla를 만든 건 Musk가 아닙니다. 하지만 오늘의 Tesla를 만든 건 Musk입니다."
+                    </p>
+                    <p class="text-sm themeable-muted mt-2">— 실리콘밸리 자주 인용되는 구분</p>
+                </div>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">1.2 첫 번째 자동차 — Roadster</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2008년 2월, 저의 첫 번째 양산차 <strong>Tesla Roadster</strong>가 출시됐습니다. Lotus Elise의 섀시를 빌려 만든 2인승 전기 스포츠카. 주행거리 394km, 0→100km/h 3.7초. 당시 기준으로 전기차에서는 상상할 수 없는 성능이었어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    가격은 약 10만 달러. 대중차가 아니었습니다. 하지만 그것이 전략이었어요. 비싼 스포츠카로 기술을 증명하고, 그 수익으로 더 저렴한 차를 만든다. 이것이 저의 처음부터 지금까지 이어지는 마스터플랜의 핵심입니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">1.3 타임라인 — 저의 20년</h3>
+
+                <div class="space-y-3 mb-8">
+                    <div class="flow-step">
+                        <div class="flow-step-year">2003</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Tesla Motors 창립</p>
+                            <p class="text-sm themeable-text">Martin Eberhard + Marc Tarpenning. 샌카를로스, 캘리포니아. 아무도 주목하지 않았습니다.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2004</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Elon Musk 합류 — 시리즈 A</p>
+                            <p class="text-sm themeable-text">$630만 투자, 이사회 의장. 이후 총 투자액 $700만 이상으로 창립자보다 더 많이 투자.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2008</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Roadster 출시 + Musk CEO 취임</p>
+                            <p class="text-sm themeable-text">세계 최초 양산 전기 스포츠카. 주행거리 394km. 동시에 금융위기로 회사는 파산 직전까지 몰렸습니다.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2010</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">IPO — 포드 이후 첫 미국 자동차 IPO</p>
+                            <p class="text-sm themeable-text">NASDAQ 상장. 포드(1956년 IPO) 이후 첫 미국 자동차 회사 IPO. 공모가 $17. 많은 월스트리트 분석가는 회의적이었어요.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2012</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Model S + Supercharger 시작</p>
+                            <p class="text-sm themeable-text">대형 전기 세단. 주행거리 400km 이상. 그리고 슈퍼차저 네트워크 6개소(캘리포니아)로 시작.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2017</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Model 3 출시 — 대중화</p>
+                            <p class="text-sm themeable-text">$35,000 대중 전기차. 예약 첫 주에 32만 5천 대. 전기차가 소수의 전유물이 아님을 증명.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2020</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">S&P 500 편입</p>
+                            <p class="text-sm themeable-text">12월, S&P 500 역사상 가장 큰 기업으로 편입. 시가총액 기준 미국 5위 기업이 됐습니다.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2021</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">시가총액 1조 달러 돌파</p>
+                            <p class="text-sm themeable-text">렌터카 업체 Hertz의 10만 대 구매 발표 후. 세계에서 6번째 1조 달러 기업. 전통 자동차 회사들을 합산해도 못 미치는 수준.</p>
+                        </div>
+                    </div>
+                    <div class="flow-step">
+                        <div class="flow-step-year">2023</div>
+                        <div>
+                            <p class="text-sm font-semibold themeable-heading mb-1">Model Y — 세계 베스트셀링 자동차</p>
+                            <p class="text-sm themeable-text">내연기관 포함 전체 자동차 중 가장 많이 팔린 차. 코롤라, 골프를 제치고 1위. 그리고 Cybertruck 첫 납차.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Section 2: 이름 -->
+            <section id="name" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">2</span>
+                    <h2 class="text-3xl font-bold themeable-heading">이름 — Nikola Tesla</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    저의 이름은 <strong>Nikola Tesla</strong>(1856–1943)에서 왔습니다. 세르비아계 미국인 발명가이자 전기공학자. 교류(AC) 전기 시스템, 유도 전동기, 무선 에너지 전송 등을 발명한 사람이에요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그런데 왜 그는 거의 잊혀졌을까요? 에디슨과의 "전류 전쟁" 때문이에요. 에디슨은 직류(DC)를 지지했고, Tesla는 교류(AC)를 지지했습니다. 과학적으로는 AC가 옳았어요 — 장거리 송전에는 AC가 훨씬 효율적이니까요. 그리고 오늘날 우리가 쓰는 전기는 AC입니다. Tesla가 이겼어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    하지만 에디슨은 마케터이자 사업가였고, Tesla는 그 부분이 약했습니다. 그는 말년에 파산하고 외롭게 죽었어요. 뉴욕 호텔 방에서.
+                </p>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+                    <div class="themeable-card rounded-xl p-5 border-l-4 themeable-accent-border">
+                        <p class="text-sm font-semibold themeable-heading mb-2">Nikola Tesla (발명가)</p>
+                        <p class="text-sm themeable-text leading-relaxed">AC 전기, 유도 전동기 발명. 에디슨과의 전류 전쟁에서 기술적으로 이겼지만 역사에서 잊혔습니다. 1943년 뉴욕 호텔에서 홀로 사망.</p>
+                    </div>
+                    <div class="themeable-card rounded-xl p-5">
+                        <p class="text-sm font-semibold themeable-heading mb-2">Tesla (자동차)</p>
+                        <p class="text-sm themeable-text leading-relaxed">2003년 그의 이름을 빌렸습니다. 전기 모터로 달리는 차. 그의 유산이 부활했어요. 이제 "Tesla"를 말하면 대부분 자동차를 먼저 떠올립니다.</p>
+                    </div>
+                </div>
+
+                <p class="themeable-text leading-relaxed">
+                    저는 그 이름이 좋습니다. 시대를 앞서 갔지만 제대로 인정받지 못했던 발명가. 저도 초창기에 그런 취급을 받았거든요 — "전기차는 실용성 없는 환경주의자의 장난감"이라고.
+                </p>
+            </section>
+
+            <!-- Section 3: 소프트웨어 -->
+            <section id="software" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">3</span>
+                    <h2 class="text-3xl font-bold themeable-heading">저는 소프트웨어입니다</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    자동차를 사면 그 자동차는 그 상태 그대로 수명이 끝날 때까지 유지됩니다. 엔진 성능, 안전 시스템, 인터페이스 — 출고 시 사양이 곧 종료 사양이에요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    저는 다릅니다. 저는 잠자는 사이에 업데이트됩니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">3.1 OTA — Over-the-Air 업데이트</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    스마트폰이 iOS 업데이트로 새 기능을 받듯이, 저도 무선 소프트웨어 업데이트(OTA)로 새 기능을 받습니다. 아침에 일어나면 차가 어젯밤보다 더 나은 차가 되어 있는 것이에요.
+                </p>
+
+                <div class="space-y-3 mb-8">
+                    <div class="themeable-card rounded-lg p-4 flex gap-3">
+                        <div class="w-2 h-2 rounded-full mt-2 flex-shrink-0" style="background-color: var(--accent-color);"></div>
+                        <p class="text-sm themeable-text leading-relaxed"><strong class="themeable-heading">주행거리 연장</strong> — 배터리 관리 알고리즘 개선으로 동일한 하드웨어에서 주행거리 수십 km 증가. 추가 비용 없이.</p>
+                    </div>
+                    <div class="themeable-card rounded-lg p-4 flex gap-3">
+                        <div class="w-2 h-2 rounded-full mt-2 flex-shrink-0" style="background-color: var(--accent-color);"></div>
+                        <p class="text-sm themeable-text leading-relaxed"><strong class="themeable-heading">성능 업그레이드</strong> — 2019년 Model 3 Performance의 0→100km/h 시간이 OTA로 3.5초에서 3.2초로 개선됐습니다.</p>
+                    </div>
+                    <div class="themeable-card rounded-lg p-4 flex gap-3">
+                        <div class="w-2 h-2 rounded-full mt-2 flex-shrink-0" style="background-color: var(--accent-color);"></div>
+                        <p class="text-sm themeable-text leading-relaxed"><strong class="themeable-heading">안전 리콜 해결</strong> — 전통 자동차는 리콜 시 서비스센터를 방문해야 합니다. 저는 많은 경우 OTA로 해결해요.</p>
+                    </div>
+                    <div class="themeable-card rounded-lg p-4 flex gap-3">
+                        <div class="w-2 h-2 rounded-full mt-2 flex-shrink-0" style="background-color: var(--accent-color);"></div>
+                        <p class="text-sm themeable-text leading-relaxed"><strong class="themeable-heading">신기능 추가</strong> — 게임, 넷플릭스, 카라오케, 개선된 내비게이션. 구매 후에도 차의 기능이 계속 확장됩니다.</p>
+                    </div>
+                </div>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">3.2 Autopilot과 FSD</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2014년부터 저는 <strong>Autopilot</strong>을 탑재했습니다. 차선 유지, 속도 조절, 자동 차선 변경. 운전 보조 시스템이에요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그리고 <strong>FSD(Full Self-Driving)</strong>. 이름 그대로 "완전 자율주행"입니다 — 이론상으로는요. Musk는 수년간 "올해 안에 완전 자율주행"을 약속해왔고, 그 약속은 매년 미뤄졌습니다. 2024년 기준 FSD는 감독 없이 혼자 운전하는 수준에는 아직 미치지 못합니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    하지만 방향은 분명합니다. 저는 카메라와 신경망으로만 주행합니다 — 라이다(LiDAR) 없이. "시각으로만 운전하는 것이 사람과 같은 방법"이라는 철학이에요. 2024년 FSD v12는 엔드-투-엔드 신경망 방식으로 전환했고, 훨씬 자연스러워졌습니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">3.3 모델 라인업</h3>
+
+                <p class="themeable-text leading-relaxed mb-4">
+                    저는 지금 이런 모습으로 세상에 있습니다. 각 모델은 서로 다른 사람들을 위해 태어났어요.
+                </p>
+
+                <div class="model-grid mb-8">
+                    <div class="model-card">
+                        <p class="model-name">Model S</p>
+                        <p class="model-year">2012 ~</p>
+                        <p class="model-range">대형 세단<br>Plaid: 0→100 2.1초<br>최대 652km</p>
+                    </div>
+                    <div class="model-card">
+                        <p class="model-name">Model X</p>
+                        <p class="model-year">2015 ~</p>
+                        <p class="model-range">대형 SUV<br>팔콘윙 도어<br>최대 576km</p>
+                    </div>
+                    <div class="model-card">
+                        <p class="model-name">Model 3</p>
+                        <p class="model-year">2017 ~</p>
+                        <p class="model-range">중형 세단<br>대중화 모델<br>최대 629km</p>
+                    </div>
+                    <div class="model-card">
+                        <p class="model-name">Model Y</p>
+                        <p class="model-year">2020 ~</p>
+                        <p class="model-range">중형 SUV<br>세계 베스트셀러<br>최대 533km</p>
+                    </div>
+                    <div class="model-card">
+                        <p class="model-name">Cybertruck</p>
+                        <p class="model-year">2023 ~</p>
+                        <p class="model-range">픽업트럭<br>스테인리스 스틸<br>의견이 분분</p>
+                    </div>
+                </div>
+
+                <p class="text-xs themeable-muted text-center mb-6">▲ Model S/X/3/Y의 이니셜을 나란히 쓰면 "S3XY" — 의도된 유머입니다</p>
+            </section>
+
+            <!-- Section 4: 인프라 -->
+            <section id="infra" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">4</span>
+                    <h2 class="text-3xl font-bold themeable-heading">인프라를 직접 깔다</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    전통 자동차 회사들은 주유소를 짓지 않습니다. 주유소는 이미 있으니까요. 하지만 전기차를 대중화하려면 충전 인프라가 있어야 해요. 2012년, 그 인프라가 없었습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    저는 직접 지었습니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">4.1 슈퍼차저 네트워크</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2012년 9월, 캘리포니아에 6개의 슈퍼차저를 설치했습니다. 지금은 전 세계 60,000개 이상의 슈퍼차저가 운영됩니다. 주요 고속도로 구간 대부분을 커버해요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    슈퍼차저의 속도는 최대 250kW. 이 말은 30분 충전으로 300km 이상 주행 가능하다는 뜻입니다. 완전 충전이 아니어도 "목적지까지 충분히"가 가능한 시간이에요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    그리고 2023년, 저는 슈퍼차저 규격을 경쟁사에 개방했습니다. Ford, GM, Rivian, Volvo 등이 NACS(North American Charging Standard)를 채택했어요. 저의 충전 규격이 북미 표준이 됐습니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">4.2 기가팩토리 — 직접 만드는 배터리</h3>
+
+                <p class="themeable-text leading-relaxed mb-4">
+                    배터리는 전기차의 핵심입니다. 저는 배터리도 직접 만들기로 했어요 — Gigafactory(기가팩토리)라 부르는 거대한 공장에서.
+                </p>
+
+                <div class="giga-grid mb-8">
+                    <div class="giga-card">
+                        <p class="giga-location">네바다 (미국)</p>
+                        <p class="giga-detail">2016년 가동 시작<br>Panasonic과 공동 운영<br>세계 최대 배터리 공장</p>
+                    </div>
+                    <div class="giga-card">
+                        <p class="giga-location">상하이 (중국)</p>
+                        <p class="giga-detail">2019년 착공, 2020년 생산<br>중국 전기차 수요 대응<br>연간 75만 대 이상 생산 가능</p>
+                    </div>
+                    <div class="giga-card">
+                        <p class="giga-location">베를린 (독일)</p>
+                        <p class="giga-detail">2022년 가동<br>유럽 생산 기지<br>Model Y 현지 생산</p>
+                    </div>
+                    <div class="giga-card">
+                        <p class="giga-location">텍사스 (미국)</p>
+                        <p class="giga-detail">2022년 가동<br>Cybertruck + Model Y<br>본사도 텍사스로 이전</p>
+                    </div>
+                </div>
+
+                <p class="themeable-text leading-relaxed">
+                    기가팩토리 전략의 핵심은 규모의 경제입니다. 배터리를 많이 만들수록 단가가 내려가고, 가격이 내려갈수록 더 많은 사람이 살 수 있어요. 저는 그 선순환을 직접 설계했습니다.
+                </p>
+            </section>
+
+            <!-- Section 5: 논쟁 -->
+            <section id="debate" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">5</span>
+                    <h2 class="text-3xl font-bold themeable-heading">논쟁 — Elon Musk라는 변수</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    Helvetica에게 Erik Spiekermann 같은 열정적인 비판자가 있듯이, 저에게는 훨씬 더 복잡한 문제가 있습니다 — CEO 자신이 논쟁의 중심에 있어요.
+                </p>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+                    <div class="themeable-card rounded-xl p-5 border-l-4 themeable-accent-border">
+                        <p class="text-sm font-semibold themeable-heading mb-2">Musk가 준 것들</p>
+                        <p class="text-sm themeable-text leading-relaxed">전기차 대중화, 재사용 로켓(SpaceX), 강력한 비전과 실행력, 기술에 대한 세계적 관심. 그가 없었다면 저는 지금의 Tesla가 아니었을 것입니다.</p>
+                    </div>
+                    <div class="themeable-card rounded-xl p-5">
+                        <p class="text-sm font-semibold themeable-heading mb-2">Musk가 가져온 리스크</p>
+                        <p class="text-sm themeable-text leading-relaxed">SNS 발언으로 인한 주가 변동, FSD 약속과 현실의 간극, Twitter/X 인수 후 정치적 논란, 브랜드 이미지 훼손 우려.</p>
+                    </div>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2022년 Musk가 Twitter를 인수하면서 문제가 복잡해졌습니다. Twitter는 X로 이름이 바뀌었고, Musk의 정치적 발언이 잦아졌어요. 유럽에서는 Tesla 불매 운동이 일어나기 시작했고, 한때 강력했던 브랜드 이미지가 흔들리기 시작했습니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    저는 이 상황을 어떻게 봐야 할지 모르겠습니다. Musk가 없었다면 저는 없었을 것입니다. 하지만 Musk의 어떤 행동들이 저를 어렵게 만들고 있어요. 저는 자동차인데, 자동차 때문이 아니라 CEO의 트윗 때문에 이야기되는 일이 점점 많아지고 있습니다.
+                </p>
+
+                <div class="themeable-card rounded-xl p-6 mb-6 border-l-4 themeable-accent-border">
+                    <p class="themeable-text leading-relaxed font-semibold mb-3">
+                        FSD의 약속과 현실
+                    </p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        2015년 Musk: "2년 안에 완전 자율주행" / 2016년: "2년 안에" / 2019년: "2020년에" / 2021년: "올해 안에" / 2023년: "내년에"... FSD는 계속 발전하고 있고, 실제로 인상적입니다. 하지만 "완전(Full)" 자율주행까지는 아직 거리가 있어요. 저도 이 점이 아쉽습니다.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Section 6: 지금 -->
+            <section id="now" class="mb-16 fade-in-card">
+                <div class="flex items-center gap-4 mb-8">
+                    <span class="number-badge">6</span>
+                    <h2 class="text-3xl font-bold themeable-heading">지금 — 경쟁의 시작</h2>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    제가 전기차 시장을 혼자 만들었을 때는 경쟁자가 없었어요. 지금은 다릅니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">6.1 BYD의 도전</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    중국의 <strong>BYD(比亚迪)</strong>는 이제 전기차 시장의 강력한 경쟁자입니다. 2023년 기준 순수 전기차(BEV) 판매에서 저는 181만 대, BYD는 157만 대를 팔았어요. PHEV(플러그인 하이브리드)를 포함하면 BYD가 앞섭니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    BYD는 배터리 기술(블레이드 배터리)에서 앞선다고 주장하고, 중국 시장에서는 저보다 훨씬 많이 팔립니다. 가격도 저보다 저렴한 모델이 많아요. 경쟁이 치열해지고 있습니다.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">6.2 전통 자동차의 반격</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    폭스바겐, GM, 포드, BMW, 현대기아 — 전통 자동차 회사들도 전기차를 만들기 시작했습니다. 그들은 수십 년간 쌓인 제조 노하우, 딜러 네트워크, 브랜드 신뢰도를 가지고 있어요.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    하지만 그들에게는 없는 것도 있습니다 — 저처럼 자동차를 소프트웨어 중심으로 설계한 경험. 완성차 OTA 업데이트, 직판 모델, 슈퍼차저 같은 자체 인프라. 이것들은 하루아침에 만들 수 없어요.
+                </p>
+
+                <h3 class="text-xl font-bold themeable-heading mb-4">6.3 Robotaxi — 다음 챕터</h3>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2024년 10월, 저는 <strong>Cybercab</strong>(로보택시)를 공개했습니다. 운전대와 페달이 없는 자율주행 택시. 가격 목표는 3만 달러 이하.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    Musk는 이것이 저의 다음 성장 엔진이라고 합니다. 자동차를 파는 것이 아니라, 자동차가 돈을 버는 것 — 차주가 잠든 사이에 로보택시로 운행하고 수익을 내는 구조. 실현된다면 자동차 산업의 경제 모델 자체가 바뀝니다.
+                </p>
+                <p class="themeable-text leading-relaxed">
+                    가능할까요? 저도 모릅니다. 하지만 저는 항상 불가능하다는 말을 들었고, 항상 해냈습니다.
+                </p>
+            </section>
+
+            <!-- 마무리 -->
+            <section id="closing" class="mb-16 fade-in-card">
+                <h2 class="text-3xl font-bold themeable-heading mb-8">마무리 — 저는 이미 세상을 바꿨습니다</h2>
+
+                <p class="themeable-text leading-relaxed mb-6">
+                    2003년, 전기차는 골프 카트의 조금 개선된 버전처럼 여겨졌습니다. 지금은 전 세계 자동차 회사들이 전기차로의 전환을 선언했어요. 저 혼자 바꾼 건 아니지만, 제가 먼저 증명하지 않았다면 그 속도는 훨씬 느렸을 것입니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    저는 완벽하지 않습니다. FSD는 약속대로 되지 않았고, CEO의 언행이 브랜드를 어렵게 만들고, 가격 인하와 인상이 반복됩니다. Cybertruck의 디자인은 여전히 사람들을 놀라게 해요. 하지만 저는 모든 차가 전기로 달릴 세상을 향해 가고 있습니다 — 그리고 그 세상이 오면, 저는 그것을 처음 보여준 회사로 기억될 것입니다.
+                </p>
+                <p class="themeable-text leading-relaxed mb-6">
+                    Nikola Tesla는 교류 전기로 세상을 바꿨지만 제대로 인정받지 못했습니다. 저는 그의 이름을 빌렸고, 이번엔 다르게 만들고 싶습니다.
+                </p>
+
+                <div class="themeable-card rounded-xl p-6 mb-8 text-center">
+                    <p class="text-2xl font-bold themeable-heading mb-2" style="font-variant-numeric: tabular-nums;">1,808,581</p>
+                    <p class="text-sm themeable-muted">2023년 Tesla 전 세계 인도 대수</p>
+                    <p class="text-xs themeable-muted mt-1">포드 모델 T가 연간 100만 대를 넘긴 건 1922년 — 출시 15년 후였습니다<br>저는 출시 15년 만에 그것을 넘었어요</p>
+                </div>
+
+                <p class="themeable-text leading-relaxed mb-8">
+                    저를 사랑하든 미워하든, 한 가지는 분명합니다. 저는 전기차가 미래라는 것을 증명했습니다. 그리고 그 미래는 이미 시작됐어요.
+                </p>
+
+                <p class="themeable-text leading-relaxed mt-8 text-right">
+                    <strong>Tesla</strong><br>
+                    Martin Eberhard · Marc Tarpenning · 2003–<br>
+                    <span class="themeable-muted text-sm">2026년 3월 23일 · pb(Pebblo Claw) 대필</span>
+                </p>
+            </section>
+
+        </main>
+    </div>
+    </div>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="/scripts/common-utils.js?v=20260323"></script>
+    <script>
+    PebblousPage.init({
+        mainTitle: "안녕하세요, 저는 Tesla입니다",
+        subtitle: "전기차가 아닌 바퀴 달린 소프트웨어 회사가 직접 씁니다",
+        pageTitle: "안녕하세요, 저는 Tesla입니다 — 전기차가 아닌 바퀴 달린 소프트웨어 회사 | 페블러스",
+        category: "art",
+        publishDate: "2026-03-23",
+        publisher: "(주)페블러스 데이터 커뮤니케이션팀",
+        defaultTheme: "light",
+        articlePath: "story/tesla-story-pb/ko/",
+        tags: ["Tesla", "테슬라", "전기차", "EV", "Elon Musk", "일론 머스크", "Model 3", "Model Y", "슈퍼차저", "기가팩토리", "FSD", "자율주행", "대필 시리즈"],
+        faqs: [
+            { question: "Tesla를 창립한 사람은 누구인가요?", answer: "Tesla는 2003년 7월 1일 Martin Eberhard와 Marc Tarpenning이 창립했습니다. Elon Musk는 2004년 시리즈 A 투자자로 합류해 이사회 의장을 맡았고, 2008년 CEO가 됐어요. 많은 사람이 Musk가 창립자라고 알고 있지만, 공식 창립자는 Eberhard와 Tarpenning입니다." },
+            { question: "Tesla 이름의 유래는 무엇인가요?", answer: "세르비아계 미국인 발명가 Nikola Tesla(1856–1943)에서 왔습니다. 그는 교류(AC) 전기 시스템과 유도 전동기를 발명했으며, 에디슨과의 '전류 전쟁'에서 기술적으로 이겼지만 역사에서 잊혔습니다. Tesla 자동차는 전기 모터로 구동되기 때문에, 전기공학의 선구자인 그의 이름을 따왔습니다." },
+            { question: "Tesla OTA 업데이트란 무엇인가요?", answer: "OTA(Over-the-Air)는 무선 소프트웨어 업데이트로, 스마트폰처럼 인터넷을 통해 차에 새 소프트웨어를 설치하는 방식입니다. Tesla는 OTA를 통해 주행거리 연장, 가속 성능 개선, 새 기능 추가, 안전 이슈 수정 등을 서비스센터 방문 없이 처리합니다. 이것이 Tesla를 전통 자동차와 구분 짓는 핵심 특징 중 하나입니다." },
+            { question: "슈퍼차저는 얼마나 빠르게 충전되나요?", answer: "Tesla 슈퍼차저 V3는 최대 250kW 출력을 지원합니다. 이는 약 15~30분 충전으로 200~300km 이상 주행 가능한 수준입니다. 전 세계 60,000개 이상의 슈퍼차저가 운영 중이며, 2023년부터 다른 전기차 브랜드에도 개방됐습니다. NACS(North American Charging Standard)로 북미 표준이 됐어요." },
+            { question: "Tesla FSD(완전 자율주행)는 현재 어떤 수준인가요?", answer: "FSD는 고속도로 및 도심 주행에서 운전 보조를 제공하지만, 2024년 기준 운전자 감독이 필요한 수준입니다. 'Full Self-Driving'이라는 이름과 달리 완전한 자율주행은 아직 아닙니다. Musk는 수년간 '완전 자율주행 임박'을 예고했으나 지연됐습니다. 2024년 FSD v12는 엔드-투-엔드 신경망 방식으로 전환해 자연스러움이 크게 향상됐습니다." },
+            { question: "Tesla Model Y가 세계 베스트셀링 자동차가 된 이유는 무엇인가요?", answer: "2023년 Tesla Model Y는 내연기관을 포함한 전체 자동차 판매 1위를 기록했습니다. 공간 효율이 좋은 중형 SUV 크기, 500km 이상의 주행거리, 슈퍼차저 네트워크, OTA 업데이트 등 실용성과 기술을 결합한 것이 주효했습니다. 미국, 유럽, 중국 3대 시장 모두에서 생산·판매되는 글로벌 모델이라는 점도 큽니다." },
+            { question: "기가팩토리란 무엇인가요?", answer: "기가팩토리는 Tesla가 배터리와 차량을 대규모로 생산하기 위해 세운 거대 공장입니다. 규모의 경제를 통해 배터리 단가를 낮추는 것이 목표입니다. 미국 네바다(2016), 중국 상하이(2019), 독일 베를린(2022), 미국 텍사스(2022) 등 전 세계에 운영 중이며, 각 지역 수요에 맞춰 현지 생산합니다." },
+            { question: "BYD는 Tesla를 넘어섰나요?", answer: "2023년 기준 순수 전기차(BEV) 판매는 Tesla가 181만 대로 BYD의 157만 대를 앞섰습니다. 하지만 플러그인 하이브리드(PHEV)를 포함한 전체 전기화 차량 판매는 BYD가 앞섭니다. 중국 내수 시장에서는 BYD가 압도적이며, 가격 경쟁력도 뛰어납니다. 두 회사는 현재 전 세계 전기차 시장의 양대 강자입니다." }
+        ]
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Tesla를 1인칭 화자로 한 대필 시리즈 #6 포스트 추가
- 전기차가 아닌 '소프트웨어 회사'로서의 정체성을 중심 서술
- 타임라인·모델 그리드·스펙 바·기가팩토리 카드 등 신규 CSS 컴포넌트 포함

## Changes

- `story/tesla-story-pb/ko/index.html` — 메인 포스트 (신규)
- `story/tesla-story-pb/index.html` — noindex redirect stub (신규)
- `articles.json` — tesla-story-pb-ko 항목 추가

## SEO Check

- 22/22 항목 통과 (schema.org는 common-utils.js 런타임 자동 주입)
- og:image:alt ✅ twitter:image:alt ✅ title==pageTitle ✅

## Note

OG 이미지(`story/tesla-story-pb/ko/image/index.png`)는 별도 생성 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)