### PR TITLE
fix: 버니 샌더스 KO — CSS 로드 순서 수정

### DIFF
--- a/story/bernie-sanders-ai-moratorium-pb/ko/index.html
+++ b/story/bernie-sanders-ai-moratorium-pb/ko/index.html
@@ -79,8 +79,8 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="/css/theme-variables.css?v=20260412">
-    <link rel="stylesheet" href="/styles/common-styles.css?v=20260412">
     <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260412">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260412">
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
 


### PR DESCRIPTION
## 문제

CLAUDE.md 기준과 다른 CSS 순서로 배포된 상태.

```html
<!-- ❌ 현재 (origin/main 8355449) -->
theme-variables.css
common-styles.css    ← Tailwind 전에 로드되면 오버라이드 불가
tailwind-build.css

<!-- ✅ CLAUDE.md 기준 -->
theme-variables.css
tailwind-build.css
common-styles.css    ← Tailwind 이후 로드해야 커스텀 스타일 우선 적용
```

## 변경 파일

- `story/bernie-sanders-ai-moratorium-pb/ko/index.html`

## 근거

`CLAUDE.md` → 아티클 CSS 순서 고정 항목