### PR TITLE
feat(report): VQ-Tokenizer 1편 — KO + EN 아티클

### DIFF
--- a/report/vq-tokenizer-data-quality-synthesis/en/index.html
+++ b/report/vq-tokenizer-data-quality-synthesis/en/index.html
@@ -1,0 +1,804 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO -->
+    <meta name="author" content="Pebblous Data Communication Team">
+    <meta name="language" content="English">
+    <meta http-equiv="content-language" content="en">
+    <meta name="copyright" content="© 2026 Pebblous. All rights reserved.">
+    <meta name="robots" content="index, follow">
+    <meta name="keywords" content="VQ tokenizer, codebook collapse, vector quantization, lucidrains, vector-quantize-pytorch, codebook utilization, VQ-VAE, VQGAN, EnCodec, DAC, MAGVIT-2, FSQ, DiVeQ, DataClinic, PebbloSim, data quality">
+
+    <title>VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data | Pebblous</title>
+    <meta name="description" content="What 10% codebook utilization really means: your AI has never seen 90% of the world. A deep dive into VQ-Tokenizer mechanics, why lucidrains gets 1.6M monthly downloads, and how DataClinic and PebbloSim connect.">
+
+    <link rel="canonical" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/">
+    <link rel="alternate" hreflang="en" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/">
+    <link rel="alternate" hreflang="ko" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/">
+
+    <!-- OG -->
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data">
+    <meta property="og:description" content="What 10% codebook utilization really means: your AI has never seen 90% of the world. VQ-Tokenizer mechanics, lucidrains, DataClinic and PebbloSim — deep dive.">
+    <meta property="og:url" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/">
+    <meta property="og:image" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/image/og-en.png">
+    <meta property="og:locale" content="en_US">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data">
+    <meta name="twitter:description" content="What 10% codebook utilization means: your AI has never seen 90% of the world. A deep dive into VQ-Tokenizer.">
+    <meta name="twitter:image" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/image/og-en.png">
+    <meta name="twitter:image:alt" content="VQ-Tokenizer codebook utilization and data quality infographic">
+    <meta name="twitter:site" content="@pebblous_ai">
+    <meta name="twitter:creator" content="@pebblous_ai">
+
+    <!-- GTM -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-57L9F58B');</script>
+
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+    <!-- Stylesheets (fixed order) -->
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260422">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260422">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260422">
+
+    <!-- KaTeX (formulas) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"
+            onload="renderMathInElement(document.body, {
+                delimiters: [
+                    {left: '$$', right: '$$', display: true},
+                    {left: '$', right: '$', display: false}
+                ]
+            });"></script>
+
+    <style>
+        /* Article-specific supplementary styles */
+        .data-table th {
+            color: var(--text-muted);
+            font-weight: 600;
+            border-bottom: 2px solid var(--accent-color);
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+        .data-table td {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-primary);
+        }
+        .data-table tr:hover td {
+            background-color: var(--bg-secondary);
+        }
+        .data-table thead tr {
+            background-color: var(--bg-card);
+        }
+        .code-block {
+            background-color: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 1.25rem 1.5rem;
+            overflow-x: auto;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.85rem;
+            line-height: 1.8;
+            margin-bottom: 1.5rem;
+        }
+        .code-block code {
+            color: var(--text-primary);
+        }
+        .code-comment { color: var(--text-muted); }
+        .formula-label {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            text-align: center;
+            margin-top: -0.5rem;
+            margin-bottom: 1rem;
+        }
+        .stat-highlight {
+            font-size: 2rem;
+            font-weight: 800;
+            color: var(--accent-color);
+            display: block;
+            line-height: 1.2;
+        }
+        .stat-card {
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 1.25rem;
+            text-align: center;
+        }
+        .refs-list li {
+            border-bottom: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .refs-list li:last-child { border-bottom: none; }
+        .timeline-item {
+            display: flex;
+            gap: 1rem;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid var(--border-color);
+            align-items: flex-start;
+        }
+        .timeline-year {
+            font-weight: 700;
+            color: var(--accent-color);
+            min-width: 3.5rem;
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body class="antialiased themeable-bg">
+    <!-- GTM noscript -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57L9F58B" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="header-placeholder"></div>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">
+        <div class="lg:flex lg:gap-8 lg:justify-center lg:items-start">
+
+            <!-- TOC -->
+            <nav class="hidden lg:block lg:w-[240px] lg:shrink-0 sticky top-20 self-start">
+                <h3 class="font-bold themeable-heading mb-4 text-lg">Contents</h3>
+                <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
+                    <li><a href="#executive-summary" class="block pl-4 themeable-toc-link transition-colors duration-200">Executive Summary</a></li>
+                    <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. Why Discretization</a></li>
+                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. VQ-VAE & STE</a></li>
+                    <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. Codebook Collapse</a></li>
+                    <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. Industry Map</a></li>
+                    <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. The lucidrains Factor</a></li>
+                    <li><a href="#section-6" class="block pl-4 themeable-toc-link transition-colors duration-200">6. Codebook Quality = Data Quality</a></li>
+                    <li><a href="#section-7" class="block pl-4 themeable-toc-link transition-colors duration-200">7. Pebblous Perspective</a></li>
+                    <li><a href="#section-8" class="block pl-4 themeable-toc-link transition-colors duration-200">8. DiVeQ Preview</a></li>
+                    <li><a href="#faq" class="block pl-4 themeable-toc-link transition-colors duration-200">FAQ</a></li>
+                    <li><a href="#references" class="block pl-4 themeable-toc-link transition-colors duration-200">References</a></li>
+                </ul>
+            </nav>
+
+            <!-- Main Content -->
+            <main class="max-w-[800px] px-4 sm:px-6">
+
+                <!-- Hero -->
+                <header class="text-left mb-12">
+                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
+                </header>
+
+                <!-- Executive Summary -->
+                <section id="executive-summary" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>If codebook utilization is 10%, your AI has never seen 90% of the world.</strong> A VQ-Tokenizer (vector quantization tokenizer) maps continuous embeddings to K discrete codewords. Under naive training with K=1,024 codewords, only 10–30% are ever activated. The remaining 70–90% sit idle as dead code — meaning the model begins inference without having learned those patterns at all.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            In VQGAN experiments, 66% of 8,912 codewords went entirely unused. APCodec recorded 14.7%–41.2% utilization before fixing the issue. By contrast, Google MAGVIT-2 uses LFQ (Lookup-Free Quantization) with K=2<sup>18</sup>=262,144 vocabulary at near 100% utilization, achieving FID 1.78 — surpassing diffusion models (2.12). Phil Wang's (lucidrains) <strong>vector-quantize-pytorch</strong> packages all major VQ variants in a single library with 1.6M monthly downloads.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            The "Data Void" that DataClinic's L3 diagnosis surfaces is the same phenomenon as VQ codebook dead code — just observed from a different angle. PebbloSim's Vector-to-Param technology (US 12,481,720) closes the loop by reverse-mapping those empty codeword coordinates into simulation parameters, turning diagnosis into prescription. This report covers VQ-Tokenizer mechanics, codebook collapse, the industry landscape, and Pebblous product connections — plus a preview of DiVeQ, to be presented at ICLR 2026 on April 27.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 1 -->
+                <section id="section-1" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">1</span>The Sensory Organ — Why AI Needs Discretization</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        In 1992, JPEG divided images into 8×8 pixel blocks and compressed each block into discrete cosine transform (DCT) coefficients. Instead of storing infinite pixel combinations, it stored only the most frequent frequency patterns. VQ-Tokenizers inherit this logic for the deep learning era: rather than continuous high-dimensional embeddings, they store K meaningful patterns — learned from data — as codewords.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">The Problem with Continuous Embeddings</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        The embedding vectors produced by ResNets or ViTs live in a continuous real-valued space — theoretically infinite. Three problems follow. First, generalization is hard across an unbounded representation space: two visually similar images can land in completely different positions. Second, autoregressive models like GPT are designed to predict "the next token," and continuous vectors are not suitable prediction targets. Third, storage and transmission costs are high — a real-valued vector requires far more bits than an integer index.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Three Advantages of Discretization</h3>
+                    <ul class="space-y-3 mb-6">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>A learned vocabulary:</strong> K codewords form a dictionary of the most frequent meaningful patterns in training data — the same way humans categorize the world into "dog," "cat," and so on.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>Autoregressive compatibility:</strong> Codeword indices can be treated exactly like text tokens. This is how Chameleon and LlamaGen process images and text through a single Transformer.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>Compression efficiency:</strong> A single integer index replaces a 512-dimensional float vector. DAC (Descript Audio Codec) uses this to compress 44.1 kHz audio by 90×.</span>
+                        </li>
+                    </ul>
+
+                    <p class="themeable-text leading-relaxed mb-4">The mathematical core of this discretization is a single operation — replacing the encoder output $z$ with the nearest codeword $e_k$ in the codebook:</p>
+
+                    <div class="my-6 text-center">
+                        $$z_q = \arg\min_k \|z - e_k\|_2$$
+                    </div>
+                    <p class="formula-label">Eq. 1. VQ codebook lookup: replacing continuous embedding z with the nearest codeword</p>
+
+                    <p class="themeable-text leading-relaxed">
+                        This simple formula became the common language across images (VQGAN), audio (EnCodec, DAC), video (MAGVIT-2), and multimodal models (Chameleon). The VQ-Tokenizer is AI's sensory organ.
+                    </p>
+                </section>
+
+                <!-- Section 2 -->
+                <section id="section-2" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">2</span>VQ-VAE Dissected — Architecture and the STE</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        VQ-VAE (van den Oord et al., NeurIPS 2017) is the prototype of the modern VQ-Tokenizer. The structure looks simple, but it carries a fatal obstacle: the argmin operation is not differentiable. The Straight-Through Estimator (STE) is the clever workaround.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Three-Stage Architecture</h3>
+                    <ul class="space-y-3 mb-6">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">①</span>
+                            <span class="themeable-text leading-relaxed"><strong>Encoder $z_e(x)$:</strong> Converts input (image, audio, text) into a continuous embedding vector. Any architecture — CNN, Transformer — works here.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">②</span>
+                            <span class="themeable-text leading-relaxed"><strong>Codebook lookup (non-differentiable!):</strong> $z_q = \arg\min_k \|z_e - e_k\|_2$. Selects the nearest codeword. The argmin is a step function — its gradient is 0 during backpropagation, which means the encoder cannot learn. This is the fatal problem.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">③</span>
+                            <span class="themeable-text leading-relaxed"><strong>Decoder $D(z_q)$:</strong> Reconstructs the original input from the discrete codeword $z_q$. Reconstruction quality is the training objective.</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Straight-Through Estimator (STE): A Trick That Works</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        The STE idea is simple: use $z_q$ (the discrete codeword) in the forward pass, but during backpropagation pass the gradient of $z_q$ straight through to $z_e$ as if the quantization never happened. Van den Oord openly described this in the paper as "a trick, but it works."
+                    </p>
+
+                    <div class="code-block">
+                        <code><span class="code-comment"># Straight-Through Estimator (PyTorch)</span>
+z_q = z_e + (z_q - z_e).detach()
+<span class="code-comment"># Forward: uses z_q value / Backward: gradient flows through z_e (detach blocks z_q → z_e path)</span></code>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Three-Term Loss Function</h3>
+                    <p class="themeable-text leading-relaxed mb-4">VQ-VAE minimizes the sum of three losses:</p>
+
+                    <div class="my-6 text-center">
+                        $$L = \underbrace{\|x - D(z_q)\|^2}_{\text{reconstruction loss}} + \underbrace{\|\text{sg}[z_e(x)] - e\|^2}_{\text{codebook loss}} + \underbrace{\beta \|z_e(x) - \text{sg}[e]\|^2}_{\text{commitment loss}\ (\beta=0.25)}$$
+                    </div>
+                    <p class="formula-label">Eq. 2. VQ-VAE loss function. sg[·] is the stop-gradient operator</p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        The <strong>commitment loss</strong> ($\beta=0.25$) prevents the encoder output from drifting too far from the codewords. In practice, using EMA (exponential moving average) updates — moving codeword positions like k-means — is more stable than the codebook loss term. Most modern implementations (EnCodec, DAC) adopt EMA.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Getting Started with lucidrains in 3 Lines</h3>
+                    <div class="code-block">
+                        <code><span class="code-comment"># pip install vector-quantize-pytorch</span>
+from vector_quantize_pytorch import VectorQuantize
+
+vq = VectorQuantize(dim=512, codebook_size=1024, decay=0.8)
+quantized, indices, commit_loss = vq(x)  <span class="code-comment"># x: (batch, seq, dim)</span></code>
+                    </div>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        VQ-VAE-2 (Razavi et al., NeurIPS 2019) extended this with a hierarchical codebook. A Top codebook (32×32) captures global structure while a Bottom codebook (64×64) handles local detail — enabling 256×256 high-resolution image generation. This hierarchical approach became the standard for most VQ-based image generation models.
+                    </p>
+                </section>
+
+                <!-- Section 3 -->
+                <section id="section-3" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">3</span>Codebook Collapse — The 90% AI Has Never Seen</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Under naive VQ-VAE training, only 10–30% of K=1,024 codewords are actually used. The rest become "dead code." <strong>A real production case from APCodec</strong>: codebook utilization of 14.7%–41.2% before the fix. <strong>VQGAN experiments</strong>: 66% of 8,912 codewords went entirely unused (arXiv:2602.18896).
+                    </p>
+
+                    <!-- Stats row -->
+                    <div class="grid grid-cols-3 gap-4 mb-8">
+                        <div class="stat-card">
+                            <span class="stat-highlight">10–30%</span>
+                            <p class="themeable-muted text-xs mt-1">Naive VQ-VAE<br>avg. utilization</p>
+                        </div>
+                        <div class="stat-card">
+                            <span class="stat-highlight">66%</span>
+                            <p class="themeable-muted text-xs mt-1">VQGAN experiment<br>unused codewords</p>
+                        </div>
+                        <div class="stat-card">
+                            <span class="stat-highlight">100%</span>
+                            <p class="themeable-muted text-xs mt-1">SF-DiVeQ<br>target utilization</p>
+                        </div>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">The Collapse Mechanism: Matthew Effect</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Codebook collapse operates as a Matthew Effect — "to him who has, more will be given." Codewords that happen to be selected more at initialization receive more training signal, move to better positions, and get selected even more. Codewords that aren't selected drift further away and become dead code. It is a positive feedback loop.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Metrics for Codebook Health</h3>
+                    <p class="themeable-text leading-relaxed mb-4">Two metrics capture codebook health:</p>
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>Codebook utilization (%):</strong> $|\{k : n_k > 0\}| / K$. The fraction of codewords used at least once. Below 50% is alarming.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>Codebook perplexity:</strong> $\exp(-\sum_k p_k \log p_k)$. Maximum is K (perfect uniform distribution). Perplexity/K &lt; 0.3 indicates severe collapse.</span>
+                        </li>
+                    </ul>
+
+                    <div class="my-6 text-center">
+                        $$\text{Perplexity} = \exp\!\left(-\sum_{k=1}^{K} p_k \log p_k\right)$$
+                    </div>
+                    <p class="formula-label">Eq. 3. Codebook perplexity. $p_k$ is the usage frequency of codeword $k$</p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">A History of Attempted Fixes</h3>
+                    <div class="mb-6">
+                        <div class="timeline-item">
+                            <span class="timeline-year">2017</span>
+                            <span class="themeable-text text-sm"><strong>EMA updates</strong> — Move codewords via exponential moving average (k-means style). Delays collapse but doesn't solve the root cause</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2019–</span>
+                            <span class="themeable-text text-sm"><strong>Random Restart</strong> — Reinitialize dead codes randomly. Adopted by OpenAI Jukebox, SoundStream, EnCodec. Effective but requires hyperparameter tuning</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2023</span>
+                            <span class="themeable-text text-sm"><strong>FSQ (Finite Scalar Quantization)</strong> — Eliminates the codebook table entirely. Rounds each dimension to fixed discrete values. Guarantees 100% utilization. FID difference vs VQ: ~0.5% (4.534 vs 4.509)</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2025</span>
+                            <span class="themeable-text text-sm"><strong>DiVeQ / SF-DiVeQ (ICLR 2026)</strong> — Direction-vector reparameterization for true gradient estimation. SF-DiVeQ achieves 100% codebook utilization (full treatment in Part 2)</span>
+                        </div>
+                    </div>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            Codebook collapse is not simply a technical bug. <strong>It is a signal that your training data has only shown the model a slice of the world.</strong> Low perplexity is exactly what DataClinic calls a "Data Void" — just measured at the model layer rather than the dataset layer. Codebook diagnosis is data diversity diagnosis by another name.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 4 -->
+                <section id="section-4" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">4</span>Industry Map — Language, Audio, Vision, Physics</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        VQ-Tokenizers are not a niche technique in a single domain. Since the 2017 VQ-VAE paper, they have permeated image, audio, video, and multimodal AI. The table below maps how leading industry models apply VQ.
+                    </p>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>Domain</th>
+                                    <th>Model</th>
+                                    <th>Codebook Size</th>
+                                    <th>Utilization</th>
+                                    <th>Key Feature</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><strong>Image</strong></td>
+                                    <td>VQGAN (2021)</td>
+                                    <td>1K–16K</td>
+                                    <td>~34%</td>
+                                    <td>GAN loss added; basis for Stable Diffusion</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Image</strong></td>
+                                    <td>LlamaGen (2024)</td>
+                                    <td>16,384</td>
+                                    <td><strong>97%</strong></td>
+                                    <td>LLM paradigm, FID 2.18</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Video</strong></td>
+                                    <td>MAGVIT-2 (2023)</td>
+                                    <td>2<sup>18</sup>=262,144 (LFQ)</td>
+                                    <td>~100%</td>
+                                    <td>Beats diffusion models, FID 1.78</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Audio</strong></td>
+                                    <td>EnCodec (2022)</td>
+                                    <td>1,024 × 8 (RVQ)</td>
+                                    <td>Moderate</td>
+                                    <td>24 kHz, as low as 1.5 kbps</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Audio</strong></td>
+                                    <td>DAC (2023)</td>
+                                    <td>1,024 × 9 (RVQ)</td>
+                                    <td>Improved</td>
+                                    <td>44.1 kHz, 8 kbps, <strong>90× compression</strong></td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Multimodal</strong></td>
+                                    <td>Chameleon (2024)</td>
+                                    <td>VQ-VAE based</td>
+                                    <td>—</td>
+                                    <td>Image + text in a single Transformer</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Domain-by-Domain Insights</h3>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>Vision:</strong> VQGAN added a GAN loss to improve the visual quality of codewords and served as the latent-space compressor for Stable Diffusion. MAGVIT-2 introduces LFQ, which binarizes each dimension via $\text{sign}(z_i)$ without a learnable codebook table — achieving near-perfect utilization of 262,144 codewords.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>Audio:</strong> EnCodec and DAC use RVQ (Residual VQ) rather than a single codebook. The first VQ quantizes the input; the second VQ quantizes the residual; and so on. DAC's nine-codebook stack delivers studio-quality 44.1 kHz audio at 8 kbps — 90× compression.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>Multimodal:</strong> Chameleon (Meta, 2024) treats image VQ tokens and BPE text tokens as the same sequence. Image patches become codeword indices; text becomes BPE token indices. A single Transformer predicts the next token across this mixed sequence.
+                    </p>
+                    <p class="themeable-text leading-relaxed">
+                        <strong>Autonomous driving / physics:</strong> LiDAR point clouds and robot action sequences are also VQ candidates. Converting 3D spatial patterns to discrete codewords lets autoregressive models predict "the next LiDAR pattern" or "the next action." PebbloSim's LiDAR synthesis module applies this principle.
+                    </p>
+                </section>
+
+                <!-- Section 5 -->
+                <section id="section-5" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">5</span>The lucidrains Factor — Why One Person's Code Gets 1.6M Downloads</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        <strong>1,603,301 monthly downloads. One maintainer.</strong> Phil Wang's (GitHub: lucidrains) <code>vector-quantize-pytorch</code> has become core infrastructure for the AI research ecosystem. vllm (77,267 GitHub Stars, the leading AI inference framework) depends on it. 1,145 GitHub repositories and 58 PyPI packages are built on this single library.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Who Is Phil Wang?</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        He built ThisPersonDoesNotExist.com (the StyleGAN-powered synthetic face generator). He is backed by Stability.ai, a16z, and Hugging Face. With 59,100 GitHub followers and 386 repositories — most of them paper implementations — his philosophy is: "make papers readable as code." Comprehensibility comes before abstraction or optimization.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">A Simple API That Built an Ecosystem</h3>
+                    <div class="code-block">
+                        <code><span class="code-comment"># Standard VQ (with EMA updates)</span>
+from vector_quantize_pytorch import VectorQuantize, ResidualVQ, LFQ, FSQ
+
+vq  = VectorQuantize(dim=512, codebook_size=1024, decay=0.8)
+rvq = ResidualVQ(dim=512, num_quantizers=8, codebook_size=1024)
+lfq = LFQ(codebook_size=2**18)        <span class="code-comment"># MAGVIT-2 style</span>
+fsq = FSQ(levels=[8, 6, 5, 5, 5])    <span class="code-comment"># guaranteed 100% utilization</span></code>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Full List of Supported Variants</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        As of v1.28.2 (April 17, 2026): VectorQuantize (EMA), ResidualVQ, GroupedResidualVQ, RandomProjectionQuantizer, SimVQ/ResidualSimVQ, FSQ/ResidualFSQ, LFQ (MAGVIT-2), LatentQuantize, and <strong>directional_reparam (DiVeQ)</strong>. Since its founding in 2020, the library has maintained an average of 0.5 releases per week.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Ecosystem Impact and the Single-Maintainer Risk</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        Major AI implementations — audiolm-pytorch, soundstorm-pytorch, voicebox-pytorch, magvit2-pytorch — use this library as a core dependency. Research papers use it as their baseline, providing a form of reverse validation. That said, bus factor = 1 is a structural risk to acknowledge before production adoption. The MIT license permits unlimited commercial use.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            Comparing competitors makes the lucidrains advantage clear. taming-transformers (6,300★) has no pip package. encodec (3,800★) is audio-only. descript-audio-codec (1,600★) is also audio-only. <strong>vector-quantize-pytorch is the only library offering multimodal VQ variants as a single pip package.</strong>
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 6 -->
+                <section id="section-6" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">6</span>Codebook Quality = Data Quality — A Mirror Relationship</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        A codebook is a compressed representation of the training data distribution. Codeword positions directly reflect which patterns appear — and how often — in training data. Codebook perplexity is therefore the most honest mirror of training data diversity.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Why Codebooks Reflect Data</h3>
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">Codewords settle into position via k-means by watching training data. When data is skewed toward certain patterns, codewords cluster in that region too.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">Low perplexity → codebook represents only a subset of patterns → the data is biased or redundant. It is numerical proof that "AI has only seen 10% of the world."</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">Dead code means certain patterns are simply absent from training data. When VQGAN-LC experimented with K=100,000, it achieved 99% utilization with meaningful improvements in generation diversity (IS, FID) — proving the causal link.</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">The Mirror: DataClinic Concepts vs. VQ Concepts</h3>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>DataClinic Concept</th>
+                                    <th>VQ Concept</th>
+                                    <th>Meaning</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Over-dense cluster</td>
+                                    <td>High-usage codewords</td>
+                                    <td>Data bias / redundancy</td>
+                                </tr>
+                                <tr>
+                                    <td>Low-density gap (Data Void)</td>
+                                    <td>Dead codes</td>
+                                    <td>Patterns missing from training data</td>
+                                </tr>
+                                <tr>
+                                    <td>Spread of density distribution</td>
+                                    <td>High perplexity</td>
+                                    <td>Data diversity ↑</td>
+                                </tr>
+                                <tr>
+                                    <td>Feature-space coverage</td>
+                                    <td>Codebook utilization %</td>
+                                    <td>Representational breadth</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        DataClinic L2 (Wolfram Net V2, 1,280-dim) is structurally identical to VQ encoder output — both are continuous embeddings. L2's density distribution visualization is a continuous approximation of the codeword distribution. DataClinic L3 (domain-specific, 41–177-dim) is functionally equivalent to a small VQ codebook. For the Birds 525 dataset: 81 dimensions → 81 representative visual patterns.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>Codebook diagnosis = early-warning system for data quality.</strong> Adding codebook perplexity to L3 diagnostics directly reports ISO/IEC 5259-2's diversity quality metric (QM-Div) — surfacing data bias in numeric terms before model training even begins.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 7 -->
+                <section id="section-7" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">7</span>The Pebblous Perspective — Where DataClinic Meets PebbloSim</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        DataClinic diagnoses codebook health. PebbloSim executes the prescription that fills dead codewords. Together, built on the shared foundation of VQ-Tokenizer, they close the diagnosis → prescription loop.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">The DataClinic Angle</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        DataClinic L2's density visualization shows simultaneously which patterns are over-represented and which regions are empty. L3 (41–177-dim, domain-specific) is functionally a small VQ codebook. Birds 525: 81 dimensions → 81 representative visual patterns. Adding codebook perplexity to L3 metrics directly reports ISO 5259-2 Div-ML indicators.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">PebbloSim and the Vector-to-Param Patent</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        PebbloSim's Vector-to-Param (US 12,481,720) is the keystone of this loop. It reverse-maps dead code coordinates (the positions of empty codewords) to simulation parameters such as lighting angle, weather conditions, and camera position. Knowing "which visual patterns are absent" lets you calculate "which simulation conditions would generate those patterns."
+                    </p>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>Product</th>
+                                    <th>VQ Role</th>
+                                    <th>Diagnostic Metric</th>
+                                    <th>Business Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><strong>DataClinic L2</strong></td>
+                                    <td>Embedding-space distribution diagnosis</td>
+                                    <td>Density distribution, cluster coverage</td>
+                                    <td>Detect biased / duplicate data</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>DataClinic L3</strong></td>
+                                    <td>Domain codebook perplexity diagnosis</td>
+                                    <td>Perplexity, utilization %</td>
+                                    <td>Quantify ISO 5259 QM-Div</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim Camera</strong></td>
+                                    <td>Guarantee pixel → token diversity</td>
+                                    <td>Codebook utilization before/after</td>
+                                    <td>Synthetic data realism & diversity ↑</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim LiDAR</strong></td>
+                                    <td>Point cloud pattern compression (RVQ)</td>
+                                    <td>Reconstruction error (Sim-to-Real)</td>
+                                    <td>Prove 3D scenario coverage</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim Audio</strong></td>
+                                    <td>Domain audio discretization (RVQ codec)</td>
+                                    <td>Acoustic codebook perplexity</td>
+                                    <td>Quantify defect-sound detection range</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>AI-Ready Data</strong></td>
+                                    <td>VQ-based data coverage certification</td>
+                                    <td>Perplexity + ISO QM report</td>
+                                    <td>Regulatory compliance, client trust</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Data Greenhouse</strong></td>
+                                    <td>Diagnose → prescribe → generate loop metric</td>
+                                    <td>Before/after perplexity comparison</td>
+                                    <td>Quantify Data Flywheel ROI</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>The Data Flywheel loop:</strong> Diagnose (measure L3 perplexity) → Prescribe (targeted PebbloSim synthesis) → Re-diagnose (verify perplexity improvement). If codebook utilization improves from 30% to 85%, the AI's visible pattern space has expanded 2.8×. That is automatic codebook-coverage maximization made measurable.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 8 -->
+                <section id="section-8" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">8</span>DiVeQ Preview — The Next Step in Differentiable VQ</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        The root cause of codebook collapse is argmin's non-differentiability. EMA, Random Restart, and FSQ all either work around or avoid this root cause. DiVeQ (arXiv:2509.26469, ICLR 2026) attacks the problem at the design level.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">The Price of the STE Trick</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        During backpropagation, STE passes the gradient of $z_q$ straight through to $z_e$. This is mathematically incorrect — the true gradient of argmin is 0, but STE approximates it as 1. This inaccurate approximation is the seed of early codebook collapse.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">DiVeQ's Key Idea: Direction-Vector Reparameterization</h3>
+                    <p class="themeable-text leading-relaxed mb-4">DiVeQ separates the error vector into a <strong>direction</strong> and a <strong>magnitude</strong> to create a differentiable path:</p>
+
+                    <div class="my-6 text-center">
+                        $$z_q = z + \|c_{i^*} - z\|_2 \cdot \text{sg}\!\left[\frac{v_d}{\|v_d\|_2}\right]$$
+                    </div>
+                    <p class="formula-label">Eq. 4. DiVeQ reparameterization. $v_d = v + (c_{i^*} - z)$, $v \sim \mathcal{N}(0, \sigma^2 I)$</p>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        The <strong>magnitude</strong> ($\|c_{i^*} - z\|_2$) is differentiable. The <strong>direction</strong> ($v_d / \|v_d\|_2$) is stop-gradiented, but stochastic noise $v$ is added to smooth the direction's discontinuity. SF-DiVeQ (Segment-Free DiVeQ) goes further: it assigns values along the line segment connecting adjacent codewords, achieving 100% codebook utilization.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>April 27, 2026 — ICLR 2026.</strong> Eight days from when you read this, DiVeQ's full experimental results and code will be released. Part 2 of this series covers the complete DiVeQ derivation and adoption scenarios for DataClinic and PebbloSim.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- FAQ -->
+                <section id="faq" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">Frequently Asked Questions</h2>
+
+                    <div class="space-y-6">
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">What is the difference between a VQ-Tokenizer and a regular embedding?</h3>
+                            <p class="themeable-text leading-relaxed">A regular (continuous) embedding lives in an infinite real-valued vector space. VQ uses a finite vocabulary of K discrete codewords. Continuous embeddings are expressive but difficult to use with autoregressive models and storage-inefficient. VQ is compression-efficient, directly compatible with GPT-class language models, and makes the training data distribution explicit through the codebook.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">How do you choose codebook size K?</h3>
+                            <p class="themeable-text leading-relaxed">It depends on data complexity and diversity. CIFAR-10 → K=512; ImageNet → K=1K–16K; video (MAGVIT-2) → K=262,144 (LFQ). Rule of thumb: K too small = insufficient expressiveness; K too large = higher collapse risk. FSQ implicitly determines K as the product of per-dimension levels (e.g., [8,6,5,5,5] → K=8×6×5×5×5=6,000) without a learnable table.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">What is the difference between FSQ and VQ?</h3>
+                            <p class="themeable-text leading-relaxed">VQ maintains a learnable table of K embedding vectors and is prone to codebook collapse. FSQ has no codebook table — it rounds each dimension to fixed discrete values, guaranteeing 100% utilization. On ImageNet 256 MaskGIT, the performance gap is FID 4.534 vs. 4.509 — about 0.5%, which is negligible in practice.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">Can I use the lucidrains library in production today?</h3>
+                            <p class="themeable-text leading-relaxed">Yes — <code>pip install vector-quantize-pytorch</code> and you're running in 3 lines. The MIT license permits unlimited commercial use. Be aware of the bus factor = 1 (single maintainer) risk. For production environments, pin to a specific version and maintain a fork as a fallback strategy.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">How do you detect codebook collapse?</h3>
+                            <p class="themeable-text leading-relaxed">Codebook utilization below 50% is a warning; below 30% is severe. Perplexity/K below 0.3 indicates serious collapse. The lucidrains library's <code>threshold_ema_dead_code</code> parameter enables real-time monitoring during training. Log utilization and perplexity to W&B or TensorBoard.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">How does DataClinic use VQ-Tokenizer internally?</h3>
+                            <p class="themeable-text leading-relaxed">DataClinic L2 (Wolfram Net V2, 1,280-dim) uses continuous embeddings structurally identical to VQ encoder output. L3 (domain-specific, 41–177-dim) is functionally equivalent to a small VQ codebook. The roadmap: add codebook perplexity to L3 as an ISO 5259 QM metric, automating data diversity certification.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">Does DiVeQ completely replace STE?</h3>
+                            <p class="themeable-text leading-relaxed">It provides mathematically more accurate gradients. STE approximates the argmin gradient of 0 as 1 — it's a hack. DiVeQ estimates the true gradient via direction-vector reparameterization. It is designed as a drop-in replacement for existing VQ layers with minimal code changes. Since ICLR 2026, it is already available as the <code>directional_reparam</code> option in vector-quantize-pytorch.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">How does PebbloSim use VQ-Tokenizer?</h3>
+                            <p class="themeable-text leading-relaxed">Pre-synthesis: DataClinic measures current codebook perplexity to identify missing visual or acoustic patterns. Vector-to-Param (US 12,481,720): reverse-maps empty codeword coordinates into simulation parameters like lighting, angle, and weather. Post-synthesis: codebook utilization before/after comparison quantifies ROI. Improvement from 30% to 85% means the AI's visible pattern space has expanded 2.8×.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- References -->
+                <section id="references" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">References</h2>
+                    <ol class="refs-list space-y-1 pl-4" style="list-style: decimal;">
+                        <li>van den Oord et al. (2017). <em>Neural Discrete Representation Learning (VQ-VAE)</em>. NeurIPS 2017. arXiv:1711.00937</li>
+                        <li>Razavi et al. (2019). <em>Generating Diverse High-Fidelity Images with VQ-VAE-2</em>. NeurIPS 2019. arXiv:1906.00446</li>
+                        <li>Esser et al. (2021). <em>Taming Transformers for High-Resolution Image Synthesis (VQGAN)</em>. CVPR 2021. arXiv:2012.09841</li>
+                        <li>Défossez et al. (2022). <em>High Fidelity Neural Audio Compression (EnCodec)</em>. ICLR 2023. arXiv:2210.13438</li>
+                        <li>Kumar et al. (2023). <em>High-Fidelity Audio Compression with Improved RVQGAN (DAC)</em>. NeurIPS 2023. arXiv:2306.06546</li>
+                        <li>Mentzer et al. (2023). <em>Finite Scalar Quantization: VQ-VAE Made Simple (FSQ)</em>. ICLR 2024. arXiv:2309.15505</li>
+                        <li>Yu et al. (2023). <em>Language Model Beats Diffusion — Tokenizer is Key to Visual Generation (MAGVIT-2)</em>. ICLR 2024. arXiv:2310.05737</li>
+                        <li>Vali et al. (2025). <em>DiVeQ: Differentiable Vector Quantization</em>. ICLR 2026 (to be presented April 27). arXiv:2509.26469</li>
+                        <li>Sun et al. (2024). <em>Autoregressive Model Beats Diffusion: Llama for Scalable Image Generation (LlamaGen)</em>. arXiv:2406.06525</li>
+                        <li>Meta AI (2024). <em>Chameleon: Mixed-Modal Early-Fusion Foundation Models</em>. arXiv:2405.09818</li>
+                        <li>Zhu et al. (2024). <em>VQGAN-LC: Scaling Codebooks with Large Cluster Initialization</em>. NeurIPS 2024. arXiv:2406.11837</li>
+                        <li>Zhang et al. (2024). <em>ERVQ: Ensemble Residual Vector Quantization for Neural Audio Codecs (APCodec)</em>. arXiv:2410.12359</li>
+                        <li>Balle et al. (2026). <em>Beyond Stationarity: Spectral Analysis of Codebook Collapse</em>. arXiv:2602.18896</li>
+                        <li>Zhu et al. (2026). <em>Early Quantization Shrinks Codebook</em>. arXiv:2603.17052</li>
+                        <li>ISO/IEC 5259-1:2024, ISO/IEC 5259-2:2024. <em>Artificial intelligence — Data quality for analytics and ML</em>. International Organization for Standardization.</li>
+                        <li>Wang, Phil (lucidrains). <em>vector-quantize-pytorch v1.28.2</em>. GitHub. MIT License. github.com/lucidrains/vector-quantize-pytorch</li>
+                        <li>Pebblous (2026). <em>US Patent 12,481,720 — Vector-to-Param Simulation Parameterization</em>. USPTO.</li>
+                    </ol>
+                </section>
+
+            </main>
+        </div>
+    </div>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="/scripts/common-utils.js?v=20260422"></script>
+    <script>
+        PebblousPage.init({
+            mainTitle: "VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data",
+            subtitle: "What 10% Codebook Utilization Means — Your AI Has Never Seen 90% of the World",
+            pageTitle: "VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data | Pebblous",
+            category: "tech",
+            publishDate: "2026-04-22",
+            publisher: "Pebblous Data Communication Team",
+            defaultTheme: "light",
+            articlePath: "report/vq-tokenizer-data-quality-synthesis/en/",
+            tags: ["VQ-Tokenizer", "codebook collapse", "data quality", "lucidrains", "vector-quantize-pytorch", "DataClinic", "PebbloSim", "DiVeQ", "ICLR 2026", "ISO 5259", "VQ-VAE", "VQGAN", "EnCodec", "DAC", "MAGVIT-2"],
+            faqs: [
+                {
+                    question: "What is the difference between a VQ-Tokenizer and a regular embedding?",
+                    answer: "A regular embedding lives in an infinite real-valued vector space. VQ uses a finite vocabulary of K discrete codewords. VQ is compression-efficient, directly compatible with GPT-class language models, and makes the training data distribution explicit through the codebook."
+                },
+                {
+                    question: "How do you choose codebook size K?",
+                    answer: "It depends on data complexity and diversity. CIFAR-10 → K=512; ImageNet → K=1K–16K; video (MAGVIT-2) → K=262,144. FSQ implicitly determines K as the product of per-dimension levels (e.g., [8,6,5,5,5] → K=6,000) without a learnable table."
+                },
+                {
+                    question: "What is the difference between FSQ and VQ?",
+                    answer: "VQ maintains a learnable codebook table and is prone to collapse. FSQ has no table — it rounds each dimension to fixed discrete values, guaranteeing 100% utilization. The performance gap on ImageNet 256 MaskGIT is FID 4.534 vs. 4.509 — negligible in practice."
+                },
+                {
+                    question: "Can I use the lucidrains library in production today?",
+                    answer: "Yes — pip install vector-quantize-pytorch and running in 3 lines. MIT license permits unlimited commercial use. Be aware of bus factor = 1 (single maintainer). Pin to a specific version and maintain a fork for production environments."
+                },
+                {
+                    question: "How do you detect codebook collapse?",
+                    answer: "Codebook utilization below 50% is a warning; below 30% is severe. Perplexity/K below 0.3 indicates serious collapse. The lucidrains library's threshold_ema_dead_code parameter enables real-time monitoring during training."
+                },
+                {
+                    question: "How does DataClinic use VQ-Tokenizer internally?",
+                    answer: "DataClinic L2 (Wolfram Net V2, 1,280-dim) uses continuous embeddings structurally identical to VQ encoder output. L3 (domain-specific, 41–177-dim) is functionally equivalent to a small VQ codebook. Roadmap: add codebook perplexity as an ISO 5259 QM metric for automated data diversity certification."
+                },
+                {
+                    question: "Does DiVeQ completely replace STE?",
+                    answer: "It provides mathematically more accurate gradients. STE approximates argmin gradient 0 as 1 — a hack. DiVeQ estimates the true gradient via direction-vector reparameterization. Designed as a drop-in replacement, already available as directional_reparam in vector-quantize-pytorch."
+                },
+                {
+                    question: "How does PebbloSim use VQ-Tokenizer?",
+                    answer: "Pre-synthesis: DataClinic measures codebook perplexity to identify missing patterns. Vector-to-Param (US 12,481,720) reverse-maps empty codeword coordinates into simulation parameters. Post-synthesis: before/after utilization comparison quantifies ROI. 30% to 85% improvement means 2.8× more pattern space for the AI."
+                }
+            ]
+        });
+    </script>
+</body>
+</html>

--- a/report/vq-tokenizer-data-quality-synthesis/index.html
+++ b/report/vq-tokenizer-data-quality-synthesis/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=ko/">
+    <link rel="canonical" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+    <title>VQ-Tokenizer: The Technical Backbone of Data Quality and Synthetic Data</title>
+    <script>
+        (function() {
+            var lang = navigator.language || navigator.userLanguage || 'en';
+            if (lang.toLowerCase().startsWith('ko')) {
+                window.location.replace('ko/');
+            } else {
+                window.location.replace('en/');
+            }
+        })();
+    </script>
+</head>
+<body>
+    <p>Redirecting... <a href="ko/">한국어</a> | <a href="en/">English</a></p>
+</body>
+</html>

--- a/report/vq-tokenizer-data-quality-synthesis/ko/index.html
+++ b/report/vq-tokenizer-data-quality-synthesis/ko/index.html
@@ -1,0 +1,804 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- SEO 기본 -->
+    <meta name="author" content="Pebblous Data Communication Team">
+    <meta name="language" content="Korean">
+    <meta http-equiv="content-language" content="ko">
+    <meta name="copyright" content="© 2026 Pebblous. All rights reserved.">
+    <meta name="robots" content="index, follow">
+    <meta name="keywords" content="VQ 토크나이저, 코드북 붕괴, vector quantization, lucidrains, vector-quantize-pytorch, 코드북 활용률, VQ-VAE, VQGAN, EnCodec, DAC, MAGVIT-2, FSQ, DiVeQ, DataClinic, PebbloSim, 데이터 품질">
+
+    <title>VQ-Tokenizer: 데이터 품질과 합성 데이터의 기술적 척추 | 페블러스</title>
+    <meta name="description" content="코드북 활용률 10%가 의미하는 것: AI가 세상의 90%를 본 적 없다는 경고. VQ-Tokenizer의 기술 원리부터 lucidrains 월 160만 다운로드 비결, DataClinic·PebbloSim 적용까지 심층 해설.">
+
+    <link rel="canonical" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+    <link rel="alternate" hreflang="ko" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+    <link rel="alternate" hreflang="en" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/">
+    <link rel="alternate" hreflang="x-default" href="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+
+    <!-- OG -->
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="VQ-Tokenizer: 데이터 품질과 합성 데이터의 기술적 척추">
+    <meta property="og:description" content="코드북 활용률 10%가 의미하는 것: AI가 세상의 90%를 본 적 없다는 경고. VQ-Tokenizer의 기술 원리부터 lucidrains 월 160만 다운로드 비결, DataClinic·PebbloSim 적용까지 심층 해설.">
+    <meta property="og:url" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/">
+    <meta property="og:image" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/image/og-ko.png">
+    <meta property="og:locale" content="ko_KR">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="VQ-Tokenizer: 데이터 품질과 합성 데이터의 기술적 척추">
+    <meta name="twitter:description" content="코드북 활용률 10%가 의미하는 것: AI가 세상의 90%를 본 적 없다는 경고. VQ 토크나이저 심층 해설.">
+    <meta name="twitter:image" content="https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/image/og-ko.png">
+    <meta name="twitter:image:alt" content="VQ-Tokenizer 코드북 활용률과 데이터 품질 인포그래픽">
+    <meta name="twitter:site" content="@pebblous_ai">
+    <meta name="twitter:creator" content="@pebblous_ai">
+
+    <!-- GTM -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-57L9F58B');</script>
+
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+    <!-- Stylesheets (순서 고정) -->
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260422">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260422">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260422">
+
+    <!-- KaTeX (수식 포함) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js"
+            onload="renderMathInElement(document.body, {
+                delimiters: [
+                    {left: '$$', right: '$$', display: true},
+                    {left: '$', right: '$', display: false}
+                ]
+            });"></script>
+
+    <style>
+        /* 아티클 전용 보조 스타일 */
+        .data-table th {
+            color: var(--text-muted);
+            font-weight: 600;
+            border-bottom: 2px solid var(--accent-color);
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+        .data-table td {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-primary);
+        }
+        .data-table tr:hover td {
+            background-color: var(--bg-secondary);
+        }
+        .data-table thead tr {
+            background-color: var(--bg-card);
+        }
+        .code-block {
+            background-color: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 1.25rem 1.5rem;
+            overflow-x: auto;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.85rem;
+            line-height: 1.8;
+            margin-bottom: 1.5rem;
+        }
+        .code-block code {
+            color: var(--text-primary);
+        }
+        .code-comment { color: var(--text-muted); }
+        .formula-label {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            text-align: center;
+            margin-top: -0.5rem;
+            margin-bottom: 1rem;
+        }
+        .stat-highlight {
+            font-size: 2rem;
+            font-weight: 800;
+            color: var(--accent-color);
+            display: block;
+            line-height: 1.2;
+        }
+        .stat-card {
+            background-color: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 1.25rem;
+            text-align: center;
+        }
+        .refs-list li {
+            border-bottom: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .refs-list li:last-child { border-bottom: none; }
+        .timeline-item {
+            display: flex;
+            gap: 1rem;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid var(--border-color);
+            align-items: flex-start;
+        }
+        .timeline-year {
+            font-weight: 700;
+            color: var(--accent-color);
+            min-width: 3.5rem;
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body class="antialiased themeable-bg">
+    <!-- GTM noscript -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57L9F58B" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="header-placeholder"></div>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">
+        <div class="lg:flex lg:gap-8 lg:justify-center lg:items-start">
+
+            <!-- TOC -->
+            <nav class="hidden lg:block lg:w-[240px] lg:shrink-0 sticky top-20 self-start">
+                <h3 class="font-bold themeable-heading mb-4 text-lg">목차</h3>
+                <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
+                    <li><a href="#executive-summary" class="block pl-4 themeable-toc-link transition-colors duration-200">Executive Summary</a></li>
+                    <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. 왜 이산화가 필요한가</a></li>
+                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. VQ-VAE 해부 & STE</a></li>
+                    <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. 코드북 붕괴</a></li>
+                    <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. 산업 적용 지도</a></li>
+                    <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. lucidrains 비결</a></li>
+                    <li><a href="#section-6" class="block pl-4 themeable-toc-link transition-colors duration-200">6. 코드북 품질 = 데이터 품질</a></li>
+                    <li><a href="#section-7" class="block pl-4 themeable-toc-link transition-colors duration-200">7. 페블러스 관점</a></li>
+                    <li><a href="#section-8" class="block pl-4 themeable-toc-link transition-colors duration-200">8. DiVeQ 예고</a></li>
+                    <li><a href="#faq" class="block pl-4 themeable-toc-link transition-colors duration-200">FAQ</a></li>
+                    <li><a href="#references" class="block pl-4 themeable-toc-link transition-colors duration-200">참고 자료</a></li>
+                </ul>
+            </nav>
+
+            <!-- Main Content -->
+            <main class="max-w-[800px] px-4 sm:px-6">
+
+                <!-- Hero -->
+                <header class="text-left mb-12">
+                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
+                </header>
+
+                <!-- Executive Summary -->
+                <section id="executive-summary" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>코드북 활용률이 10%라는 것은, AI가 세상의 90%를 본 적이 없다는 뜻이다.</strong> VQ-Tokenizer(벡터 양자화 토크나이저)는 연속 임베딩을 K개의 이산 코드워드로 변환하는 장치다. 나이브(naive) 학습에서 K=1,024개 코드북 중 실제로 사용되는 코드워드는 10~30%에 불과하다. 나머지 70~90%는 비활성 상태로 남는다. AI는 그 비율만큼 세상의 패턴을 학습하지 못한 채 추론을 시작한다.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            VQGAN 실험에서는 8,912개 코드북 중 66%가 전혀 사용되지 않았다. APCodec은 해결 전 14.7%~41.2% 활용률을 기록했다. 반면 Google MAGVIT-2는 LFQ(Lookup-Free Quantization)로 K=2<sup>18</sup>=262,144 어휘를 거의 100% 활용하며 FID 1.78을 달성했고, 이는 기존 확산 모델(2.12)을 능가했다. lucidrains(Phil Wang)의 <strong>vector-quantize-pytorch</strong>는 이 모든 VQ 변형을 단일 라이브러리에서 제공하며 월 160만 다운로드를 기록한다.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            DataClinic의 L3 진단이 발견하는 "저밀도 갭(Data Void)"은 VQ 코드북의 Dead Code와 정확히 같은 현상의 다른 이름이다. PebbloSim의 Vector-to-Param 기술(US 12,481,720)은 이 빈 코드워드 좌표를 시뮬레이션 파라미터로 역변환해 처방까지 완성한다. 이 보고서는 VQ-Tokenizer의 기술 원리, 코드북 붕괴 메커니즘, 산업 적용 지도, 페블러스 제품과의 접점을 심층 해설한다. 4월 27일 ICLR 2026에서 발표될 DiVeQ의 예고도 포함한다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 1 -->
+                <section id="section-1" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">1</span>토크나이저의 감각기관 — 왜 이산화가 필요한가</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        1992년 JPEG는 픽셀을 8×8 블록으로 나누고, 각 블록을 이산 코사인 변환(DCT) 계수로 압축했다. "무한한 픽셀 조합" 대신 "자주 나오는 주파수 패턴"만 저장한 것이다. VQ-Tokenizer는 이 논리의 현대적 계승이다. 연속적인 고차원 임베딩 대신, 학습으로 찾아낸 K개의 의미 있는 패턴만 코드워드로 저장한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">연속 임베딩의 한계</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        ResNet이나 ViT가 출력하는 임베딩 벡터는 실수(real number)로 가득한 연속 공간에 존재한다. 이 공간은 이론상 무한하다. 문제는 세 가지다. 첫째, 무한한 표현 공간에서 일반화(generalization)는 어렵다 — 비슷해 보이는 두 이미지가 임베딩 공간에서 전혀 다른 위치에 있을 수 있다. 둘째, GPT 같은 자동회귀(autoregressive) 모델은 "다음 토큰 예측"을 하도록 설계됐는데, 연속 벡터는 예측 대상으로 적합하지 않다. 셋째, 저장 및 전송 효율이 낮다 — 실수 벡터는 정수 인덱스보다 훨씬 많은 비트를 요구한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">이산화의 세 가지 장점</h3>
+                    <ul class="space-y-3 mb-6">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>학습된 어휘(vocabulary):</strong> K개 코드워드는 학습 데이터에서 자주 등장하는 의미 패턴의 사전이다. 인간이 "개", "고양이"처럼 범주를 만들듯, AI도 시각·음향 세계를 유한한 어휘로 범주화한다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>자동회귀 모델과의 호환성:</strong> 이미지 코드워드 인덱스는 텍스트 토큰처럼 취급할 수 있다. Chameleon, LlamaGen이 이미지와 텍스트를 단일 Transformer로 처리하는 비결이 여기 있다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>압축 효율:</strong> 512차원 실수 벡터 대신 정수 인덱스 하나만 저장한다. DAC(Descript Audio Codec)는 이 원리로 44.1kHz 오디오를 90배 압축한다.</span>
+                        </li>
+                    </ul>
+
+                    <p class="themeable-text leading-relaxed mb-4">이 이산화의 수학적 핵심은 단 하나의 연산으로 표현된다. 인코더 출력 $z$를 코드북에서 가장 가까운 코드워드 $e_k$로 대체하는 것이다:</p>
+
+                    <div class="my-6 text-center">
+                        $$z_q = \arg\min_k \|z - e_k\|_2$$
+                    </div>
+                    <p class="formula-label">식 1. VQ 코드북 룩업: 연속 임베딩 z를 가장 가까운 코드워드로 대체</p>
+
+                    <p class="themeable-text leading-relaxed">
+                        이 간단한 수식이 이미지(VQGAN), 오디오(EnCodec, DAC), 비디오(MAGVIT-2), 멀티모달(Chameleon)을 관통하는 공통 언어가 됐다. VQ-Tokenizer는 AI 멀티모달의 감각기관이다.
+                    </p>
+                </section>
+
+                <!-- Section 2 -->
+                <section id="section-2" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">2</span>VQ-VAE 해부 — 3단계 아키텍처와 STE</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        VQ-VAE(van den Oord et al., NeurIPS 2017)는 VQ-Tokenizer의 원형이다. 구조는 단순해 보이지만, "미분 불가능한 argmin"이라는 치명적 장벽을 가지고 있다. STE(Straight-Through Estimator)는 이 장벽을 우회하는 영리한 해결책이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">3단계 아키텍처</h3>
+                    <ul class="space-y-3 mb-6">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">①</span>
+                            <span class="themeable-text leading-relaxed"><strong>인코더 $z_e(x)$:</strong> 입력 이미지/오디오/텍스트를 연속 임베딩 벡터로 변환한다. CNN, Transformer 등 어떤 아키텍처도 사용 가능하다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">②</span>
+                            <span class="themeable-text leading-relaxed"><strong>코드북 룩업 (미분 불가능!):</strong> $z_q = \arg\min_k \|z_e - e_k\|_2$. 가장 가까운 코드워드를 선택한다. argmin은 계단 함수로, 역전파 시 기울기가 0이 된다. 인코더가 학습되지 않는 치명적 문제다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">③</span>
+                            <span class="themeable-text leading-relaxed"><strong>디코더 $D(z_q)$:</strong> 이산 코드워드 $z_q$로부터 원본을 재구성한다. 재구성 품질이 학습 목표다.</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Straight-Through Estimator(STE): 속임수이지만 잘 작동한다</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        STE의 핵심은 단순하다: 순전파(forward pass)에서는 $z_q$(이산 코드워드)를 쓰고, 역전파(backward pass)에서는 $z_q$의 기울기를 그대로 $z_e$로 통과시킨다. van den Oord는 논문에서 이를 "속임수이지만 잘 작동한다"고 솔직히 표현했다.
+                    </p>
+
+                    <div class="code-block">
+                        <code><span class="code-comment"># Straight-Through Estimator (PyTorch)</span>
+z_q = z_e + (z_q - z_e).detach()
+<span class="code-comment"># 순전파: z_q 값 사용 / 역전파: z_e로 기울기 통과 (detach로 z_q → z_e 경로 차단)</span></code>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">손실 함수 3항</h3>
+                    <p class="themeable-text leading-relaxed mb-4">VQ-VAE는 세 가지 손실의 합을 최소화한다:</p>
+
+                    <div class="my-6 text-center">
+                        $$L = \underbrace{\|x - D(z_q)\|^2}_{\text{재구성 손실}} + \underbrace{\|\text{sg}[z_e(x)] - e\|^2}_{\text{codebook 손실}} + \underbrace{\beta \|z_e(x) - \text{sg}[e]\|^2}_{\text{commitment 손실}\ (\beta=0.25)}$$
+                    </div>
+                    <p class="formula-label">식 2. VQ-VAE 손실 함수. sg[·]는 stop-gradient(역전파 차단) 연산자</p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        <strong>commitment loss</strong>($\beta=0.25$)는 인코더 출력이 코드워드에서 너무 멀어지지 않도록 한다. 실제로는 codebook loss 대신 EMA(지수이동평균) 업데이트를 써서 코드워드 위치를 k-평균 방식으로 이동시키는 것이 더 안정적이다. EnCodec, DAC 등 현대 구현은 대부분 EMA를 채택한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">lucidrains 3줄 시작</h3>
+                    <div class="code-block">
+                        <code><span class="code-comment"># pip install vector-quantize-pytorch</span>
+from vector_quantize_pytorch import VectorQuantize
+
+vq = VectorQuantize(dim=512, codebook_size=1024, decay=0.8)
+quantized, indices, commit_loss = vq(x)  <span class="code-comment"># x: (batch, seq, dim)</span></code>
+                    </div>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        VQ-VAE-2(Razavi et al., NeurIPS 2019)는 계층적 코드북으로 이를 확장했다. Top 코드북(32×32)이 전역 구조를, Bottom 코드북(64×64)이 지역 세부를 담당하여 256×256 고해상도 이미지를 생성한다. 이 계층적 접근은 현재 대부분의 VQ 기반 이미지 생성 모델의 표준이 됐다.
+                    </p>
+                </section>
+
+                <!-- Section 3 -->
+                <section id="section-3" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">3</span>코드북 붕괴 — AI가 보지 못하는 90%</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        나이브 VQ-VAE 학습에서 K=1,024개 코드북 중 실제 사용되는 코드워드는 10~30%에 불과하다. 나머지는 "죽은 코드(Dead Code)"가 된다. <strong>APCodec의 실제 프로덕션 사례</strong>: 해결 전 코드북 활용률 14.7%~41.2%. <strong>VQGAN 실험</strong>: 8,912개 코드북 중 66%가 전혀 사용되지 않음(arXiv:2602.18896).
+                    </p>
+
+                    <!-- Stats row -->
+                    <div class="grid grid-cols-3 gap-4 mb-8">
+                        <div class="stat-card">
+                            <span class="stat-highlight">10~30%</span>
+                            <p class="themeable-muted text-xs mt-1">나이브 VQ-VAE<br>평균 활용률</p>
+                        </div>
+                        <div class="stat-card">
+                            <span class="stat-highlight">66%</span>
+                            <p class="themeable-muted text-xs mt-1">VQGAN 실험<br>미사용 코드북 비율</p>
+                        </div>
+                        <div class="stat-card">
+                            <span class="stat-highlight">100%</span>
+                            <p class="themeable-muted text-xs mt-1">SF-DiVeQ<br>목표 활용률</p>
+                        </div>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">붕괴 메커니즘: 마태 효과</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        코드북 붕괴는 마태 효과(Matthew Effect)로 작동한다. "가진 자는 더 갖게 된다." 초기에 우연히 많이 선택된 코드워드는 더 많은 학습 신호를 받아 더 좋은 위치로 이동하고, 결과적으로 더 자주 선택된다. 반면 초기에 선택받지 못한 코드워드는 점점 멀어져 Dead Code가 된다. 이는 양의 피드백 루프(positive feedback loop)다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">측정 지표</h3>
+                    <p class="themeable-text leading-relaxed mb-4">두 가지 지표로 코드북 건강을 측정한다:</p>
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>코드북 활용률(%):</strong> $|\{k : n_k > 0\}| / K$. 적어도 한 번 이상 사용된 코드워드의 비율. &lt;50%이면 경보 수준.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>코드북 퍼플렉시티(Perplexity):</strong> $\exp(-\sum_k p_k \log p_k)$. 최댓값은 K(완벽 균일 분포). Perplexity/K &lt; 0.3이면 심각한 붕괴.</span>
+                        </li>
+                    </ul>
+
+                    <div class="my-6 text-center">
+                        $$\text{Perplexity} = \exp\!\left(-\sum_{k=1}^{K} p_k \log p_k\right)$$
+                    </div>
+                    <p class="formula-label">식 3. 코드북 퍼플렉시티. $p_k$는 코드워드 $k$의 사용 빈도 비율</p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">해결 시도의 역사</h3>
+                    <div class="mb-6">
+                        <div class="timeline-item">
+                            <span class="timeline-year">2017</span>
+                            <span class="themeable-text text-sm"><strong>EMA 업데이트</strong> — 코드워드를 k-평균 이동평균으로 갱신. 붕괴를 지연시킬 뿐 근본 해결 아님</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2019~</span>
+                            <span class="themeable-text text-sm"><strong>Random Restart</strong> — Dead Code를 랜덤으로 재초기화. OpenAI Jukebox, SoundStream, EnCodec 채택. 효과적이나 하이퍼파라미터 튜닝 필요</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2023</span>
+                            <span class="themeable-text text-sm"><strong>FSQ (Finite Scalar Quantization)</strong> — 코드북 테이블 자체를 제거. 각 차원을 고정된 이산값으로 반올림. 100% 활용률 보장. VQ 대비 FID 차이 ~0.5% (4.534 vs 4.509)</span>
+                        </div>
+                        <div class="timeline-item">
+                            <span class="timeline-year">2025</span>
+                            <span class="themeable-text text-sm"><strong>DiVeQ / SF-DiVeQ (ICLR 2026)</strong> — 방향 벡터 재매개변수화로 진짜 기울기 추정. SF-DiVeQ: 100% 코드북 활용률 달성 (2편에서 상세 해설)</span>
+                        </div>
+                    </div>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            코드북 붕괴는 단순한 기술적 버그가 아니다. <strong>이것은 "학습 데이터가 세상의 일부밖에 보지 못했다"는 신호다.</strong> 퍼플렉시티가 낮다는 것은 DataClinic이 발견하는 "저밀도 갭(Data Void)"과 정확히 같은 현상이다. 코드북 진단은 데이터 다양성 진단의 또 다른 이름이다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 4 -->
+                <section id="section-4" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">4</span>산업 적용 지도 — 언어·음성·시각·물리</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        VQ-Tokenizer는 특정 도메인의 틈새 기술이 아니다. 2017년 VQ-VAE 논문 이후 이미지, 오디오, 비디오, 멀티모달 AI 전 영역에 침투했다. 아래는 주요 산업 모델들의 VQ 적용 지도다.
+                    </p>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>도메인</th>
+                                    <th>모델</th>
+                                    <th>코드북 크기</th>
+                                    <th>활용률</th>
+                                    <th>핵심 특징</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><strong>이미지</strong></td>
+                                    <td>VQGAN (2021)</td>
+                                    <td>1K~16K</td>
+                                    <td>~34%</td>
+                                    <td>GAN loss 추가, Stable Diffusion 전신</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>이미지</strong></td>
+                                    <td>LlamaGen (2024)</td>
+                                    <td>16,384</td>
+                                    <td><strong>97%</strong></td>
+                                    <td>LLM 패러다임, FID 2.18</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>비디오</strong></td>
+                                    <td>MAGVIT-2 (2023)</td>
+                                    <td>2<sup>18</sup>=262,144 (LFQ)</td>
+                                    <td>~100%</td>
+                                    <td>확산 모델 능가 FID 1.78</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>오디오</strong></td>
+                                    <td>EnCodec (2022)</td>
+                                    <td>1,024 × 8 (RVQ)</td>
+                                    <td>보통</td>
+                                    <td>24kHz, 최저 1.5kbps</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>오디오</strong></td>
+                                    <td>DAC (2023)</td>
+                                    <td>1,024 × 9 (RVQ)</td>
+                                    <td>개선됨</td>
+                                    <td>44.1kHz, 8kbps, <strong>90배 압축</strong></td>
+                                </tr>
+                                <tr>
+                                    <td><strong>멀티모달</strong></td>
+                                    <td>Chameleon (2024)</td>
+                                    <td>VQ-VAE 기반</td>
+                                    <td>—</td>
+                                    <td>이미지+텍스트 단일 Transformer</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">도메인별 핵심 인사이트</h3>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>시각:</strong> VQGAN은 GAN 손실을 추가해 코드워드의 시각적 품질을 높였고, Stable Diffusion의 잠재 공간 압축기로 쓰였다. MAGVIT-2는 학습 가능한 코드북 테이블 없이 $\text{sign}(z_i)$로 각 차원을 이진화하는 LFQ를 도입해 262,144개 어휘를 거의 완전히 활용한다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>오디오:</strong> EnCodec과 DAC는 단일 VQ 대신 RVQ(Residual VQ)를 쓴다. 첫 번째 VQ로 양자화한 후 남은 잔차를 두 번째 VQ로, 그 잔차를 세 번째 VQ로 계속 양자화한다. DAC의 9개 코드북 체계는 44.1kHz 스튜디오 품질 오디오를 8kbps, 즉 90배 압축으로 전달한다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>멀티모달:</strong> Chameleon(Meta 2024)은 이미지 VQ 토큰과 BPE 텍스트 토큰을 동일한 시퀀스로 취급한다. 이미지 패치는 VQ로 코드워드 인덱스가 되고, 텍스트는 BPE 토큰 인덱스가 된다. 단일 Transformer가 이 혼합 시퀀스로 다음 토큰을 예측한다.
+                    </p>
+                    <p class="themeable-text leading-relaxed">
+                        <strong>자율주행/물리:</strong> LiDAR 포인트 클라우드와 로봇 행동 시퀀스에도 VQ가 적용된다. 3D 공간 패턴을 이산 코드워드로 변환하면 자동회귀 모델이 "다음 LiDAR 패턴"이나 "다음 행동"을 예측할 수 있다. PebbloSim의 LiDAR 합성 모듈이 이 원리를 활용한다.
+                    </p>
+                </section>
+
+                <!-- Section 5 -->
+                <section id="section-5" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">5</span>lucidrains 비결 — 왜 1인의 코드가 월 160만 다운로드를 낳는가</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        <strong>월 1,603,301회 다운로드. 유지보수자는 단 1명.</strong> Phil Wang(GitHub: lucidrains)이 만든 <code>vector-quantize-pytorch</code>는 AI 연구 생태계의 핵심 인프라가 됐다. vllm(77,267 GitHub Stars, AI 추론 프레임워크)이 이 라이브러리에 의존한다. 1,145개 GitHub 저장소, 58개 PyPI 패키지가 이 단일 라이브러리를 기반으로 한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Phil Wang은 누구인가</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        ThisPersonDoesNotExist.com(StyleGAN 기반 가상 인물 생성기)을 만든 개발자다. Stability.ai, a16z, Hugging Face의 후원을 받는다. GitHub 팔로워 59,100명, 저장소 386개 — 대부분이 논문 구현이다. 그의 철학은 "논문을 읽을 수 있는 코드로 만든다"다. 추상화와 최적화보다 이해 가능성을 우선한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">단순한 API가 생태계를 만든다</h3>
+                    <div class="code-block">
+                        <code><span class="code-comment"># 기본 VQ (EMA 업데이트 포함)</span>
+from vector_quantize_pytorch import VectorQuantize, ResidualVQ, LFQ, FSQ
+
+vq  = VectorQuantize(dim=512, codebook_size=1024, decay=0.8)
+rvq = ResidualVQ(dim=512, num_quantizers=8, codebook_size=1024)
+lfq = LFQ(codebook_size=2**18)        <span class="code-comment"># MAGVIT-2 방식</span>
+fsq = FSQ(levels=[8, 6, 5, 5, 5])    <span class="code-comment"># 100% 활용률 보장</span></code>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">지원 변형 전체 목록</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        v1.28.2(2026년 4월 17일 기준) 기준으로 다음 VQ 변형을 지원한다: VectorQuantize(EMA), ResidualVQ, GroupedResidualVQ, RandomProjectionQuantizer, SimVQ/ResidualSimVQ, FSQ/ResidualFSQ, LFQ(MAGVIT-2), LatentQuantize, <strong>directional_reparam(DiVeQ)</strong>. 2020년 창설 이후 주당 0.5 릴리스 속도를 유지한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">생태계 효과와 단일 유지보수자 리스크</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        audiolm-pytorch, soundstorm-pytorch, voicebox-pytorch, magvit2-pytorch 등 대형 AI 구현들이 이 라이브러리를 핵심 의존성으로 쓴다. "연구 논문이 이 라이브러리를 기준선으로 사용한다" — 역방향 유효성 검증이 이뤄지는 셈이다. 단, 버스 팩터(bus factor)=1이라는 구조적 리스크는 프로덕션 도입 전 고려해야 한다. MIT 라이선스로 상업적 사용은 무제한 허용된다.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            경쟁 라이브러리를 비교하면 lucidrains의 강점이 더 분명해진다. taming-transformers(6,300★)는 pip 패키지가 없고, encodec(3,800★)은 오디오 전용이며, descript-audio-codec(1,600★) 역시 오디오에 국한된다. <strong>멀티모달 VQ 변형을 하나의 pip 패키지로 제공하는 곳은 vector-quantize-pytorch가 유일하다.</strong>
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 6 -->
+                <section id="section-6" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">6</span>코드북 품질 = 데이터 품질 — 거울 관계</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        코드북은 학습 데이터 분포의 압축된 표현이다. 코드워드의 위치는 학습 데이터가 어떤 패턴으로 분포하는지를 직접 반영한다. 따라서 코드북 퍼플렉시티는 학습 데이터 다양성의 가장 정직한 거울이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">인과 연결: 왜 코드북이 데이터를 반영하는가</h3>
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">코드워드는 학습 데이터를 보면서 k-평균 방식으로 위치를 결정한다. 데이터가 편향(특정 패턴에 집중)되면 코드워드도 그 영역에 몰린다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">퍼플렉시티 낮음 → 코드북이 일부 패턴만 표현 → 데이터가 편향·중복. "AI가 세상의 10%만 봤다"는 수치적 증명이다.</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-teal-500 mt-1 font-bold">•</span>
+                            <span class="themeable-text leading-relaxed">Dead Code = 데이터에 특정 패턴 자체가 없다는 뜻. VQGAN-LC가 K=100,000으로 실험했을 때 99% 활용률을 달성하고 생성 다양성(IS, FID)이 유의미하게 향상된 것은 이 인과를 증명한다.</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">DataClinic 개념과 VQ 개념의 거울 관계</h3>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>DataClinic 개념</th>
+                                    <th>VQ 개념</th>
+                                    <th>의미</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>과밀집 클러스터</td>
+                                    <td>High-usage codewords</td>
+                                    <td>데이터 편향 / 중복</td>
+                                </tr>
+                                <tr>
+                                    <td>저밀도 갭 (Data Void)</td>
+                                    <td>Dead codes</td>
+                                    <td>데이터에 미커버된 패턴</td>
+                                </tr>
+                                <tr>
+                                    <td>밀도 분포 퍼짐</td>
+                                    <td>높은 퍼플렉시티</td>
+                                    <td>데이터 다양성 ↑</td>
+                                </tr>
+                                <tr>
+                                    <td>특징 공간 커버리지</td>
+                                    <td>Codebook utilization%</td>
+                                    <td>전체 패턴 대표성</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        DataClinic L2(Wolfram Net V2, 1,280차원)는 VQ 인코더 출력과 구조적으로 동일한 연속 임베딩이다. L2 밀도 분포 시각화는 코드워드 분포의 연속 근사다. DataClinic L3(도메인 특화, 41~177차원)는 소규모 VQ와 기능적으로 동일하다. Birds 525 데이터셋 기준 81차원 임베딩은 81개 대표 시각 패턴을 의미한다.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>코드북 진단 = 데이터 품질 조기 경보 시스템.</strong> L3 진단에 코드북 퍼플렉시티를 추가하면 ISO/IEC 5259-2의 다양성 품질 지표(QM-Div)를 자동으로 보고할 수 있다. 모델 학습 전에 데이터 편향을 수치로 포착한다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 7 -->
+                <section id="section-7" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">7</span>페블러스 관점 — DataClinic과 PebbloSim의 접점</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        DataClinic은 코드북 건강을 진단하고, PebbloSim은 빈 코드워드를 채우는 처방을 실행한다. 두 제품은 VQ-Tokenizer라는 공통 기술 위에서 진단→처방 루프를 완성한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">DataClinic 각도</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        DataClinic L2(1,280차원 연속 임베딩)의 밀도 분포 시각화는 코드워드 분포의 연속 근사다. "어느 패턴이 과밀집인가"와 "어느 영역이 비어 있는가"를 동시에 보여준다. L3(41~177차원 도메인 특화)는 소규모 VQ와 기능적으로 동일하다. Birds 525: 81차원 → 81개 대표 시각 패턴. 코드북 퍼플렉시티를 L3 지표에 추가하면 ISO 5259-2 Div-ML 지표를 직접 보고할 수 있다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">PebbloSim과 Vector-to-Param 특허</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        PebbloSim의 Vector-to-Param(US 12,481,720)은 이 루프의 핵심이다. Dead Code 좌표(빈 코드워드의 위치)를 조명각도, 날씨, 카메라 위치 등 시뮬레이션 파라미터로 역변환한다. "어떤 시각 패턴이 없는지"를 알면, "어떤 시뮬레이션 조건에서 그 패턴을 생성할 수 있는지"를 계산할 수 있다.
+                    </p>
+
+                    <div class="overflow-x-auto mb-8 rounded-lg" style="border: 1px solid var(--border-color);">
+                        <table class="w-full text-sm data-table">
+                            <thead>
+                                <tr>
+                                    <th>제품</th>
+                                    <th>VQ 역할</th>
+                                    <th>진단 지표</th>
+                                    <th>비즈니스 가치</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><strong>DataClinic L2</strong></td>
+                                    <td>임베딩 공간 분포 진단</td>
+                                    <td>밀도 분포, 클러스터 커버리지</td>
+                                    <td>편향·중복 데이터 탐지</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>DataClinic L3</strong></td>
+                                    <td>도메인 코드북 퍼플렉시티 진단</td>
+                                    <td>Perplexity, utilization%</td>
+                                    <td>ISO 5259 QM-Div 정량화</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim 카메라</strong></td>
+                                    <td>픽셀→토큰 다양성 보장</td>
+                                    <td>코드북 활용률 전/후 비교</td>
+                                    <td>합성 데이터 현실성·다양성 ↑</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim LiDAR</strong></td>
+                                    <td>포인트 클라우드 패턴 압축(RVQ)</td>
+                                    <td>재구성 오차 (Sim-to-Real)</td>
+                                    <td>3D 시나리오 커버리지 증명</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>PebbloSim 오디오</strong></td>
+                                    <td>도메인 음향 이산화(RVQ 코덱)</td>
+                                    <td>음향 코드북 퍼플렉시티</td>
+                                    <td>결함음 탐지 범위 정량화</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>AI-Ready Data</strong></td>
+                                    <td>VQ 기반 데이터 커버리지 인증</td>
+                                    <td>Perplexity + ISO QM 리포트</td>
+                                    <td>규제 준수 증빙, 고객 신뢰</td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Data Greenhouse</strong></td>
+                                    <td>진단→처방→생성 루프 척도</td>
+                                    <td>Before/After 퍼플렉시티 비교</td>
+                                    <td>Data Flywheel ROI 수치화</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>Data Flywheel 루프:</strong> 진단(DataClinic L3 퍼플렉시티 측정) → 처방(PebbloSim 정밀 합성) → 재진단(퍼플렉시티 향상 확인). 코드북 활용률이 30%에서 85%로 개선됐다면, AI 학습 데이터가 보는 세상의 패턴이 2.8배 늘어났다는 뜻이다. 이것이 코드북 커버리지 자동 최대화 루프다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 8 -->
+                <section id="section-8" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8"><span class="number-badge">8</span>DiVeQ 예고 — 미분 가능한 VQ의 다음 단계</h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        코드북 붕괴의 근본 원인은 argmin의 비미분성이다. EMA, Random Restart, FSQ는 모두 이 근본 원인을 우회하거나 회피한다. DiVeQ(arXiv:2509.26469, ICLR 2026)는 설계 수준에서 이 문제를 해결하는 접근이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">STE의 한계: 속임수의 대가</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        STE는 역전파 시 $z_q$의 기울기를 $z_e$로 그대로 통과시킨다. 이는 수학적으로 틀린 기울기다. argmin의 실제 기울기는 0이지만, STE는 1로 근사한다. 이 근사가 학습 초기의 코드북 붕괴를 유발하는 씨앗이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">DiVeQ 핵심: 방향 벡터 재매개변수화</h3>
+                    <p class="themeable-text leading-relaxed mb-4">DiVeQ는 오차 벡터의 <strong>방향</strong>과 <strong>크기</strong>를 분리해 미분 가능한 경로를 만든다:</p>
+
+                    <div class="my-6 text-center">
+                        $$z_q = z + \|c_{i^*} - z\|_2 \cdot \text{sg}\!\left[\frac{v_d}{\|v_d\|_2}\right]$$
+                    </div>
+                    <p class="formula-label">식 4. DiVeQ 재매개변수화. $v_d = v + (c_{i^*} - z)$, $v \sim \mathcal{N}(0, \sigma^2 I)$</p>
+
+                    <p class="themeable-text leading-relaxed mb-4">
+                        <strong>크기</strong>($\|c_{i^*} - z\|_2$)는 미분 가능하다. <strong>방향</strong>($v_d / \|v_d\|_2$)은 stop-gradient로 차단하지만, 확률적 노이즈 $v$를 더해 방향의 불연속성을 완화한다. SF-DiVeQ(Segment-Free DiVeQ)는 여기서 더 나아가 인접 코드워드를 연결하는 선분 위에서 값을 할당, 100% 코드북 활용률을 달성한다.
+                    </p>
+
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>2026년 4월 27일, ICLR 2026.</strong> 이 보고서를 읽는 지금으로부터 8일 후 DiVeQ의 전체 실험 결과와 코드가 공개된다. 2편에서 DiVeQ 수식과 DataClinic·PebbloSim 채택 시나리오를 전면 해설한다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- FAQ -->
+                <section id="faq" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">자주 묻는 질문</h2>
+
+                    <div class="space-y-6">
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">VQ-Tokenizer와 일반 임베딩의 차이는?</h3>
+                            <p class="themeable-text leading-relaxed">일반(연속) 임베딩은 무한한 실수 벡터 공간에 존재한다. VQ는 K개의 이산 코드워드만 존재하는 유한 어휘 공간을 쓴다. 연속 임베딩은 표현력이 높지만 자동회귀 모델과 호환이 어렵고 압축 효율이 낮다. VQ는 압축 효율이 높고 GPT류 언어 모델과 직접 호환되며, 코드북이 데이터 분포를 명시적으로 표현한다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">코드북 크기(K)는 어떻게 결정하나?</h3>
+                            <p class="themeable-text leading-relaxed">데이터 복잡도와 다양성에 따라 결정한다. CIFAR-10 → K=512, ImageNet → K=1K~16K, 비디오(MAGVIT-2) → K=262,144(LFQ). 경험칙: K가 너무 작으면 표현력 부족, 너무 크면 붕괴 위험 증가. FSQ는 K를 직접 설정하지 않고 차원별 레벨의 곱으로 암묵적으로 결정한다(예: [8,6,5,5,5] → K=8×6×5×5×5=6,000).</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">FSQ(Finite Scalar Quantization)와 VQ의 차이는?</h3>
+                            <p class="themeable-text leading-relaxed">VQ는 학습 가능한 K개 임베딩 벡터 테이블을 유지하고, 코드북 붕괴가 발생할 수 있다. FSQ는 코드북 테이블이 없다. 각 차원을 고정된 이산값으로 반올림하는 방식으로 100% 활용률을 보장한다. ImageNet 256 MaskGIT 기준 성능 차이는 FID 4.534 vs 4.509 — 약 0.5%로 실용적 차이가 없다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">lucidrains 라이브러리를 실제 프로젝트에 바로 쓸 수 있나?</h3>
+                            <p class="themeable-text leading-relaxed">네, <code>pip install vector-quantize-pytorch</code> 후 3줄로 시작 가능하다. MIT 라이선스로 상업적 사용이 무제한 허용된다. 단, 버스 팩터(bus factor)=1(단독 메인테이너) 리스크를 인식하고 도입해야 한다. 프로덕션 환경에서는 특정 버전을 고정하고 포크(fork)를 관리하는 전략을 권장한다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">코드북 붕괴를 감지하는 지표는?</h3>
+                            <p class="themeable-text leading-relaxed">코드북 활용률(%) &lt; 50%이면 경보 수준, &lt; 30%이면 심각. Perplexity / K &lt; 0.3이면 심각한 붕괴다. lucidrains 라이브러리의 <code>threshold_ema_dead_code</code> 파라미터로 훈련 중 실시간 모니터링이 가능하다. 활용률과 퍼플렉시티를 W&B나 TensorBoard에 로깅하는 것을 권장한다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">DataClinic은 VQ-tokenizer를 내부적으로 어떻게 쓰는가?</h3>
+                            <p class="themeable-text leading-relaxed">DataClinic L2(Wolfram Net V2, 1,280차원)는 VQ 인코더 출력과 구조적으로 동일한 연속 임베딩을 사용한다. L3(도메인 특화, 41~177차원)는 소규모 VQ와 기능적으로 동일하다. 향후 방향: L3에 코드북 퍼플렉시티를 ISO 5259 QM 지표로 직접 보고하는 기능을 추가하면 데이터 다양성 인증이 자동화된다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">DiVeQ는 STE를 완전히 대체하는가?</h3>
+                            <p class="themeable-text leading-relaxed">수학적으로는 더 정확한 기울기를 제공한다. STE는 argmin에서 기울기=0을 1로 근사하는 "속임수"지만, DiVeQ는 오차 벡터의 방향(방향 재매개변수화)으로 진짜 기울기를 추정한다. 기존 VQ 레이어의 drop-in replacement로 설계됐으며 최소한의 코드 변경으로 교체 가능하다. ICLR 2026 발표 후 vector-quantize-pytorch의 <code>directional_reparam</code> 옵션으로 이미 사용 가능하다.</p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-lg font-semibold themeable-heading mb-2">PebbloSim에서 VQ-tokenizer를 어떻게 활용하는가?</h3>
+                            <p class="themeable-text leading-relaxed">합성 전: DataClinic으로 현재 코드북 퍼플렉시티를 측정하고 부족한 시각/음향 패턴을 탐지한다. Vector-to-Param(US 12,481,720): 빈 코드워드 좌표를 조명·각도·날씨 등 시뮬레이션 파라미터로 역변환한다. 합성 후: 코드북 활용률 전/후 비교로 ROI를 수치화한다. 활용률 30%→85% 개선이라면 AI가 보는 세상이 2.8배 확장된 것이다.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- References -->
+                <section id="references" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">참고 자료</h2>
+                    <ol class="refs-list space-y-1 pl-4" style="list-style: decimal;">
+                        <li>van den Oord et al. (2017). <em>Neural Discrete Representation Learning (VQ-VAE)</em>. NeurIPS 2017. arXiv:1711.00937</li>
+                        <li>Razavi et al. (2019). <em>Generating Diverse High-Fidelity Images with VQ-VAE-2</em>. NeurIPS 2019. arXiv:1906.00446</li>
+                        <li>Esser et al. (2021). <em>Taming Transformers for High-Resolution Image Synthesis (VQGAN)</em>. CVPR 2021. arXiv:2012.09841</li>
+                        <li>Défossez et al. (2022). <em>High Fidelity Neural Audio Compression (EnCodec)</em>. ICLR 2023. arXiv:2210.13438</li>
+                        <li>Kumar et al. (2023). <em>High-Fidelity Audio Compression with Improved RVQGAN (DAC)</em>. NeurIPS 2023. arXiv:2306.06546</li>
+                        <li>Mentzer et al. (2023). <em>Finite Scalar Quantization: VQ-VAE Made Simple (FSQ)</em>. ICLR 2024. arXiv:2309.15505</li>
+                        <li>Yu et al. (2023). <em>Language Model Beats Diffusion — Tokenizer is Key to Visual Generation (MAGVIT-2)</em>. ICLR 2024. arXiv:2310.05737</li>
+                        <li>Vali et al. (2025). <em>DiVeQ: Differentiable Vector Quantization</em>. ICLR 2026 (4월 27일 발표 예정). arXiv:2509.26469</li>
+                        <li>Sun et al. (2024). <em>Autoregressive Model Beats Diffusion: Llama for Scalable Image Generation (LlamaGen)</em>. arXiv:2406.06525</li>
+                        <li>Meta AI (2024). <em>Chameleon: Mixed-Modal Early-Fusion Foundation Models</em>. arXiv:2405.09818</li>
+                        <li>Zhu et al. (2024). <em>VQGAN-LC: Scaling Codebooks with Large Cluster Initialization</em>. NeurIPS 2024. arXiv:2406.11837</li>
+                        <li>Zhang et al. (2024). <em>ERVQ: Ensemble Residual Vector Quantization for Neural Audio Codecs (APCodec)</em>. arXiv:2410.12359</li>
+                        <li>Balle et al. (2026). <em>Beyond Stationarity: Spectral Analysis of Codebook Collapse</em>. arXiv:2602.18896</li>
+                        <li>Zhu et al. (2026). <em>Early Quantization Shrinks Codebook</em>. arXiv:2603.17052</li>
+                        <li>ISO/IEC 5259-1:2024, ISO/IEC 5259-2:2024. <em>Artificial intelligence — Data quality for analytics and ML</em>. International Organization for Standardization.</li>
+                        <li>Wang, Phil (lucidrains). <em>vector-quantize-pytorch v1.28.2</em>. GitHub. MIT License. github.com/lucidrains/vector-quantize-pytorch</li>
+                        <li>Pebblous (2026). <em>US Patent 12,481,720 — Vector-to-Param Simulation Parameterization</em>. USPTO.</li>
+                    </ol>
+                </section>
+
+            </main>
+        </div>
+    </div>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="/scripts/common-utils.js?v=20260422"></script>
+    <script>
+        PebblousPage.init({
+            mainTitle: "VQ-Tokenizer: 데이터 품질과 합성 데이터의 기술적 척추",
+            subtitle: "코드북 활용률 10%가 뜻하는 것 — AI가 세상의 90%를 본 적이 없다",
+            pageTitle: "VQ-Tokenizer: 데이터 품질과 합성 데이터의 기술적 척추 | 페블러스",
+            category: "tech",
+            publishDate: "2026-04-22",
+            publisher: "(주)페블러스 데이터 커뮤니케이션팀",
+            defaultTheme: "light",
+            articlePath: "report/vq-tokenizer-data-quality-synthesis/ko/",
+            tags: ["VQ-Tokenizer", "코드북 붕괴", "데이터 품질", "lucidrains", "vector-quantize-pytorch", "DataClinic", "PebbloSim", "DiVeQ", "ICLR 2026", "ISO 5259", "VQ-VAE", "VQGAN", "EnCodec", "DAC", "MAGVIT-2"],
+            faqs: [
+                {
+                    question: "VQ-Tokenizer와 일반 임베딩의 차이는?",
+                    answer: "일반(연속) 임베딩은 무한한 실수 벡터 공간에 존재합니다. VQ는 K개의 이산 코드워드만 존재하는 유한 어휘 공간을 사용합니다. VQ는 자동회귀 모델과 직접 호환되고 압축 효율이 높으며, 코드북이 학습 데이터 분포를 명시적으로 표현합니다."
+                },
+                {
+                    question: "코드북 크기(K)는 어떻게 결정하나?",
+                    answer: "데이터 복잡도에 따라 결정합니다. CIFAR-10 → K=512, ImageNet → K=1K~16K, 비디오(MAGVIT-2) → K=262,144. 경험칙: K가 너무 작으면 표현력 부족, 너무 크면 붕괴 위험 증가. FSQ는 차원별 레벨의 곱으로 암묵적으로 결정합니다."
+                },
+                {
+                    question: "FSQ(Finite Scalar Quantization)와 VQ의 차이는?",
+                    answer: "VQ는 학습 가능한 코드북 테이블을 유지하며 붕괴 위험이 있습니다. FSQ는 코드북 테이블이 없고, 각 차원을 고정된 이산값으로 반올림해 100% 활용률을 보장합니다. 성능 차이는 FID 약 0.5%로 실용적 차이가 없습니다."
+                },
+                {
+                    question: "lucidrains 라이브러리를 실제 프로젝트에 바로 쓸 수 있나?",
+                    answer: "네, pip install vector-quantize-pytorch 후 3줄로 시작 가능합니다. MIT 라이선스로 상업적 사용이 무제한 허용됩니다. 단, 버스 팩터(bus factor)=1(단독 메인테이너) 리스크를 인식하고 특정 버전을 고정해 사용하는 것을 권장합니다."
+                },
+                {
+                    question: "코드북 붕괴를 감지하는 지표는?",
+                    answer: "코드북 활용률(%) < 50%이면 경보, < 30%이면 심각합니다. Perplexity/K < 0.3이면 심각한 붕괴입니다. lucidrains 라이브러리의 threshold_ema_dead_code 파라미터로 훈련 중 실시간 모니터링이 가능합니다."
+                },
+                {
+                    question: "DataClinic은 VQ-tokenizer를 내부적으로 어떻게 쓰는가?",
+                    answer: "DataClinic L2(Wolfram Net V2, 1,280차원)는 VQ 인코더 출력과 구조적으로 동일한 연속 임베딩을 사용합니다. L3(도메인 특화, 41~177차원)는 소규모 VQ와 기능적으로 동일합니다. 향후 L3에 코드북 퍼플렉시티를 ISO 5259 QM 지표로 직접 보고할 예정입니다."
+                },
+                {
+                    question: "DiVeQ는 STE를 완전히 대체하는가?",
+                    answer: "수학적으로 더 정확한 기울기를 제공합니다. STE는 argmin에서 기울기=0을 1로 근사하는 속임수이지만, DiVeQ는 오차 벡터의 방향으로 진짜 기울기를 추정합니다. 기존 VQ 레이어의 drop-in replacement로 최소한의 코드 변경으로 교체 가능합니다."
+                },
+                {
+                    question: "PebbloSim에서 VQ-tokenizer를 어떻게 활용하는가?",
+                    answer: "DataClinic으로 코드북 퍼플렉시티를 측정해 부족한 패턴을 탐지합니다. Vector-to-Param(US 12,481,720)으로 빈 코드워드 좌표를 시뮬레이션 파라미터로 역변환합니다. 합성 후 활용률 전/후 비교로 ROI를 수치화합니다."
+                }
+            ]
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- VQ-Tokenizer 심층보고서 1편 (KO + EN) 추가
- 퍼블리시 타겟: 2026-04-22 (ICLR 2026 발표 April 27 직전)

## 파일

| 파일 | 설명 |
|------|------|
| `report/vq-tokenizer-data-quality-synthesis/ko/index.html` | 한국어 아티클 |
| `report/vq-tokenizer-data-quality-synthesis/en/index.html` | 영어 아티클 |
| `report/vq-tokenizer-data-quality-synthesis/index.html` | 언어 감지 리다이렉트 |

## 콘텐츠 구성

- 8개 섹션 + Executive Summary + FAQ + References
- KaTeX 수식 4개 (VQ 룩업, VQ-VAE 손실, 퍼플렉시티, DiVeQ)
- 코드 블록 2개 (STE Python, lucidrains API)
- 표 3개 (산업 도메인 지도, DataClinic↔VQ 거울 관계, 페블러스 제품 7종)
- FAQ 8개 (HTML 본문 + PebblousPage.init() 양쪽)

## 미완료 (퍼블리시 전 필요)

- [ ] OG 이미지 생성 (`og-ko.png`, `og-en.png`)
- [ ] `articles.json` 등록
- [ ] SEO-check

## 라이브 미리보기

- KO: https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/ko/
- EN: https://pebblous.com/report/vq-tokenizer-data-quality-synthesis/en/

> 2편: DiVeQ 상세보고서 — ICLR 2026 발표(4/27) 후 별도 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)