### PR TITLE
fix: ImageNet 스토리 class-card/density-card 대표이미지 병행 패턴 적용

### DIFF
--- a/story/dataclinic-report-123-imagenet-story-pb/ko/index.html
+++ b/story/dataclinic-report-123-imagenet-story-pb/ko/index.html
@@ -172,7 +172,15 @@
             background-color: var(--bg-card);
             border: 1px solid var(--border-color);
         }
-        .class-card img { width: 100%; aspect-ratio: 1; object-fit: cover; }
+        .class-card-images { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background-color: var(--border-color); }
+        .class-card-img-wrap { position: relative; overflow: hidden; background-color: var(--bg-card); }
+        .class-card-img-wrap img { width: 100%; aspect-ratio: 1; object-fit: cover; display: block; }
+        .img-type-label {
+            position: absolute; bottom: 2px; left: 2px;
+            font-size: 0.5rem; font-weight: 600;
+            background: rgba(0,0,0,.65); color: #fff;
+            padding: 1px 3px; border-radius: 2px; line-height: 1.4;
+        }
         .class-card .class-name { font-size: 0.75rem; text-align: center; padding: 0.3rem 0.25rem; color: var(--text-muted); line-height: 1.3; }
 
         .density-grid-3 {
@@ -188,7 +196,16 @@
             background-color: var(--bg-card);
             border: 1px solid var(--border-color);
         }
-        .density-card img { width: 100%; display: block; }
+        .density-card .den-imgs { display: grid; grid-template-columns: 2fr 1fr; gap: 1px; background-color: var(--border-color); }
+        .density-card .den-imgs > div { position: relative; overflow: hidden; background-color: var(--bg-card); }
+        .density-card .den-imgs .den-chart img { width: 100%; aspect-ratio: 4/3; object-fit: cover; display: block; }
+        .density-card .den-imgs .den-rep img { width: 100%; aspect-ratio: 1; object-fit: cover; display: block; }
+        .density-card .den-label {
+            position: absolute; bottom: 2px; left: 2px;
+            font-size: 0.5rem; font-weight: 600;
+            background: rgba(0,0,0,.65); color: #fff;
+            padding: 1px 3px; border-radius: 2px; line-height: 1.4;
+        }
         .density-card .den-info { padding: 0.5rem 0.75rem 0.65rem; }
         .density-card .den-name { font-size: 0.875rem; font-weight: 600; color: var(--text-primary); }
         .density-card .den-note { font-size: 0.72rem; color: var(--text-muted); margin-top: 0.2rem; line-height: 1.4; }
@@ -446,59 +463,166 @@
                         <!-- Mean image gallery -->
                         <div class="class-grid mt-6">
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tench.png" alt="tench 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/tench/n01440764_13144.JPEG" alt="tench 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tench.png" alt="tench 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Tench<br>(민물고기)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/goldfish.png" alt="goldfish 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/goldfish/n01443537_11018.JPEG" alt="goldfish 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/goldfish.png" alt="goldfish 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Goldfish<br>(금붕어)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/dalmatian.png" alt="dalmatian 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/dalmatian/n02110341_1785.JPEG" alt="dalmatian 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/dalmatian.png" alt="dalmatian 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Dalmatian<br>(달마시안)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/golden%20retriever.png" alt="golden retriever 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/golden%20retriever/n02099601_5119.JPEG" alt="golden retriever 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/golden%20retriever.png" alt="golden retriever 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Golden Retriever<br>(골든 리트리버)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tiger.png" alt="tiger 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/tiger/n02129604_17265.JPEG" alt="tiger 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tiger.png" alt="tiger 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Tiger<br>(호랑이)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tabby.png" alt="tabby 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/tabby/n02123045_5827.JPEG" alt="tabby 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/tabby.png" alt="tabby 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Tabby Cat<br>(줄무늬 고양이)</div>
                             </div>
                         </div>
-                        <p class="text-xs themeable-muted text-center mt-1">▲ L1 클래스 평균 이미지 — 해당 클래스의 모든 이미지를 픽셀 단위로 평균한 결과. 선명도가 시각적 일관성을 나타냅니다.</p>
+                        <p class="text-xs themeable-muted text-center mt-1">▲ 각 카드 왼쪽: 클래스 대표 이미지(실제 샘플) / 오른쪽: 평균 이미지. 선명한 평균 이미지일수록 시각적 일관성이 높습니다.</p>
 
                         <div class="class-grid mt-4">
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/sports%20car.png" alt="sports car 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/sports%20car/n04285008_4005.JPEG" alt="sports car 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/sports%20car.png" alt="sports car 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Sports Car<br>(스포츠카)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/convertible.png" alt="convertible 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/convertible/n03100240_1093.JPEG" alt="convertible 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/convertible.png" alt="convertible 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Convertible<br>(컨버터블)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/mountain%20bike.png" alt="mountain bike 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/mountain%20bike/n03792782_34681.JPEG" alt="mountain bike 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/mountain%20bike.png" alt="mountain bike 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Mountain Bike<br>(산악자전거)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/scorpion.png" alt="scorpion 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/scorpion/n01770393_9274.JPEG" alt="scorpion 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/scorpion.png" alt="scorpion 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Scorpion<br>(전갈)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/banana.png" alt="banana 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/banana/n07753592_10731.JPEG" alt="banana 대표 이미지" loading="lazy">
+                                        <span class="img-type-label">실제</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/banana.png" alt="banana 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">Banana<br>(바나나)</div>
                             </div>
                             <div class="class-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/total.png" alt="전체 평균 이미지" loading="lazy">
+                                <div class="class-card-images">
+                                    <div class="class-card-img-wrap" style="background-color:var(--bg-card); display:flex; align-items:center; justify-content:center;">
+                                        <span style="font-size:0.6rem; color:var(--text-muted); padding:0.5rem; text-align:center;">1,000개<br>클래스 평균</span>
+                                    </div>
+                                    <div class="class-card-img-wrap">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/total.png" alt="전체 평균 이미지" loading="lazy">
+                                        <span class="img-type-label">전체평균</span>
+                                    </div>
+                                </div>
                                 <div class="class-name">전체 평균<br>(Overall Mean)</div>
                             </div>
                         </div>
-                        <p class="text-xs themeable-muted text-center mt-1">▲ 스포츠카·컨버터블 평균 이미지가 비슷하게 흐릿한 것을 주목하세요. 두 클래스의 시각적 경계가 모호합니다.</p>
+                        <p class="text-xs themeable-muted text-center mt-1">▲ 각 카드 왼쪽: 실제 샘플 / 오른쪽: 평균 이미지. 스포츠카·컨버터블의 평균이 비슷하게 흐릿한 것을 주목하세요 — 두 클래스의 시각적 경계가 모호합니다.</p>
                     </div>
                 </section>
 
@@ -596,55 +720,115 @@
 
                         <div class="density-grid-3">
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/dalmatian.png"
-                                     alt="달마시안 L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/dalmatian.png"
+                                             alt="달마시안 L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/dalmatian/n02110341_1785.JPEG"
+                                             alt="dalmatian 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Dalmatian (달마시안)</div>
                                     <div class="den-note">120개 개 품종 중 하나. 흰 바탕에 검은 점의 일관된 패턴 → 고밀도</div>
                                 </div>
                             </div>
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/golden%20retriever.png"
-                                     alt="골든 리트리버 L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/golden%20retriever.png"
+                                             alt="골든 리트리버 L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/golden%20retriever/n02099601_5119.JPEG"
+                                             alt="golden retriever 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Golden Retriever</div>
                                     <div class="den-note">유사한 배경(잔디, 공원)과 자세의 이미지 많음 → 클러스터 중심부</div>
                                 </div>
                             </div>
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/tabby.png"
-                                     alt="줄무늬 고양이 L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/tabby.png"
+                                             alt="줄무늬 고양이 L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/tabby/n02123045_5827.JPEG"
+                                             alt="tabby 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Tabby Cat (줄무늬 고양이)</div>
                                     <div class="den-note">다양한 자세·환경·조명 → 개 품종보다 분산 큼</div>
                                 </div>
                             </div>
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/tench.png"
-                                     alt="tench L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/tench.png"
+                                             alt="tench L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/tench/n01440764_13144.JPEG"
+                                             alt="tench 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Tench (민물고기)</div>
                                     <div class="den-note">낚시꾼이 물고기를 들고 있는 유사 구도 반복 → 좁고 집중된 분포</div>
                                 </div>
                             </div>
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/sports%20car.png"
-                                     alt="스포츠카 L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/sports%20car.png"
+                                             alt="스포츠카 L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/sports%20car/n04285008_4005.JPEG"
+                                             alt="sports car 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Sports Car (스포츠카)</div>
                                     <div class="den-note">다양한 색상·각도·배경 → 자동차 클러스터 내 분산</div>
                                 </div>
                             </div>
                             <div class="density-card">
-                                <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/scorpion.png"
-                                     alt="전갈 L2 밀도 분포" loading="lazy">
+                                <div class="den-imgs">
+                                    <div class="den-chart">
+                                        <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-2/Lens-1.6/english/densityPlot/scorpion.png"
+                                             alt="전갈 L2 밀도 분포" loading="lazy">
+                                        <span class="den-label">밀도</span>
+                                    </div>
+                                    <div class="den-rep">
+                                        <img src="https://cdn.dataclinic.ai/datasets/imagenet/train/scorpion/n01770393_9274.JPEG"
+                                             alt="scorpion 대표 이미지" loading="lazy">
+                                        <span class="den-label">실제</span>
+                                    </div>
+                                </div>
                                 <div class="den-info">
                                     <div class="den-name">Scorpion (전갈)</div>
                                     <div class="den-note">독특한 실루엣, 다양한 배경 → 저밀도 분산 분포</div>
                                 </div>
                             </div>
                         </div>
-                        <p class="text-xs themeable-muted text-center">▲ L2 클래스별 밀도 분포. 달마시안·tench는 높은 밀도, scorpion은 낮은 밀도를 보입니다.</p>
+                        <p class="text-xs themeable-muted text-center">▲ L2 클래스별 밀도 분포 + 대표 이미지. 달마시안·tench는 높은 밀도, scorpion은 낮은 밀도를 보입니다.</p>
                     </div>
                 </section>
 


### PR DESCRIPTION
## 변경 내용

story-style-guide §8 패턴을 ImageNet 스토리에 적용합니다.
변경 파일: `story/dataclinic-report-123-imagenet-story-pb/ko/index.html` 1개만

### §8-1 class-card (실제 + 평균 이미지 1:1)
- 기존: 평균 이미지만 단독 표시 (12개 카드)
- 변경: 왼쪽 실제 샘플 / 오른쪽 평균 이미지 나란히 배치
- class-card-images 그리드 + img-type-label ("실제"/"평균") 추가

### §8-2 density-card (밀도 차트 + 대표 이미지 2:1)
- 기존: 밀도 플롯만 단독 표시 (6개 카드)
- 변경: 밀도 차트(2) + 실제 대표 이미지(1) 나란히 배치
- den-imgs 서브그리드 + den-label ("밀도"/"실제") 추가

### 이미지 출처
DataClinic API (diagnosis_report_id=123, chart_id=6)에서 조회, CDN 200 확인

🤖 Generated with Claude Code