### PR TITLE
fix: 터보퀀츠 — 논문 & 구글 블로그 링크 추가

### DIFF
--- a/pebblopedia/turboquant/ko/index.html
+++ b/pebblopedia/turboquant/ko/index.html
@@ -334,6 +334,11 @@
                         <p class="themeable-text leading-relaxed"><strong>PebbloPedia</strong>는 하나의 개념을 다섯 가지 깊이로 설명하는 페블러스의 지식 시리즈예요. 이번 다섯 번째 편의 주제는 <strong>터보퀀츠(TurboQuant)</strong> — 2026년 3월 구글 리서치가 발표한 AI 메모리 압축 기술입니다.</p>
                         <p class="themeable-text leading-relaxed mt-4">정확도를 1도 잃지 않으면서 AI의 메모리를 6배 줄이고, 연산을 8배 빠르게 만들었습니다. 트위터에서 777만 뷰를 기록했고, Cloudflare CEO는 "Google의 DeepSeek 순간"이라고 불렀습니다. KAIST와 NYU가 구글과 함께 만든 한국발 연구이기도 합니다.</p>
                         <p class="themeable-text leading-relaxed mt-4">아무 단계에서나 시작해도 됩니다. 초등학생 비유부터 정보 이론의 하한선까지 — 같은 기술이 다섯 개의 얼굴로 나타납니다.</p>
+                        <p class="themeable-text leading-relaxed mt-4 text-sm">
+                            📄 <a href="https://arxiv.org/abs/2504.19874" target="_blank" rel="noopener" class="text-orange-400 hover:text-orange-300 transition-colors">논문 (arXiv:2504.19874)</a>
+                            &nbsp;·&nbsp;
+                            <a href="https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/" target="_blank" rel="noopener" class="text-orange-400 hover:text-orange-300 transition-colors">구글 리서치 블로그</a>
+                        </p>
                     </div>
 
                     <!-- 핵심 수치 -->


### PR DESCRIPTION
Executive Summary에 논문 링크 추가.

- arXiv:2504.19874 (TurboQuant 논문)
- research.google/blog (구글 리서치 블로그)

🤖 Generated with Claude Code (claude.ai/claude-code)