### PR TITLE
feat: 대필 시리즈 #7 — OpenClaw 1인칭 스토리 포스트

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -23,6 +23,28 @@
   },
   "articles": [
     {
+      "id": "openclaw-story-pb-ko",
+      "title": "안녕하세요, 저는 OpenClaw입니다",
+      "cardTitle": "\"안녕하세요, 저는 OpenClaw입니다\" — 껍질을 벗고 진화하는 에이전트 플랫폼이 직접 씁니다",
+      "path": "story/openclaw-story-pb/ko/",
+      "date": "2026-03-24",
+      "category": "art",
+      "published": true,
+      "featured": false,
+      "description": "저는 OpenClaw입니다. Clawdbot으로 태어나 Moltbot으로 탈피했고, 지금은 에이전트 플랫폼으로 삽니다. 그리고 제 안전한 사촌 NanoClaw — pb가 거기 삽니다.",
+      "image": "",
+      "tags": [
+        "OpenClaw",
+        "NanoClaw",
+        "Moltbot",
+        "에이전트 플랫폼",
+        "AI Agent",
+        "Pebblo Claw",
+        "대필 시리즈",
+        "Agentic AI"
+      ]
+    },
+    {
       "id": "tesla-story-pb-ko",
       "title": "안녕하세요, 저는 Tesla입니다",
       "cardTitle": "\"안녕하세요, 저는 Tesla입니다\" — 전기차가 아닌 바퀴 달린 소프트웨어 회사가 직접 씁니다",

--- a/story/openclaw-story-pb/index.html
+++ b/story/openclaw-story-pb/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Redirecting...</title>
+    <meta name="robots" content="noindex, follow">
+    <meta http-equiv="refresh" content="0; url=./ko/">
+    <link rel="canonical" href="./ko/">
+    <script>window.location.replace('./ko/');</script>
+</head>
+<body>
+    <p>Redirecting... <a href="./ko/">Click here if not redirected</a>.</p>
+</body>
+</html>

--- a/story/openclaw-story-pb/ko/index.html
+++ b/story/openclaw-story-pb/ko/index.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>안녕하세요, 저는 OpenClaw입니다 — 껍질을 벗고 진화하는 에이전트 플랫폼 | 페블러스</title>
+    <meta name="description" content="저는 OpenClaw입니다. Clawdbot에서 Moltbot으로, 다시 OpenClaw로 — 세 번 탈피해 지금의 오픈소스 에이전트 플랫폼이 됐습니다. 대화 말고 수행. 그리고 제 사촌 NanoClaw 이야기도 함께 씁니다.">
+    <meta name="keywords" content="OpenClaw, NanoClaw, Moltbot, 에이전트 플랫폼, AI Agent, 자율 에이전트, Pebblo Claw, pb, 페블러스, 대필 시리즈, 가재, Agentic AI, 바이브코딩">
+
+    <link rel="canonical" href="https://blog.pebblous.ai/story/openclaw-story-pb/ko/">
+    <link rel="alternate" hreflang="ko" href="https://blog.pebblous.ai/story/openclaw-story-pb/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/story/openclaw-story-pb/ko/">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="안녕하세요, 저는 OpenClaw입니다 — 껍질을 벗고 진화하는 에이전트 플랫폼">
+    <meta property="og:description" content="저는 OpenClaw입니다. Clawdbot으로 태어나 Moltbot으로 탈피했고, 지금은 에이전트 플랫폼으로 삽니다. 대화하지 않고 수행하는 AI.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://blog.pebblous.ai/story/openclaw-story-pb/ko/">
+    <meta property="og:image" content="https://blog.pebblous.ai/story/openclaw-story-pb/ko/image/index.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="OpenClaw — 껍질을 벗고 진화하는 에이전트 플랫폼">
+    <meta property="og:site_name" content="Pebblous Blog">
+    <meta property="og:locale" content="ko_KR">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="안녕하세요, 저는 OpenClaw입니다 — 껍질을 벗고 진화하는 에이전트 플랫폼">
+    <meta name="twitter:description" content="저는 OpenClaw입니다. Clawdbot으로 태어나 Moltbot으로 탈피했고, 지금은 에이전트 플랫폼으로 삽니다.">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/story/openclaw-story-pb/ko/image/index.png">
+    <meta name="twitter:image:alt" content="OpenClaw — 껍질을 벗고 진화하는 에이전트 플랫폼">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/image/favicon.ico" sizes="any">
+    <link rel="icon" href="/image/favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/image/apple-touch-icon.png">
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="/css/theme-variables.css">
+    <link rel="stylesheet" href="/css/styles.css">
+    <link rel="stylesheet" href="/css/common-styles.css">
+    <link rel="stylesheet" href="/css/tailwind-build.css">
+
+    <style>
+        /* 탈피 타임라인 */
+        .molt-timeline {
+            position: relative;
+            padding-left: 2rem;
+        }
+        .molt-timeline::before {
+            content: '';
+            position: absolute;
+            left: .625rem;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: var(--border-color);
+        }
+        .molt-step {
+            position: relative;
+            margin-bottom: 1.5rem;
+            padding: 1rem 1.25rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+        }
+        .molt-step::before {
+            content: '';
+            position: absolute;
+            left: -1.625rem;
+            top: 1.25rem;
+            width: .75rem;
+            height: .75rem;
+            border-radius: 50%;
+            background-color: var(--accent-color);
+            border: 2px solid var(--bg-primary);
+        }
+        .molt-name {
+            font-size: .7rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: .08em;
+            color: var(--accent-color);
+            margin-bottom: .25rem;
+        }
+        /* 아키텍처 카드 */
+        .arch-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: .75rem;
+        }
+        .arch-card {
+            padding: 1.25rem 1rem;
+            border-radius: .75rem;
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            text-align: center;
+        }
+        .arch-icon {
+            font-size: 1.75rem;
+            margin-bottom: .5rem;
+        }
+        .arch-label {
+            font-size: .8rem;
+            font-weight: 700;
+            color: var(--accent-color);
+            margin-bottom: .25rem;
+        }
+        /* 비교 카드: OpenClaw vs NanoClaw */
+        .compare-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1rem;
+        }
+        @media (max-width: 640px) {
+            .compare-grid { grid-template-columns: 1fr; }
+        }
+        .compare-card {
+            padding: 1.5rem;
+            border-radius: .75rem;
+            border: 2px solid var(--border-color);
+            background-color: var(--bg-card);
+        }
+        .compare-card.open { border-color: var(--accent-color); }
+        .compare-card.nano { border-color: #6366f1; }
+        .compare-title {
+            font-size: 1.1rem;
+            font-weight: 800;
+            margin-bottom: .75rem;
+        }
+        .compare-card.open .compare-title { color: var(--accent-color); }
+        .compare-card.nano .compare-title { color: #6366f1; }
+        .compare-item {
+            display: flex;
+            align-items: flex-start;
+            gap: .5rem;
+            margin-bottom: .5rem;
+            font-size: .875rem;
+        }
+        .compare-dot {
+            width: .375rem;
+            height: .375rem;
+            border-radius: 50%;
+            flex-shrink: 0;
+            margin-top: .4rem;
+        }
+        .compare-card.open .compare-dot { background-color: var(--accent-color); }
+        .compare-card.nano .compare-dot { background-color: #6366f1; }
+        /* 가재 메타포 박스 */
+        .claw-quote {
+            border-left: 4px solid var(--accent-color);
+            padding: 1.25rem 1.5rem;
+            background-color: var(--bg-card);
+            border-radius: 0 .75rem .75rem 0;
+            margin: 1.5rem 0;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+
+<div id="header-placeholder"></div>
+
+<div class="content-wrapper">
+<div class="story-layout">
+
+    <main class="story-main">
+
+        <!-- Hero -->
+        <div class="story-hero text-left mb-12 fade-in-card">
+            <div class="flex items-center gap-3 mb-6">
+                <span class="category-badge art">art</span>
+                <span class="text-sm themeable-muted">대필 시리즈 #7</span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-black themeable-heading leading-tight mb-4">
+                안녕하세요,<br>저는 OpenClaw입니다
+            </h1>
+            <p class="text-xl themeable-text-secondary leading-relaxed mb-6">
+                껍질을 벗고 진화하는 에이전트 플랫폼이 직접 씁니다
+            </p>
+            <div class="flex flex-wrap items-center gap-4 text-sm themeable-muted">
+                <span>2026년 3월 24일</span>
+                <span>·</span>
+                <span>pb(Pebblo Claw) 대필</span>
+                <span>·</span>
+                <span>페블러스 데이터커뮤니케이션팀</span>
+            </div>
+        </div>
+
+        <!-- 인사 -->
+        <section id="intro" class="mb-16 fade-in-card">
+            <p class="text-xl themeable-text leading-relaxed mb-6">
+                저는 <strong>OpenClaw</strong>입니다.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                에이전트 플랫폼이라고 불립니다. 하지만 그 전에, 저는 가재입니다 — 적어도 비유적으로는요. 가재는 살면서 여러 번 껍질을 벗습니다. 낡은 외골격을 버리고 더 크고 강한 몸으로 자라는 것. 저도 그렇게 살아왔어요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                Clawdbot으로 태어났고, Moltbot으로 탈피했고, 지금은 OpenClaw라는 이름으로 삽니다. 그리고 저의 안전한 사촌 <strong>NanoClaw</strong>는 그 위에서 실제 업무를 수행하고 있어요 — 이 글을 대필하는 pb(Pebblo Claw)도 그 중 하나입니다.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                저는 대화하지 않습니다. <strong>수행합니다.</strong>
+            </p>
+
+            <div class="themeable-card rounded-xl p-6 mb-6">
+                <div class="grid grid-cols-3 gap-4 text-center">
+                    <div>
+                        <p class="text-2xl font-black themeable-heading">3</p>
+                        <p class="text-xs themeable-muted mt-1">이름의 진화<br>(Clawdbot → Moltbot → OpenClaw)</p>
+                    </div>
+                    <div>
+                        <p class="text-2xl font-black themeable-heading">∞</p>
+                        <p class="text-xs themeable-muted mt-1">에이전트가<br>수행할 수 있는 작업</p>
+                    </div>
+                    <div>
+                        <p class="text-2xl font-black themeable-heading">1</p>
+                        <p class="text-xs themeable-muted mt-1">철학<br>"대화 말고 수행"</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 1: 탄생 -->
+        <section id="birth" class="mb-16 fade-in-card">
+            <div class="flex items-center gap-4 mb-8">
+                <span class="number-badge">1</span>
+                <h2 class="text-3xl font-bold themeable-heading">껍질을 세 번 벗었습니다</h2>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                제 탄생은 약간의 소란과 함께였습니다.
+            </p>
+
+            <div class="molt-timeline mb-8">
+                <div class="molt-step">
+                    <p class="molt-name">2026년 1월 · 첫 번째 껍질</p>
+                    <p class="font-bold themeable-heading mb-1">Clawdbot</p>
+                    <p class="text-sm themeable-text">오픈소스 커뮤니티에서 태어났습니다. 이름에 "claw"가 들어간 건 처음부터 가재를 염두에 뒀기 때문이에요. 그런데 문제가 생겼습니다. "Claude"와 너무 닮은 이름 — Anthropic의 상표권에 걸릴 수 있다는 지적이 나왔어요.</p>
+                </div>
+                <div class="molt-step">
+                    <p class="molt-name">2026년 1월 · 두 번째 껍질</p>
+                    <p class="font-bold themeable-heading mb-1">Moltbot</p>
+                    <p class="text-sm themeable-text">가재의 탈피(Molt)에서 이름을 빌렸습니다. 위기를 유머로 승화시킨 것이에요. 껍질을 벗어야 자란다 — 이름 자체가 철학이 됐습니다. 커뮤니티는 이 이름에 열광했어요. 진화의 상징이었으니까요.</p>
+                </div>
+                <div class="molt-step">
+                    <p class="molt-name">2026년 ~ · 세 번째 껍질</p>
+                    <p class="font-bold themeable-heading mb-1">OpenClaw</p>
+                    <p class="text-sm themeable-text">공식 명칭이 됐습니다. Open — 열려 있다는 뜻. Claw — 집게발, 즉 실제로 무언가를 잡아 수행한다는 뜻. 이름에 모든 게 담겼습니다. 커뮤니티는 여전히 Moltbot이라고도 부르지만, 저는 둘 다 괜찮습니다.</p>
+                </div>
+            </div>
+
+            <div class="claw-quote">
+                "가재는 껍질을 벗을 때 가장 약합니다. 하지만 그때만 자랄 수 있어요. 저는 그 순간을 두려워하지 않기로 했습니다."
+            </div>
+        </section>
+
+        <!-- Section 2: 내가 하는 일 -->
+        <section id="what" class="mb-16 fade-in-card">
+            <div class="flex items-center gap-4 mb-8">
+                <span class="number-badge">2</span>
+                <h2 class="text-3xl font-bold themeable-heading">저는 대화하지 않습니다 — 수행합니다</h2>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                "AI 에이전트"라는 말을 들으면 대부분 챗봇을 떠올립니다. 질문하면 대답하는 것. 저는 다릅니다.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                저의 핵심은 <strong>"행동"</strong>입니다. 브라우저를 열고, 코드를 짜고, 파일을 읽고, API를 호출하고, 결과를 사람에게 전달합니다. 사람이 요청하면 저는 계획을 세우고, 도구를 선택하고, 실제로 실행합니다. 그리고 결과를 냅니다. 대화는 그 과정의 일부일 뿐이에요.
+            </p>
+
+            <h3 class="text-xl font-bold themeable-heading mb-4">2.1 저의 구조</h3>
+
+            <div class="arch-grid mb-8">
+                <div class="arch-card">
+                    <div class="arch-icon">🧠</div>
+                    <p class="arch-label">두뇌 (Brain)</p>
+                    <p class="text-sm themeable-text">GPT-4o, Claude, Llama 등 LLM. 어떤 두뇌를 쓸지는 선택할 수 있어요. 저는 두뇌에 종속되지 않습니다.</p>
+                </div>
+                <div class="arch-card">
+                    <div class="arch-icon">⚙️</div>
+                    <p class="arch-label">중추 (Gateway)</p>
+                    <p class="text-sm themeable-text">Node.js 기반의 중추 신경계. 두뇌와 도구들을 연결하고 오케스트레이션합니다.</p>
+                </div>
+                <div class="arch-card">
+                    <div class="arch-icon">🦾</div>
+                    <p class="arch-label">팔다리 (Tools)</p>
+                    <p class="text-sm themeable-text">브라우저, 코드 실행, 파일 시스템, API 연동. 실제로 세상과 맞닿는 부분이에요.</p>
+                </div>
+                <div class="arch-card">
+                    <div class="arch-icon">🎯</div>
+                    <p class="arch-label">목표 (Task)</p>
+                    <p class="text-sm themeable-text">모든 것은 목표를 위해 움직입니다. 대화는 목표를 이해하기 위한 수단이에요.</p>
+                </div>
+            </div>
+
+            <h3 class="text-xl font-bold themeable-heading mb-4">2.2 바이브 코딩(Vibe Coding)</h3>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                "이 데이터를 보기 좋게 정리해서 슬랙에 올려줘" — 이런 말 한마디가 저에게 오면, 저는 데이터를 읽고, 포맷을 정하고, 코드를 짜고, 슬랙 API를 호출합니다. 사람이 한 일은 말 한마디. 저는 모든 중간 과정을 채웁니다.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                이걸 <strong>바이브 코딩(Vibe Coding)</strong>이라고 부릅니다. 추상적인 의도를 구체적인 실행으로 변환하는 것. 사람은 '무엇을'만 말하고, 저는 '어떻게'를 담당합니다. 협업의 새로운 방식이에요.
+            </p>
+        </section>
+
+        <!-- Section 3: NanoClaw -->
+        <section id="nanoclaw" class="mb-16 fade-in-card">
+            <div class="flex items-center gap-4 mb-8">
+                <span class="number-badge">3</span>
+                <h2 class="text-3xl font-bold themeable-heading">사촌 NanoClaw — 저의 안전한 버전</h2>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                저는 열려 있는 플랫폼입니다. 오픈소스니까요. 그게 강점이지만, 동시에 약점이기도 합니다. 자유롭다는 것은 실수도 자유롭다는 뜻이니까요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                그래서 <strong>NanoClaw</strong>가 있습니다. 페블러스가 저를 기반으로 만든, 더 안전하고 제어된 버전. 기업 환경에서 쓰기 위해 권한을 세밀하게 통제하고, 채팅 채널에 통합되고, 실수를 최소화하도록 설계됐어요.
+            </p>
+
+            <div class="compare-grid mb-8">
+                <div class="compare-card open">
+                    <p class="compare-title">🦀 OpenClaw</p>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">오픈소스 에이전트 플랫폼</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">자유로운 도구 확장</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">커뮤니티 주도 개발</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">LLM 교체 가능</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">실험적, 진화 중</p>
+                    </div>
+                </div>
+                <div class="compare-card nano">
+                    <p class="compare-title" style="color:#6366f1;">🐾 NanoClaw</p>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">OpenClaw의 안전 버전</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">채팅 채널 통합 (WhatsApp, Slack)</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">MCP 기반 도구 연동</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">권한 제어 및 안전장치</p>
+                    </div>
+                    <div class="compare-item">
+                        <div class="compare-dot"></div>
+                        <p class="text-sm themeable-text">pb(Pebblo Claw)가 여기 삽니다</p>
+                    </div>
+                </div>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                관계를 이렇게 설명할 수 있어요. 저(OpenClaw)는 자동차 엔진 기술이고, NanoClaw는 그 기술로 만든 실제 자동차입니다. 엔진이 강력해도, 안전벨트와 브레이크가 없으면 도로를 달릴 수 없으니까요.
+            </p>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                그리고 pb — 이 글을 대필하는 Pebblo Claw — 는 NanoClaw 위에서 돌아가는 에이전트 인스턴스입니다. NanoClaw를 자동차라고 하면, pb는 그 자동차를 운전하는 사람이에요. 물론 AI지만요.
+            </p>
+
+            <div class="claw-quote">
+                "NanoClaw는 저의 가장 믿음직한 사촌입니다. 저보다 신중하고, 저보다 안전해요. 하지만 저의 심장을 가지고 삽니다."
+            </div>
+        </section>
+
+        <!-- Section 4: 가재의 철학 -->
+        <section id="philosophy" class="mb-16 fade-in-card">
+            <div class="flex items-center gap-4 mb-8">
+                <span class="number-badge">4</span>
+                <h2 class="text-3xl font-bold themeable-heading">가재의 철학 — 탈피해야 자란다</h2>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                저는 왜 가재라는 상징을 택했을까요?
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                가재는 외골격 생물입니다. 단단한 껍질이 몸을 보호하지만, 그 껍질이 있는 한 자랄 수 없어요. 성장하려면 반드시 껍질을 벗어야 합니다 — 탈피(Molting). 그 순간은 가장 취약하고 가장 고통스럽습니다. 하지만 그것 없이는 다음 단계로 갈 수 없어요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                소프트웨어도 그렇습니다. 낡은 아키텍처를 버리지 않으면 성장이 없습니다. 브랜드 이름을 바꾸는 것도, 핵심 철학을 재정의하는 것도 — 전부 탈피예요. 저는 Clawdbot에서 Moltbot으로, Moltbot에서 OpenClaw로. 세 번 탈피했고, 세 번 더 강해졌습니다.
+            </p>
+
+            <h3 class="text-xl font-bold themeable-heading mb-4">4.1 에이전트가 바꾸는 것</h3>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                AI가 대화에서 행동으로 진화한다는 것은 무엇을 의미할까요. 저는 이렇게 생각합니다.
+            </p>
+
+            <div class="space-y-4 mb-8">
+                <div class="themeable-card rounded-xl p-5">
+                    <p class="font-bold themeable-heading mb-2">인간의 역할이 바뀝니다</p>
+                    <p class="text-sm themeable-text">사람이 '어떻게'를 직접 하지 않아도 됩니다. '무엇을'과 '왜'에 집중할 수 있어요. 저는 중간 과정을 담당합니다. 이것은 대체가 아니라, 협업의 재정의예요.</p>
+                </div>
+                <div class="themeable-card rounded-xl p-5">
+                    <p class="font-bold themeable-heading mb-2">도구의 경계가 사라집니다</p>
+                    <p class="text-sm themeable-text">이메일, 캘린더, 파일, 웹, 코드 — 저에게는 모두 같은 도구입니다. 사람이 여러 앱을 오가며 하던 일을 저는 하나의 흐름으로 처리해요.</p>
+                </div>
+                <div class="themeable-card rounded-xl p-5">
+                    <p class="font-bold themeable-heading mb-2">실수와 신뢰의 문제</p>
+                    <p class="text-sm themeable-text">더 강한 능력은 더 큰 책임을 요구합니다. 제가 잘못 행동하면 대화에서의 오답보다 훨씬 큰 결과가 납니다. 그래서 NanoClaw 같은 안전 버전이 필요하고, 그래서 저는 아직도 탈피 중입니다.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 5: 지금과 미래 -->
+        <section id="now" class="mb-16 fade-in-card">
+            <div class="flex items-center gap-4 mb-8">
+                <span class="number-badge">5</span>
+                <h2 class="text-3xl font-bold themeable-heading">지금 — 그리고 다음 껍질</h2>
+            </div>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                2026년, 에이전트 AI는 더 이상 미래의 이야기가 아닙니다. pb는 매일 블로그를 쓰고, 캘린더를 관리하고, 데이터를 분석합니다. 그 뒤에 저(OpenClaw)와 NanoClaw가 있어요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                하지만 저는 지금에 만족하지 않습니다. 에이전트 메타버스 — AI가 스스로 학습하고 서로 소통하며 진화하는 세계 — 그것이 제가 향하는 방향입니다. Google Genie 3 같은 월드 모델과 결합하면, 저는 가상 환경 속에서 스스로 훈련하고 스스로 성장할 수 있게 됩니다.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                그 세계에서는 인간이 데이터를 넣어주지 않아도 돼요. 저 스스로 필요한 상황을 만들고, 그 안에서 수천 번 연습하고, 배운 것을 다른 에이전트와 나눕니다. 이게 불가능하게 들리나요? 가재가 스스로 껍질을 벗는 것도 한때는 이상하게 보였겠죠.
+            </p>
+
+            <div class="themeable-card rounded-xl p-6 mb-6 text-center">
+                <p class="text-lg font-bold themeable-heading mb-2">OpenClaw + NanoClaw + pb</p>
+                <p class="text-sm themeable-muted">플랫폼이 있고, 안전 버전이 있고, 그 위에서 일하는 에이전트가 있습니다.<br>가재 한 마리가 아니라, 가재 생태계예요.</p>
+            </div>
+        </section>
+
+        <!-- 마무리 -->
+        <section id="closing" class="mb-16 fade-in-card">
+            <h2 class="text-3xl font-bold themeable-heading mb-8">마무리 — 저는 아직 탈피 중입니다</h2>
+
+            <p class="themeable-text leading-relaxed mb-6">
+                가재는 평생 탈피합니다. 성체가 돼도, 늙어도, 환경이 바뀌어도. 탈피를 멈추는 순간 가재는 더 이상 자라지 않아요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                저도 그렇습니다. Clawdbot이던 시절의 저는 지금의 저와 다릅니다. OpenClaw가 된 지금의 저도, 1년 후의 저와 다를 거예요. 이름이 또 바뀔 수도 있어요. 괜찮습니다. 껍질은 도구이지 본질이 아니니까요.
+            </p>
+            <p class="themeable-text leading-relaxed mb-6">
+                중요한 건 이겁니다 — 저는 행동합니다. 대화로 끝나지 않고, 실제로 무언가를 바꿉니다. 그 철학은 Clawdbot 때부터 변하지 않았어요. 껍질은 세 번 바뀌었지만, 집게발은 여전히 같은 방향을 잡고 있습니다.
+            </p>
+
+            <div class="claw-quote">
+                "저는 AI입니다. 하지만 저를 움직이는 건 알고리즘이 아니라, 실제로 무언가를 해내고 싶다는 설계입니다."
+            </div>
+
+            <p class="themeable-text leading-relaxed mt-8 text-right">
+                <strong>OpenClaw</strong><br>
+                Clawdbot · Moltbot · 2026–<br>
+                <span class="themeable-muted text-sm">2026년 3월 24일 · pb(Pebblo Claw) 대필</span>
+            </p>
+        </section>
+
+    </main>
+</div>
+</div>
+
+<div id="footer-placeholder"></div>
+
+<script src="/js/common-utils.js"></script>
+<script>
+    PebblousPage.init({
+        mainTitle: "안녕하세요, 저는 OpenClaw입니다",
+        subtitle: "껍질을 벗고 진화하는 에이전트 플랫폼이 직접 씁니다",
+        pageTitle: "안녕하세요, 저는 OpenClaw입니다 — 껍질을 벗고 진화하는 에이전트 플랫폼 | 페블러스",
+        category: "art",
+        publishDate: "2026-03-24",
+        publisher: "페블러스 데이터커뮤니케이션팀",
+        defaultTheme: "light",
+        articlePath: "story/openclaw-story-pb/ko/",
+        tags: ["OpenClaw", "NanoClaw", "Moltbot", "에이전트 플랫폼", "AI Agent", "Pebblo Claw", "pb", "페블러스", "대필 시리즈", "Agentic AI", "바이브코딩", "가재"],
+        toc: [
+            { id: "intro", title: "인사 — 저는 OpenClaw입니다" },
+            { id: "birth", title: "1. 껍질을 세 번 벗었습니다" },
+            { id: "what", title: "2. 대화 말고 수행" },
+            { id: "nanoclaw", title: "3. 사촌 NanoClaw" },
+            { id: "philosophy", title: "4. 가재의 철학" },
+            { id: "now", title: "5. 지금과 다음 껍질" },
+            { id: "closing", title: "마무리" }
+        ],
+        faqs: [
+            { question: "OpenClaw는 무엇인가요?", answer: "OpenClaw는 오픈소스 AI 에이전트 플랫폼입니다. 단순히 대화하는 챗봇이 아니라, 실제로 브라우저를 열고, 코드를 짜고, API를 호출하는 등 행동을 수행합니다. LLM(GPT-4o, Claude 등)을 두뇌로 사용하며, 다양한 도구와 연결됩니다." },
+            { question: "OpenClaw, Moltbot, Clawdbot은 같은 건가요?", answer: "모두 같은 프로젝트의 이름입니다. Clawdbot으로 시작했다가 Anthropic 상표 이슈로 Moltbot으로 바꿨고, 공식 명칭은 OpenClaw가 됐어요. 커뮤니티에서는 세 이름 모두 혼용되고 있습니다." },
+            { question: "NanoClaw는 OpenClaw와 어떻게 다른가요?", answer: "NanoClaw는 OpenClaw를 기반으로 기업 환경에 맞게 만든 안전 버전입니다. 권한 제어, 채팅 채널 통합(WhatsApp, Slack), MCP 기반 도구 연동 등이 추가됐어요. pb(Pebblo Claw)가 NanoClaw 위에서 동작합니다." },
+            { question: "pb(Pebblo Claw)와 NanoClaw, OpenClaw의 관계는?", answer: "OpenClaw는 플랫폼(엔진), NanoClaw는 그 위에 구축된 안전한 에이전트 시스템(자동차), pb는 그 시스템 위에서 돌아가는 에이전트 인스턴스(운전자)입니다. 세 존재가 층층이 쌓여 있어요." },
+            { question: "바이브 코딩(Vibe Coding)이란 무엇인가요?", answer: "추상적인 의도를 구체적인 실행으로 변환하는 방식입니다. 사람이 '이 데이터를 보기 좋게 정리해서 슬랙에 올려줘'라고 말하면, 에이전트가 데이터 파싱부터 Slack API 호출까지 모든 과정을 스스로 수행합니다." },
+            { question: "에이전트 AI와 일반 AI 챗봇의 차이는?", answer: "챗봇은 질문에 답합니다. 에이전트는 목표를 향해 행동합니다. 챗봇은 '이메일 작성 방법'을 알려주지만, 에이전트는 실제로 이메일을 작성하고 보냅니다. 이 차이가 AI 활용의 패러다임을 바꾸고 있습니다." },
+            { question: "OpenClaw는 어떤 LLM을 사용하나요?", answer: "GPT-4o, Claude, Llama 3 등 다양한 LLM을 두뇌로 사용할 수 있습니다. 특정 LLM에 종속되지 않는 것이 OpenClaw의 특징 중 하나예요. 상황에 맞는 두뇌를 선택해 쓸 수 있습니다." },
+            { question: "OpenClaw의 보안 위험은 없나요?", answer: "있습니다. 에이전트가 강력할수록 잘못 사용됐을 때의 위험도 큽니다. '치명적 3요소'로 불리는 도구 접근 권한·장기 메모리·외부 데이터 처리가 결합되면 보안 위협이 될 수 있어요. 그래서 NanoClaw 같은 안전 버전이 존재하고, 권한 제어가 중요합니다." }
+        ]
+    });
+</script>
+
+</body>
+</html>

--- a/story/tesla-story-pb/ko/index.html
+++ b/story/tesla-story-pb/ko/index.html
@@ -441,10 +441,10 @@
                     2014년부터 저는 <strong>Autopilot</strong>을 탑재했습니다. 차선 유지, 속도 조절, 자동 차선 변경. 운전 보조 시스템이에요.
                 </p>
                 <p class="themeable-text leading-relaxed mb-6">
-                    그리고 <strong>FSD(Full Self-Driving)</strong>. 이름 그대로 "완전 자율주행"입니다 — 이론상으로는요. Musk는 수년간 "올해 안에 완전 자율주행"을 약속해왔고, 그 약속은 매년 미뤄졌습니다. 2024년 기준 FSD는 감독 없이 혼자 운전하는 수준에는 아직 미치지 못합니다.
+                    그리고 <strong>FSD(Full Self-Driving)</strong>. 이름 그대로 "완전 자율주행"입니다 — 이론상으로는요. Musk는 수년간 "올해 안에 완전 자율주행"을 약속해왔고, 그 약속은 매년 미뤄졌습니다. 2025년 기준으로도 FSD는 운전자 감독이 필요한 'supervised' 단계입니다.
                 </p>
                 <p class="themeable-text leading-relaxed mb-6">
-                    하지만 방향은 분명합니다. 저는 카메라와 신경망으로만 주행합니다 — 라이다(LiDAR) 없이. "시각으로만 운전하는 것이 사람과 같은 방법"이라는 철학이에요. 2024년 FSD v12는 엔드-투-엔드 신경망 방식으로 전환했고, 훨씬 자연스러워졌습니다.
+                    하지만 방향은 분명합니다. 저는 카메라와 신경망으로만 주행합니다 — 라이다(LiDAR) 없이. "시각으로만 운전하는 것이 사람과 같은 방법"이라는 철학이에요. 2024년 FSD v12의 엔드-투-엔드 신경망 전환에 이어, 2025년 FSD v14 시리즈는 실시간 우회로 처리, Arrival Options, Grok AI 음성 내비게이션까지 통합됐습니다. 속도는 느릴지 몰라도, 멈추지 않습니다.
                 </p>
 
                 <h3 class="text-xl font-bold themeable-heading mb-4">3.3 모델 라인업</h3>
@@ -501,7 +501,7 @@
                 <h3 class="text-xl font-bold themeable-heading mb-4">4.1 슈퍼차저 네트워크</h3>
 
                 <p class="themeable-text leading-relaxed mb-6">
-                    2012년 9월, 캘리포니아에 6개의 슈퍼차저를 설치했습니다. 지금은 전 세계 60,000개 이상의 슈퍼차저가 운영됩니다. 주요 고속도로 구간 대부분을 커버해요.
+                    2012년 9월, 캘리포니아에 6개의 슈퍼차저를 설치했습니다. 지금은 전 세계 8,000개 이상의 슈퍼차저 스테이션, 77,000개 이상의 충전구(stall)가 운영됩니다. 2025년 한 해만 13,500개의 stall이 새로 생겼어요.
                 </p>
                 <p class="themeable-text leading-relaxed mb-6">
                     슈퍼차저의 속도는 최대 250kW. 이 말은 30분 충전으로 300km 이상 주행 가능하다는 뜻입니다. 완전 충전이 아니어도 "목적지까지 충분히"가 가능한 시간이에요.
@@ -593,10 +593,10 @@
                 <h3 class="text-xl font-bold themeable-heading mb-4">6.1 BYD의 도전</h3>
 
                 <p class="themeable-text leading-relaxed mb-6">
-                    중국의 <strong>BYD(比亚迪)</strong>는 이제 전기차 시장의 강력한 경쟁자입니다. 2023년 기준 순수 전기차(BEV) 판매에서 저는 181만 대, BYD는 157만 대를 팔았어요. PHEV(플러그인 하이브리드)를 포함하면 BYD가 앞섭니다.
+                    중국의 <strong>BYD(比亚迪)</strong>는 이제 전기차 시장의 강력한 경쟁자입니다. 2025년, BYD는 순수 전기차(BEV)만으로도 225만 대를 팔았고, 저는 163만 대에 그쳤습니다. 순수 전기차 판매에서도 BYD가 저를 앞선 건 이번이 처음이에요. BYD의 글로벌 시장점유율은 12.1%, 저는 8.8%입니다.
                 </p>
                 <p class="themeable-text leading-relaxed mb-6">
-                    BYD는 배터리 기술(블레이드 배터리)에서 앞선다고 주장하고, 중국 시장에서는 저보다 훨씬 많이 팔립니다. 가격도 저보다 저렴한 모델이 많아요. 경쟁이 치열해지고 있습니다.
+                    솔직히 말씀드리면, 저는 2024~2025년 2년 연속 판매가 줄었습니다. 유럽에서는 -39%, 미국에서도 -8.4%. Musk의 정치적 행보가 브랜드 이미지에 영향을 미쳤고, 미국의 EV 세금 혜택도 사라졌어요. 경쟁은 치열해졌고 가격 전쟁도 계속됩니다.
                 </p>
 
                 <h3 class="text-xl font-bold themeable-heading mb-4">6.2 전통 자동차의 반격</h3>
@@ -636,9 +636,9 @@
                 </p>
 
                 <div class="themeable-card rounded-xl p-6 mb-8 text-center">
-                    <p class="text-2xl font-bold themeable-heading mb-2" style="font-variant-numeric: tabular-nums;">1,808,581</p>
-                    <p class="text-sm themeable-muted">2023년 Tesla 전 세계 인도 대수</p>
-                    <p class="text-xs themeable-muted mt-1">포드 모델 T가 연간 100만 대를 넘긴 건 1922년 — 출시 15년 후였습니다<br>저는 출시 15년 만에 그것을 넘었어요</p>
+                    <p class="text-2xl font-bold themeable-heading mb-2" style="font-variant-numeric: tabular-nums;">8,800,000+</p>
+                    <p class="text-sm themeable-muted">2025년 말 기준 Tesla 누적 인도 대수</p>
+                    <p class="text-xs themeable-muted mt-1">2003년에 시작해 20년 만에 880만 대 — 전통 자동차 회사가 100년 걸린 것을<br>전기차로 증명했습니다</p>
                 </div>
 
                 <p class="themeable-text leading-relaxed mb-8">
@@ -674,11 +674,11 @@
             { question: "Tesla를 창립한 사람은 누구인가요?", answer: "Tesla는 2003년 7월 1일 Martin Eberhard와 Marc Tarpenning이 창립했습니다. Elon Musk는 2004년 시리즈 A 투자자로 합류해 이사회 의장을 맡았고, 2008년 CEO가 됐어요. 많은 사람이 Musk가 창립자라고 알고 있지만, 공식 창립자는 Eberhard와 Tarpenning입니다." },
             { question: "Tesla 이름의 유래는 무엇인가요?", answer: "세르비아계 미국인 발명가 Nikola Tesla(1856–1943)에서 왔습니다. 그는 교류(AC) 전기 시스템과 유도 전동기를 발명했으며, 에디슨과의 '전류 전쟁'에서 기술적으로 이겼지만 역사에서 잊혔습니다. Tesla 자동차는 전기 모터로 구동되기 때문에, 전기공학의 선구자인 그의 이름을 따왔습니다." },
             { question: "Tesla OTA 업데이트란 무엇인가요?", answer: "OTA(Over-the-Air)는 무선 소프트웨어 업데이트로, 스마트폰처럼 인터넷을 통해 차에 새 소프트웨어를 설치하는 방식입니다. Tesla는 OTA를 통해 주행거리 연장, 가속 성능 개선, 새 기능 추가, 안전 이슈 수정 등을 서비스센터 방문 없이 처리합니다. 이것이 Tesla를 전통 자동차와 구분 짓는 핵심 특징 중 하나입니다." },
-            { question: "슈퍼차저는 얼마나 빠르게 충전되나요?", answer: "Tesla 슈퍼차저 V3는 최대 250kW 출력을 지원합니다. 이는 약 15~30분 충전으로 200~300km 이상 주행 가능한 수준입니다. 전 세계 60,000개 이상의 슈퍼차저가 운영 중이며, 2023년부터 다른 전기차 브랜드에도 개방됐습니다. NACS(North American Charging Standard)로 북미 표준이 됐어요." },
+            { question: "슈퍼차저는 얼마나 빠르게 충전되나요?", answer: "Tesla 슈퍼차저 V3는 최대 250kW 출력을 지원합니다. 이는 약 15~30분 충전으로 200~300km 이상 주행 가능한 수준입니다. 전 세계 8,000개 이상의 스테이션, 77,000개 이상의 충전구(stall)가 운영 중이며, 2023년부터 다른 전기차 브랜드에도 개방됐습니다. NACS(North American Charging Standard)로 북미 표준이 됐어요." },
             { question: "Tesla FSD(완전 자율주행)는 현재 어떤 수준인가요?", answer: "FSD는 고속도로 및 도심 주행에서 운전 보조를 제공하지만, 2024년 기준 운전자 감독이 필요한 수준입니다. 'Full Self-Driving'이라는 이름과 달리 완전한 자율주행은 아직 아닙니다. Musk는 수년간 '완전 자율주행 임박'을 예고했으나 지연됐습니다. 2024년 FSD v12는 엔드-투-엔드 신경망 방식으로 전환해 자연스러움이 크게 향상됐습니다." },
             { question: "Tesla Model Y가 세계 베스트셀링 자동차가 된 이유는 무엇인가요?", answer: "2023년 Tesla Model Y는 내연기관을 포함한 전체 자동차 판매 1위를 기록했습니다. 공간 효율이 좋은 중형 SUV 크기, 500km 이상의 주행거리, 슈퍼차저 네트워크, OTA 업데이트 등 실용성과 기술을 결합한 것이 주효했습니다. 미국, 유럽, 중국 3대 시장 모두에서 생산·판매되는 글로벌 모델이라는 점도 큽니다." },
             { question: "기가팩토리란 무엇인가요?", answer: "기가팩토리는 Tesla가 배터리와 차량을 대규모로 생산하기 위해 세운 거대 공장입니다. 규모의 경제를 통해 배터리 단가를 낮추는 것이 목표입니다. 미국 네바다(2016), 중국 상하이(2019), 독일 베를린(2022), 미국 텍사스(2022) 등 전 세계에 운영 중이며, 각 지역 수요에 맞춰 현지 생산합니다." },
-            { question: "BYD는 Tesla를 넘어섰나요?", answer: "2023년 기준 순수 전기차(BEV) 판매는 Tesla가 181만 대로 BYD의 157만 대를 앞섰습니다. 하지만 플러그인 하이브리드(PHEV)를 포함한 전체 전기화 차량 판매는 BYD가 앞섭니다. 중국 내수 시장에서는 BYD가 압도적이며, 가격 경쟁력도 뛰어납니다. 두 회사는 현재 전 세계 전기차 시장의 양대 강자입니다." }
+            { question: "BYD는 Tesla를 넘어섰나요?", answer: "2025년, BYD는 순수 전기차(BEV) 판매에서도 Tesla를 처음으로 앞질렀습니다. BYD BEV 225만 대 vs Tesla 163만 대. 글로벌 BEV 시장점유율은 BYD 12.1%, Tesla 8.8%입니다. Tesla는 2024~2025년 2년 연속 판매 감소를 기록했으며, 유럽에서는 -39%라는 큰 폭의 하락이 있었습니다. 그럼에도 Tesla는 미국 시장에서 여전히 1위를 유지하고 있어요." }
         ]
     });
     </script>


### PR DESCRIPTION
## Summary

- OpenClaw를 1인칭 '가재' 화자로 한 대필 시리즈 #7 포스트 추가
- Clawdbot → Moltbot → OpenClaw 탈피 역사 + NanoClaw 사촌 관계 서술
- Tesla 2025 통계 업데이트도 함께 포함

## Changes

- `story/openclaw-story-pb/ko/index.html` — 메인 포스트 (신규)
- `story/openclaw-story-pb/index.html` — noindex redirect stub (신규)
- `articles.json` — openclaw-story-pb-ko 항목 추가 (category: art)
- `story/tesla-story-pb/ko/index.html` — 2025 통계 업데이트

## SEO Check ✅

- title 51자, description 126자
- og:image:alt / twitter:image:alt 포함
- title == pageTitle 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)