### PR TITLE
feat(report): Nemotron-Personas-Korea 한국 AI 자립의 출발점 [KO]

### DIFF
--- a/report/nemotron-personas-korea-2026-04/ko/index.html
+++ b/report/nemotron-personas-korea-2026-04/ko/index.html
@@ -6,11 +6,11 @@
     <meta name="author" content="Pebblous Data Communication Team">
     <meta name="language" content="Korean">
     <meta http-equiv="content-language" content="ko">
-    <meta name="copyright" content="(주)페블러스 데이터 커뮤니케이션">
+    <meta name="copyright" content="© 2026 Pebblous. All rights reserved.">
     <meta name="robots" content="index, follow">
     <meta name="revisit-after" content="7 days">
 
-    <title>Nemotron-Personas-Korea — 한국 AI 자립의 출발점 | 페블러스</title>
+    <title>한국 합성 페르소나 700만 — Nemotron-Personas-Korea 심층 분석 | 페블러스</title>
     <meta name="description" content="NVIDIA 김현우 박사의 Nemotron-Personas-Korea 허깅페이스 1위 분석. 700만 합성 페르소나의 구축 방법론, 소버린 AI 데이터 자립, 사회과학 연구 변혁, 월드모델 활용, 한계와 비판, DataClinic 진단 시나리오를 심층 분석합니다.">
     <meta name="keywords" content="Nemotron-Personas-Korea, 합성 데이터, 소버린 AI, NVIDIA, 페르소나, 한국 AI, 인구통계, DataClinic, AI-Ready Data, 허깅페이스, 사회과학, 월드모델">
 
@@ -153,12 +153,10 @@
 
                 <!-- Section 1 -->
                 <section id="section-1" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">01</span>
-                            Nemotron-Personas-Korea, 무엇이고 왜 1위인가
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">01</span>
+                        <h2 class="text-3xl font-bold themeable-heading">Nemotron-Personas-Korea, 무엇이고 왜 1위인가</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         2026년 4월 20일, NVIDIA가 허깅페이스에 공개한 Nemotron-Personas-Korea는 한국어 데이터셋으로서 전체 트렌딩 1위를 달성했다. 허깅페이스에 등록된 <strong>45만~50만</strong>개 데이터셋 가운데 한국어 특화 대규모 페르소나가 전체 1위를 기록한 사례는 확인되지 않는다. 이 데이터셋의 차별점은 규모(700만)보다 <strong>구조</strong>에 있다.
@@ -244,12 +242,10 @@
 
                 <!-- Section 2 -->
                 <section id="section-2" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">02</span>
-                            소버린 AI와 데이터 자립 &mdash; 왜 한국에 필요한가
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">02</span>
+                        <h2 class="text-3xl font-bold themeable-heading">소버린 AI와 데이터 자립 &mdash; 왜 한국에 필요한가</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         소버린 AI(Sovereign AI)는 핵심 AI 구성요소(데이터, 모델, 인프라)에 대한 국가 통제권 확보를 의미한다. 학술적으로는 "네트워크 자율성"으로 재정의된다(arXiv:2511.15734). 완전한 자급이 아니라 핵심 AI 구성요소를 통제하면서 선택적으로 국제 협력하는 것이 현실적 전략이다. Nemotron-Personas-Korea는 이 프레임워크에서 "데이터 자립"의 최소 단위이자 최초 구현체다.
@@ -280,12 +276,10 @@
 
                 <!-- Section 3 -->
                 <section id="section-3" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">03</span>
-                            사회과학 &middot; 인문학 연구 방법론의 변혁
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">03</span>
+                        <h2 class="text-3xl font-bold themeable-heading">사회과학 &middot; 인문학 연구 방법론의 변혁</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         합성 페르소나 기반 설문(Silicon Sampling)은 비용과 규모에서 기존 설문 방법론과 비교 불가능한 효율성을 제공한다. 그러나 구조적 비일관성과 동질화가 핵심 과제로 남아 있으며, 실제 설문과의 교차 검증이 반드시 수반되어야 한다.
@@ -328,12 +322,10 @@
 
                 <!-- Section 4 -->
                 <section id="section-4" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">04</span>
-                            월드모델과 독자 파운데이션 모델
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">04</span>
+                        <h2 class="text-3xl font-bold themeable-heading">월드모델과 독자 파운데이션 모델</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         PGM + LLM 하이브리드 파이프라인은 "통계적 정합성 + 자연어 풍부성"을 동시에 달성하는 기술적 혁신이다. 이 접근법이 한국 독자 파운데이션 모델의 학습에서 어떤 역할을 할 수 있는지가 이 섹션의 핵심 질문이다.
@@ -380,12 +372,10 @@
 
                 <!-- Section 5 -->
                 <section id="section-5" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">05</span>
-                            한계와 비판
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">05</span>
+                        <h2 class="text-3xl font-bold themeable-heading">한계와 비판</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         합성 데이터의 편향 전파는 학술적으로 측정 가능한 위험이다. 인구통계 기반 설계는 만능이 아니라 "첫 번째 완화 전략"이며, 독립적 품질 감사가 반드시 수반되어야 한다.
@@ -432,12 +422,10 @@
 
                 <!-- Section 6: 페블러스 관심의 이유 -->
                 <section id="section-6" class="mb-16 fade-in-card">
-                    <h2 class="text-3xl font-bold themeable-heading">
-                        <div class="flex items-center gap-4 mb-8">
-                            <span class="number-badge">06</span>
-                            페블러스가 이 데이터셋에 주목하는 이유
-                        </div>
-                    </h2>
+                    <div class="flex items-center gap-4 mb-8">
+                        <span class="number-badge">06</span>
+                        <h2 class="text-3xl font-bold themeable-heading">페블러스가 이 데이터셋에 주목하는 이유</h2>
+                    </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Nemotron-Personas-Korea의 등장은 "합성 데이터의 품질을 누가 검증하는가"라는 질문을 시장에 던진다. NVIDIA가 합성 데이터를 생성하는 세계에서, 생성된 데이터가 실제 인구를 정확히 대표하는지 독립적으로 진단하는 인프라가 필요하다. 이 지점에서 페블러스의 DataClinic과 DataGreenhouse가 자연스럽게 연결된다.
@@ -565,7 +553,7 @@
         PebblousPage.init({
             mainTitle: "Nemotron-Personas-Korea \u2014 \ud55c\uad6d AI \uc790\ub9bd\uc758 \ucd9c\ubc1c\uc810",
             subtitle: "\uc2e4\uc81c \uc778\uad6c\ud1b5\uacc4 \uae30\ubc18 \ud569\uc131 \ud398\ub974\uc18c\ub098\uac00 \uc18c\ubc84\ub9b0 LLM\uc758 \ud1a0\ub300\uac00 \ub418\ub294 \uc774\uc720",
-            pageTitle: "Nemotron-Personas-Korea \u2014 \ud55c\uad6d AI \uc790\ub9bd\uc758 \ucd9c\ubc1c\uc810 | \ud398\ube14\ub7ec\uc2a4",
+            pageTitle: "한국 합성 페르소나 700만 — Nemotron-Personas-Korea 심층 분석 | 페블러스",
             category: "tech",
             publishDate: "2026-04-26",
             publisher: "(\uc8fc)\ud398\ube14\ub7ec\uc2a4 \ub370\uc774\ud130 \ucee4\ubba4\ub2c8\ucf00\uc774\uc158\ud300",

--- a/report/nemotron-personas-korea-2026-04/ko/index.html
+++ b/report/nemotron-personas-korea-2026-04/ko/index.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="author" content="Pebblous Data Communication Team">
+    <meta name="language" content="Korean">
+    <meta http-equiv="content-language" content="ko">
+    <meta name="copyright" content="(주)페블러스 데이터 커뮤니케이션">
+    <meta name="robots" content="index, follow">
+    <meta name="revisit-after" content="7 days">
+
+    <title>Nemotron-Personas-Korea — 한국 AI 자립의 출발점 | 페블러스</title>
+    <meta name="description" content="NVIDIA 김현우 박사의 Nemotron-Personas-Korea 허깅페이스 1위 분석. 700만 합성 페르소나의 구축 방법론, 소버린 AI 데이터 자립, 사회과학 연구 변혁, 월드모델 활용, 한계와 비판, DataClinic 진단 시나리오를 심층 분석합니다.">
+    <meta name="keywords" content="Nemotron-Personas-Korea, 합성 데이터, 소버린 AI, NVIDIA, 페르소나, 한국 AI, 인구통계, DataClinic, AI-Ready Data, 허깅페이스, 사회과학, 월드모델">
+
+    <link rel="canonical" href="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/">
+    <link rel="alternate" hreflang="ko" href="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/">
+    <link rel="alternate" hreflang="en" href="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/en/">
+    <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/en/">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Nemotron-Personas-Korea — 한국 AI 자립의 출발점">
+    <meta property="og:description" content="NVIDIA 김현우 박사의 700만 합성 페르소나 데이터셋이 허깅페이스 1위를 달성한 배경과, 소버린 AI 시대 인구통계 기반 합성 페르소나의 전략적 가치를 분석합니다.">
+    <meta property="og:url" content="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/">
+    <meta property="og:image" content="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/image/index.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Nemotron-Personas-Korea 한국 AI 자립의 출발점 보고서">
+    <meta property="og:site_name" content="Pebblous Blog">
+    <meta property="og:locale" content="ko_KR">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@pebblous_ai">
+    <meta name="twitter:creator" content="@pebblous_ai">
+    <meta name="twitter:title" content="Nemotron-Personas-Korea — 한국 AI 자립의 출발점">
+    <meta name="twitter:description" content="NVIDIA 김현우 박사의 700만 합성 페르소나 데이터셋이 허깅페이스 1위를 달성한 배경과, 소버린 AI 시대 데이터 자립의 전략적 가치를 분석합니다.">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/image/index.png">
+    <meta name="twitter:image:alt" content="Nemotron-Personas-Korea 한국 AI 자립의 출발점 보고서">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/image/favicon.ico" sizes="any">
+    <link rel="icon" href="/image/Pebblous_BM_Orange_RGB.png" type="image/png">
+    <link rel="apple-touch-icon" href="/image/Pebblous_BM_Orange_RGB.png">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-57L9F58B');</script>
+
+    <!-- Styles (순서 고정) -->
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260426">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260426">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260426">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+
+    <!-- JSON-LD -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Nemotron-Personas-Korea — 한국 AI 자립의 출발점",
+      "description": "NVIDIA 김현우 박사의 700만 합성 페르소나 데이터셋이 허깅페이스 1위를 달성한 배경과 소버린 AI 시대 데이터 자립의 전략적 가치 분석.",
+      "datePublished": "2026-04-26",
+      "dateModified": "2026-04-26",
+      "author": { "@type": "Organization", "name": "Pebblous Data Communication Team" },
+      "publisher": { "@type": "Organization", "name": "페블러스", "url": "https://blog.pebblous.ai" },
+      "image": "https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/image/index.png",
+      "url": "https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/",
+      "inLanguage": "ko",
+      "keywords": ["Nemotron-Personas-Korea", "합성 데이터", "소버린 AI", "NVIDIA", "페르소나", "한국 AI"]
+    }
+    </script>
+</head>
+<body class="antialiased themeable-bg themeable-text font-sans">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57L9F58B" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <!-- Header -->
+    <div id="header-placeholder"></div>
+
+    <!-- Main Container -->
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">
+        <div class="lg:flex lg:gap-8 lg:justify-center lg:items-start">
+
+            <!-- TOC Sidebar -->
+            <nav class="hidden lg:block lg:w-[240px] lg:shrink-0 sticky top-20 self-start">
+                <h3 class="font-bold themeable-heading mb-4 text-lg">목차</h3>
+                <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
+                    <li><a href="#executive-summary" class="block pl-4 themeable-toc-link transition-colors duration-200">Executive Summary</a></li>
+                    <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. 무엇이고 왜 1위인가</a></li>
+                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. 소버린 AI와 데이터 자립</a></li>
+                    <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. 사회과학 연구 방법론의 변혁</a></li>
+                    <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. 월드모델과 파운데이션 모델</a></li>
+                    <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. 한계와 비판</a></li>
+                    <li><a href="#section-6" class="block pl-4 themeable-toc-link transition-colors duration-200">6. 페블러스가 이 데이터셋에 주목하는 이유</a></li>
+                    <li><a href="#faq" class="block pl-4 themeable-toc-link transition-colors duration-200">FAQ</a></li>
+                    <li><a href="#references" class="block pl-4 themeable-toc-link transition-colors duration-200">참고문헌</a></li>
+                </ul>
+            </nav>
+
+            <!-- Main Content -->
+            <main class="max-w-[800px] px-4 sm:px-6">
+
+                <!-- Hero Section -->
+                <header class="text-left mb-12">
+                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-6 leading-tight"></h1>
+                </header>
+
+                <!-- Executive Summary -->
+                <section id="executive-summary" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
+                    <div class="key-insight">
+                        <p class="themeable-text leading-relaxed">
+                            NVIDIA 김현우 박사(서울대 박사, KAIST AI 조교수 부임 예정)가 2026년 4월 20일 공개한 <strong>Nemotron-Personas-Korea</strong>는 한국 공식 통계(KOSIS, 대법원, 국민건강보험공단, 농촌경제연구원)를 기반으로 구축된 <strong>700만 합성 페르소나</strong> 데이터셋이다. 허깅페이스 전체 트렌딩 1위를 달성한 이 데이터셋은, 기존 번역 기반 한국어 데이터셋(KoAlpaca, KULLM)과 달리 한국 실제 인구 분포에서 출발하여 PGM(확률 그래프 모델) + Gemma-4-31B 하이브리드 파이프라인으로 생성된 최초의 대규모 네이티브 한국어 페르소나 자원이다.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            학술 연구에 따르면, 인구통계 기반 페르소나 정렬은 사회 시뮬레이션의 정렬 오차를 <strong>37.9~49.8%</strong> 감소시킨다(arXiv:2509.10127). 한국 정부가 <strong>7,350억 달러</strong> 규모 소버린 AI 전략을 추진하고 AI 기본법을 시행(2026.01)한 시점에서, 인구통계 기반 합성 페르소나는 데이터 자립의 첫 번째 구체적 성과물이다.
+                        </p>
+                        <p class="themeable-text leading-relaxed mt-4">
+                            동시에, 합성 데이터의 편향 전파(arXiv:2403.07857), 독립 가정의 한계, 19세 미만 미포함 등 품질 검증 과제가 부상한다. DataClinic의 분포 진단은 합성 페르소나의 인구통계 정합성을 정량 검증하고 편향 피드백 루프를 사전 차단하는 도구로서, 이 간극을 메우는 전략적 가치를 가진다.
+                        </p>
+                    </div>
+
+                    <!-- stat-card -->
+                    <p class="themeable-text leading-relaxed mt-6 mb-4">
+                        핵심 수치로 보면 이 데이터셋의 규모와 연구적 의의가 한눈에 드러난다.
+                    </p>
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-4 text-center">
+                            <p class="text-2xl font-bold" style="color: #F86825;">700만</p>
+                            <p class="text-sm themeable-muted">합성 페르소나</p>
+                        </div>
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-4 text-center">
+                            <p class="text-2xl font-bold" style="color: #F86825;">26개</p>
+                            <p class="text-sm themeable-muted">구조화 필드</p>
+                        </div>
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-4 text-center">
+                            <p class="text-2xl font-bold" style="color: #F86825;">~49.8%</p>
+                            <p class="text-sm themeable-muted">정렬 오차 감소</p>
+                        </div>
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-4 text-center">
+                            <p class="text-2xl font-bold" style="color: #F86825;">$735B</p>
+                            <p class="text-sm themeable-muted">한국 소버린 AI</p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Section 1 -->
+                <section id="section-1" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">01</span>
+                            Nemotron-Personas-Korea, 무엇이고 왜 1위인가
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        2026년 4월 20일, NVIDIA가 허깅페이스에 공개한 Nemotron-Personas-Korea는 한국어 데이터셋으로서 전체 트렌딩 1위를 달성했다. 허깅페이스에 등록된 <strong>45만~50만</strong>개 데이터셋 가운데 한국어 특화 대규모 페르소나가 전체 1위를 기록한 사례는 확인되지 않는다. 이 데이터셋의 차별점은 규모(700만)보다 <strong>구조</strong>에 있다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.1 PGM + LLM 하이브리드 파이프라인</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        구축 과정은 두 단계로 나뉜다. 먼저 PGM(확률 그래프 모델)이 한국 공식 통계(KOSIS 2020~2026, 대법원 성명 분포, 국민건강보험공단, 농촌경제연구원)로부터 인구통계 분포를 직접 샘플링하여 <strong>1백만 레코드</strong>의 구조화된 속성 조합을 생성한다. 이어서 Gemma-4-31B가 이 속성 조합을 7종 한국어 내러티브 페르소나로 변환한다. 단순 균일 샘플링이 아닌 실제 인구 분포를 반영한 확률적 샘플링이 핵심이다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        최종 데이터셋은 <strong>26개 구조화 필드</strong>(인구통계 12 + 페르소나 7 + 속성 6 + UUID 1)로 구성되며, <strong>17개 광역시도</strong>, <strong>252개 이상의 시군구</strong>, <strong>2,000개 이상의 직업</strong>, <strong>약 209,000개의 고유 이름</strong>(성 118개 + 이름 21,400개 이상)을 포함한다. 연령 범위는 19세에서 99세까지이며, CC BY 4.0 라이선스로 상업적 활용이 자유롭다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.2 허깅페이스 1위 달성의 구조적 원인</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        단일 요인이 아닌 다섯 가지 조건의 동시 충족이 1위를 만들었다. 첫째, Nemotron Developer Days Seoul(4/21~22, 500명 이상 참석)과 동시에 릴리스하여 초기 다운로드가 폭증했다. 둘째, NVIDIA 조직 계정(팔로워 55,600명)의 브랜드 효과가 확산을 가속했다. 셋째, 한국어 대규모 페르소나 데이터셋이 전무했다는 공급 공백이 있었다. 넷째, CC BY 4.0 라이선스가 상업적 활용 장벽을 제거했다. 다섯째, 한국 정부의 소버린 AI 정책과 시의적으로 맞물렸다. NVIDIA AI 공식 X 계정이 트렌딩 1위 사실을 직접 확인했다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.3 기존 한국어 데이터셋과의 패러다임 차이</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        기존 한국어 LLM 데이터셋과 Nemotron-Personas-Korea는 근본적으로 다른 종류의 자원이다. KoAlpaca(약 20K, 번역 기반)와 KULLM v2(수만 건, GPT-4/Dolly 번역)는 영어 명령어를 한국어로 번역한 것이다. 번역 과정에서 한국 문화 맥락이 소실된다. 반면 Nemotron-Personas-Korea는 한국 공식 통계에서 출발하여 한국어로 직접 생성된다.
+                    </p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        아래 표는 이 차이를 구조적으로 정리한 것이다.
+                    </p>
+
+                    <div class="overflow-x-auto mb-8">
+                        <table class="w-full border-collapse">
+                            <thead>
+                                <tr class="themeable-bg-secondary">
+                                    <th class="border themeable-border px-4 py-3 text-left font-semibold">구분</th>
+                                    <th class="border themeable-border px-4 py-3 text-left font-semibold">Nemotron-Personas-Korea</th>
+                                    <th class="border themeable-border px-4 py-3 text-left font-semibold">PersonaHub</th>
+                                    <th class="border themeable-border px-4 py-3 text-left font-semibold">KoAlpaca / KULLM</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">규모</td>
+                                    <td class="border themeable-border px-4 py-3"><strong>700만</strong> (1M x 7 유형)</td>
+                                    <td class="border themeable-border px-4 py-3">10억 (영어)</td>
+                                    <td class="border themeable-border px-4 py-3">~20K / 수만 건</td>
+                                </tr>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">출처</td>
+                                    <td class="border themeable-border px-4 py-3">한국 공식 통계 (KOSIS, 대법원)</td>
+                                    <td class="border themeable-border px-4 py-3">웹 크롤링</td>
+                                    <td class="border themeable-border px-4 py-3">영어 번역</td>
+                                </tr>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">속성 필드</td>
+                                    <td class="border themeable-border px-4 py-3"><strong>26개</strong> 구조화</td>
+                                    <td class="border themeable-border px-4 py-3">3~5개 비구조화</td>
+                                    <td class="border themeable-border px-4 py-3">명령어-응답 쌍</td>
+                                </tr>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">인구통계 정합성</td>
+                                    <td class="border themeable-border px-4 py-3">PGM 기반 분포 샘플링</td>
+                                    <td class="border themeable-border px-4 py-3">없음</td>
+                                    <td class="border themeable-border px-4 py-3">없음</td>
+                                </tr>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">라이선스</td>
+                                    <td class="border themeable-border px-4 py-3"><strong>CC BY 4.0</strong></td>
+                                    <td class="border themeable-border px-4 py-3">CC BY-NC-SA 4.0</td>
+                                    <td class="border themeable-border px-4 py-3">다양</td>
+                                </tr>
+                                <tr class="hover:bg-orange-500/5 transition-colors">
+                                    <td class="border themeable-border px-4 py-3 font-semibold">용도</td>
+                                    <td class="border themeable-border px-4 py-3">에이전트 시뮬레이션, 문화 정렬</td>
+                                    <td class="border themeable-border px-4 py-3">범용 페르소나</td>
+                                    <td class="border themeable-border px-4 py-3">SFT / 명령어 튜닝</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        다만 Nemotron-Personas-Korea는 명령어 데이터셋이 아닌 페르소나 데이터셋이다. 직접 SFT(Supervised Fine-Tuning)에 사용하려면 페르소나를 대화/명령어로 변환하는 후속 파이프라인이 필요하다. 이 점에서 기존 한국어 명령어 데이터셋과 경쟁이 아닌 보완 관계에 있다.
+                    </p>
+                </section>
+
+                <!-- Section 2 -->
+                <section id="section-2" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">02</span>
+                            소버린 AI와 데이터 자립 &mdash; 왜 한국에 필요한가
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        소버린 AI(Sovereign AI)는 핵심 AI 구성요소(데이터, 모델, 인프라)에 대한 국가 통제권 확보를 의미한다. 학술적으로는 "네트워크 자율성"으로 재정의된다(arXiv:2511.15734). 완전한 자급이 아니라 핵심 AI 구성요소를 통제하면서 선택적으로 국제 협력하는 것이 현실적 전략이다. Nemotron-Personas-Korea는 이 프레임워크에서 "데이터 자립"의 최소 단위이자 최초 구현체다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.1 한국 소버린 AI의 현주소</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        한국은 2026년 1월 AI 기본법을 시행했다. 2025년 8월에는 소버린 LLM 5개 컨소시엄이 선정되어 <strong>2,400억 원</strong>이 투입되었고, 12월 1차 평가에서 5개에서 4개로 축소, 2027년까지 2개 생존 구조로 설계되었다. 2026년 AI 관련 예산은 <strong>10.1조 원(약 73억 달러)</strong>이며, 삼성을 포함한 총 투자 규모는 <strong>7,350억 달러</strong>에 달한다. NVIDIA는 한국에 <strong>25만 대 이상</strong>의 GPU 배치를 계획하고 있다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        그러나 인프라 투자만으로는 소버린 AI가 완성되지 않는다. 모델의 문화적 대표성을 보장하는 학습 데이터가 없으면, GPU 위에 올라가는 것은 여전히 영어 편향의 모델이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.2 WEIRD 편향과 한국 인구통계 기반 설계</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        The Personality Trap(arXiv:2602.03334)은 LLM이 합성 인구를 생성할 때 체계적으로 <strong>WEIRD 편향</strong>(Western, Educated, Industrialized, Rich, Democratic)을 보인다는 점을 실증했다. 영어 중심 합성 페르소나는 젊고, 교육 수준이 높고, 서구적이며, 이성애적이고, 중도~진보 성향으로 편향된다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Nemotron-Personas-Korea는 이 편향을 구조적으로 우회한다. KOSIS 실제 분포에서 평균 연령 <strong>45.2세</strong>, <strong>50대 인구가 최대</strong>, <strong>17개 시도별 지역 분포</strong>, <strong>7단계 교육수준</strong>을 PGM이 직접 샘플링한다. DeepPersona(arXiv:2511.07338)의 분류학 기반 샘플링이 국가별 통계 대비 <strong>43%</strong> 개선을 보인 것은, 인구통계 정렬의 정량적 효과를 추가로 입증한다.
+                    </p>
+
+                    <div class="key-insight mb-8">
+                        <p class="themeable-text leading-relaxed">
+                            <strong>핵심 인사이트:</strong> 데이터 자립의 삼각 구조는 대표성(한국 인구 분포 반영), 다양성(2,000+ 직업, 209K 이름, 39종 가구유형), 품질(PII 제로, CC BY 4.0, NeMo Data Designer 검증)로 구성된다. 이 삼각 구조의 지속적 검증이 DataClinic의 역할이며, 합성 데이터가 시간이 지나며 실제 인구 변화를 반영하는지 모니터링하는 것이 핵심 과제다.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 3 -->
+                <section id="section-3" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">03</span>
+                            사회과학 &middot; 인문학 연구 방법론의 변혁
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        합성 페르소나 기반 설문(Silicon Sampling)은 비용과 규모에서 기존 설문 방법론과 비교 불가능한 효율성을 제공한다. 그러나 구조적 비일관성과 동질화가 핵심 과제로 남아 있으며, 실제 설문과의 교차 검증이 반드시 수반되어야 한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.1 Polypersona 방법론</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Polypersona(arXiv:2512.14562)는 인구통계적, 심리통계적 일관성을 LLM 설문 시뮬레이션에 내장한 방법론이다. 433개 페르소나를 10개 도메인에 걸쳐 3,568개 합성 응답으로 테스트한 결과, 소형 모델(TinyLlama 1.1B)이 LoRA + 4비트 양자화로 7B~8B 모델에 근접하는 성능(BLEU 0.090, ROUGE-1 0.429)을 보였다. Nemotron-Personas-Korea의 700만 페르소나를 이 방법론에 적용하면, 한국 사회과학 연구에서 인구통계적으로 대표성 있는 대규모 합성 설문이 가능해진다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.2 Silicon Sampling의 한계와 교차 검증</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Silicon Sampling 연구(arXiv:2507.02919)는 LLM 합성 설문의 구조적 비일관성과 동질화 현상을 경고한다. Population-Aligned Persona 연구(arXiv:2509.10127)에서 심층 페르소나 조건화가 응답 정확도를 최대 <strong>11.6%</strong> 향상시켰으나, WVS(World Values Survey) 교차 검증은 필수적이다. 합성 페르소나 기반 설문의 방법론적 위치는 "대체"가 아닌 "보완"이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.3 구체적 연구 활용 시나리오</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        합성 설문의 방법론적 위치는 "대체"가 아닌 "보완"이다. 비용과 시간이 많이 드는 파일럿 스터디, 기존 설문이 도달하기 어려운 희귀 인구집단 시뮬레이션, 정책 시나리오 사전 테스트에서 합성 페르소나는 독보적 효율을 발휘한다. Nemotron-Personas-Korea가 열어주는 구체적 시나리오를 살펴보면, 그 잠재력과 현재의 한계가 함께 드러난다.
+                    </p>
+
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>한국 고령화 사회 정책 시뮬레이션:</strong> 60대(777만 명), 70대 이상 인구의 행동 패턴을 합성하여 복지 정책의 시나리오별 영향을 사전 시뮬레이션</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>지역 소멸 연구:</strong> 252개 이상의 시군구 수준 지역별 페르소나로 인구 이동과 지역 경제 영향을 시뮬레이션</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>파일럿 스터디 / 희귀 집단 시뮬레이션:</strong> 기존 설문이 도달하기 어려운 소규모 인구집단(특정 직업, 특정 지역)의 사전 탐색</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>한계 &mdash; 다문화 가정:</strong> 현 데이터셋은 한국 국적 기반이므로 이주민/다문화 페르소나가 미포함됨</span>
+                        </li>
+                    </ul>
+                </section>
+
+                <!-- Section 4 -->
+                <section id="section-4" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">04</span>
+                            월드모델과 독자 파운데이션 모델
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        PGM + LLM 하이브리드 파이프라인은 "통계적 정합성 + 자연어 풍부성"을 동시에 달성하는 기술적 혁신이다. 이 접근법이 한국 독자 파운데이션 모델의 학습에서 어떤 역할을 할 수 있는지가 이 섹션의 핵심 질문이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.1 PGM + LLM 파이프라인의 기술적 의의</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        기존의 합성 페르소나 생성은 균일(uniform) 또는 무작위(random) 샘플링에 의존했다. Population-Aligned Persona 연구(arXiv:2509.10127)는 인구 정렬 접근이 균일 샘플링 대비 사회 시뮬레이션 정렬 오차를 <strong>37.9~49.8%</strong> 줄이고, WVS 응답 편차를 <strong>31.7%</strong> 축소함을 정량적으로 입증했다. NeMo Data Designer(NeurIPS 2024 공개, v0.5.0에서 MCP 도구 호출 + HuggingFace Hub 통합)는 이 파이프라인을 산업적으로 재현 가능하게 만든다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.2 Theory of Mind과 Social Reasoning</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        LLM의 Theory of Mind 서베이(arXiv:2502.06470)는 행동적, 표상적 ToM 평가와 안전 위험을 분석한다. 인구통계 기반 페르소나 조건화가 ToM 성능에 미치는 영향은 아직 초기 단계이나, 다양한 사회적 맥락(연령, 지역, 직업)에서의 추론 능력 강화 가능성을 시사한다. Nemotron-4 340B(arXiv:2406.11704)에서 정렬 과정 데이터의 <strong>98%</strong> 이상이 합성으로 구성된 것은, NVIDIA가 합성 데이터 중심 학습을 전면 채택한 맥락을 보여준다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.3 한국 독자 파운데이션 모델과의 연결</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        한국 독자 파운데이션 모델 생태계는 빠르게 성장하고 있으나, 한국어 학습 데이터의 구조적 부족이 공통된 과제다. Polyglot-ko-5.8B의 학습 데이터가 863GB에 불과해 LLaMA-2(2조 토큰)의 1/10 이하 수준이며, 벤치마크 생태계도 KLUE에서 CLIcK(1,995개 한국 문화·언어 QA), KoBALT(700개 MCQ)로 성숙하는 중이다. Nemotron-Personas-Korea는 직접 SFT 데이터가 아닌 페르소나 조건부 대화 생성·에이전트 시뮬레이션·문화 정렬 파인튜닝의 원자재로서 이 간극을 메우는 역할을 한다.
+                    </p>
+
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>HyperCLOVA X THINK:</strong> 6조 한국어+영어 토큰으로 학습, "타겟 합성 한국어 데이터"로 보강</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>EXAONE 4.0(LG AI Research, 30B):</strong> 어휘 크기를 100K에서 150K로 재설계</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>SOLAR Pro 2(Upstage):</strong> Frontier LM 리더보드에서 유일한 한국 모델</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>데이터 간극:</strong> Polyglot-ko-5.8B의 863GB는 LLaMA-2(2조 토큰)의 1/10 이하</span>
+                        </li>
+                    </ul>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Nemotron-Personas-Korea는 이 간극을 메우는 합성 페르소나 자원이다. 직접 SFT보다는 페르소나 조건부 대화 생성, AI 에이전트 시뮬레이션, 문화 정렬 파인튜닝의 기초 자원으로 활용된다. 벤치마크 생태계도 성숙하고 있다. KLUE에서 CLIcK(1,995개 한국 문화/언어 QA, 오픈소스 모델 60% 이상 어려움), KoBALT(700 MCQ, 24개 현상)로 평가 기준이 정교화되고 있다.
+                    </p>
+                </section>
+
+                <!-- Section 5 -->
+                <section id="section-5" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">05</span>
+                            한계와 비판
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        합성 데이터의 편향 전파는 학술적으로 측정 가능한 위험이다. 인구통계 기반 설계는 만능이 아니라 "첫 번째 완화 전략"이며, 독립적 품질 감사가 반드시 수반되어야 한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.1 편향 전파(Fairness Feedback Loops)</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Wyllie et al.(arXiv:2403.07857)은 모델 유도 분포 이동(MIDS)이 합성 데이터 학습 세대를 거듭할수록 편향을 증폭시킴을 실증했다. 초기에 편향이 없는 데이터에서조차 피드백 루프로 소수 집단의 대표성이 상실된다. Nature 2024(Shumailov et al.)는 반복 합성 학습 시 원본 분포의 꼬리(tail)가 소실됨을 이론적으로 증명했다. 별도 연구(arXiv:2404.01413)는 합성으로 원본을 대체하면 모델이 붕괴하지만, 원본과 누적 혼합하면 회피할 수 있음을 보여주었다. 이는 원본 공식 통계(KOSIS 등)의 보존이 필수적임을 의미한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.2 데이터셋 자체의 명시적 한계</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        Nemotron-Personas-Korea 데이터셋 카드에서 직접 확인할 수 있는 한계들이 있다.
+                    </p>
+
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>19세 미만 미포함:</strong> 아동/청소년 관련 AI 에이전트 개발에 활용 불가</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>생물학적 성별만 포함:</strong> 성 정체성, 성적 지향이 미반영</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>독립 가정:</strong> 성별과 전공, 지역과 직업 등 인구통계 변수 간 상호작용 효과가 미모델링</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>기업 특화 미포함:</strong> 금융, 의료 등 산업별 특화 페르소나 없음</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>성격 특성 미포함:</strong> Big Five 등 심리적 특성이 없어 사회 시뮬레이션 정밀도에 제약</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.3 합성-실제 격차와 모델 붕괴</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Silicon Sampling 연구(arXiv:2507.02919)는 구조적 비일관성과 동질화 현상을 경고한다. The Personality Trap(arXiv:2602.03334)에 따르면, LLM이 생성하는 페르소나는 WEIRD 편향을 내재한다. Gemma-4-31B 또한 영어 사전학습 모델이므로 한국어 내러티브 생성 시 잔여 편향이 존재할 수 있다. 완화 전략은 명확하다. 원본 공식 통계를 보존하고 합성 데이터와 혼합 사용하되, 독립적 분포 감사를 통해 피드백 루프를 사전 차단해야 한다.
+                    </p>
+                </section>
+
+                <!-- Section 6: 페블러스 관심의 이유 -->
+                <section id="section-6" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading">
+                        <div class="flex items-center gap-4 mb-8">
+                            <span class="number-badge">06</span>
+                            페블러스가 이 데이터셋에 주목하는 이유
+                        </div>
+                    </h2>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Nemotron-Personas-Korea의 등장은 "합성 데이터의 품질을 누가 검증하는가"라는 질문을 시장에 던진다. NVIDIA가 합성 데이터를 생성하는 세계에서, 생성된 데이터가 실제 인구를 정확히 대표하는지 독립적으로 진단하는 인프라가 필요하다. 이 지점에서 페블러스의 DataClinic과 DataGreenhouse가 자연스럽게 연결된다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.1 DataClinic 진단 시나리오</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        DataClinic의 기존 진단 기능을 Nemotron-Personas-Korea에 적용하면, 합성 페르소나의 인구통계 정합성을 정량적으로 검증할 수 있다. 구체적으로 세 가지 시나리오가 성립한다.
+                    </p>
+
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>클래스별 분포 분석:</strong> 연령, 지역, 직업, 교육수준별로 실제 한국 인구 분포(KOSIS)와 합성 페르소나 분포를 비교하여 과소/과대 대표 영역을 정량적으로 식별</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>밀도 등고선 분석:</strong> 반복 합성 학습 시 꼬리 분포가 소실되는 현상(Nature 2024)을 모니터링하여 모델 붕괴 징후를 조기 탐지</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed"><strong>임베딩 매니폴드 시각화:</strong> 영어 사전학습 모델(Gemma-4-31B)의 잔여 편향이 한국어 페르소나에 문화적 클러스터링 왜곡을 일으키는지 분석</span>
+                        </li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.2 NVIDIA(생성) + 페블러스(진단) 보완 구조</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        이 보완 구조의 학술적 근거는 명확하다. Fairness Feedback Loops 연구(arXiv:2403.07857)는 합성 데이터의 편향 증폭을 실증했고, 이에 대한 완화 전략으로 독립적 분포 감사를 제안한다. DataClinic의 분포 진단은 이 "편향 감사의 자동화"에 해당한다. DataGreenhouse의 Governance Layer는 합성 페르소나 메타데이터(출처 기관, 생성일, PGM 파라미터, 라이선스)를 관리하여 합성 데이터 자산의 거버넌스와 추적(ISO/IEC 5259 + ISO 42001 준수)을 가능하게 한다.
+                    </p>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        PebbloSim의 "Vector-to-Param" 특허(US 12,481,720)는 데이터 공백 좌표를 시뮬레이션 파라미터로 자동 변환한다. 합성 페르소나에서 DataClinic이 발견한 인구통계 공백을 PebbloSim이 정밀 보충하는 Data Flywheel이 가능해지는 것이다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.3 고객/파트너 실무 함의</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        한국 대기업(NAVER, LG, SK, NC 등)이 LLM 내재화를 추진할 때, 한국 인구 특성을 반영한 학습 데이터의 품질 검증 수요가 발생한다. 소버린 LLM 컨소시엄(2,400억 원, 4개 팀)이 합성 데이터를 활용할 때 품질 인증 프로세스가 필요하다. 사회과학 연구팀이 합성 페르소나 시뮬레이션을 실행할 때 분포 검증 파트너가 요구된다. 이 모든 지점에서 "합성 데이터도 품질 진단이 필요하다"는 메시지가 시장에 전달된다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.4 앞으로 탐구할 질문들</h3>
+                    <p class="themeable-text leading-relaxed mb-4">
+                        이 보고서의 분석에서 도출된, 페블러스가 다음 단계에서 탐구해야 할 질문들이 있다.
+                    </p>
+
+                    <ul class="space-y-3 mb-6" style="list-style:none;margin-left:0;">
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed">Nemotron-Personas-Korea를 DataClinic 데모 케이스로 공개하여 "합성 데이터 품질 진단"의 레퍼런스를 구축할 수 있는가?</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed">DataClinic 진단 &rarr; PebbloSim 정밀 생성 &rarr; DataClinic 재진단의 Data Flywheel은 합성 페르소나 영역에서 경쟁자가 복제하기 어려운 구조적 해자를 형성할 수 있는가?</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed">소버린 LLM 컨소시엄의 합성 데이터 활용에서, DataClinic/DataGreenhouse를 데이터 품질 검증 인프라로 포지셔닝할 수 있는 정부/대기업 파트너십 경로는?</span>
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="text-orange-500 mt-1">•</span>
+                            <span class="themeable-text leading-relaxed">합성 데이터 품질 표준이 아직 미확립된 시점에서, 페블러스가 표준 선점에 기여할 수 있는 학술/산업 협력 경로는 무엇인가?</span>
+                        </li>
+                    </ul>
+                </section>
+
+                <!-- FAQ Section -->
+                <section id="faq" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">FAQ</h2>
+                    <!-- PebblousPage.init()이 config.faqs에서 렌더링 -->
+                </section>
+
+                <!-- References -->
+                <section id="references" class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">참고문헌</h2>
+
+                    <div class="text-sm themeable-text leading-relaxed space-y-3">
+                        <p><strong>학술 논문</strong></p>
+                        <ol class="list-decimal ml-6 space-y-2">
+                            <li>Hu et al. (2025). "Population-Aligned Persona Generation for LLM-based Social Simulation." arXiv:2509.10127.</li>
+                            <li>Amidei et al. (2026). "The Personality Trap: How LLMs Embed Bias When Generating Human-Like Personas." arXiv:2602.03334.</li>
+                            <li>Wyllie et al. (2024). "Fairness Feedback Loops: Training on Synthetic Data Amplifies Bias." arXiv:2403.07857.</li>
+                            <li>Ge et al. (2024). "Scaling Synthetic Data Creation with 1,000,000,000 Personas." arXiv:2406.20094.</li>
+                            <li>Parmar et al. (2024). "Nemotron-4 340B Technical Report." arXiv:2406.11704.</li>
+                            <li>Bondarenko et al. (2025). "Sovereign Large Language Models: Benefits, Strategies, and Regulations." arXiv:2503.04745.</li>
+                            <li>Dash et al. (2025). "Polypersona: Persona-Grounded LLM for Synthetic Survey Responses." arXiv:2512.14562.</li>
+                            <li>Shumailov et al. (2024). "AI Models Collapse When Trained on Recursively Generated Data." Nature.</li>
+                            <li>(2025). "Silicon Sampling: Representativeness and Structural Consistency in LLM Surveys." arXiv:2507.02919.</li>
+                            <li>(2025). "Sovereign AI: Rethinking Autonomy in the Age of Foundation Models." arXiv:2511.15734.</li>
+                            <li>Nguyen (2025). "A Survey of Theory of Mind in Large Language Models." arXiv:2502.06470.</li>
+                            <li>Su et al. (2024). "Nemotron-CC: Transforming Common Crawl into a Refined LLM-Training Dataset." arXiv:2412.02595.</li>
+                            <li>Kim et al. (2024). "CLIcK: Cultural and Linguistic Intelligence in Korean." arXiv:2403.06412.</li>
+                            <li>(2025). "KoBALT: Korean Benchmark for Advanced Linguistic Tasks." arXiv:2505.16125.</li>
+                            <li>(2025). "DeepPersona: A Generative Engine for Scaling Deep Synthetic Personas." arXiv:2511.07338.</li>
+                            <li>(2024). "Is Model Collapse Inevitable? Breaking the Curse of Recursion by Accumulating Real and Synthetic Data." arXiv:2404.01413.</li>
+                        </ol>
+
+                        <p class="mt-6"><strong>업계 출처</strong></p>
+                        <ol class="list-decimal ml-6 space-y-2" start="17">
+                            <li>HuggingFace Dataset Card: <a href="https://huggingface.co/datasets/nvidia/Nemotron-Personas-Korea" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400 transition-colors">nvidia/Nemotron-Personas-Korea</a></li>
+                            <li>HuggingFace Blog: "How to Ground a Korean AI Agent in Real Demographics" (NVIDIA)</li>
+                            <li>NVIDIA Newsroom: South Korea AI Infrastructure &mdash; 250K+ GPU 배치 계획 (2025.10)</li>
+                            <li>NVIDIA AI on X: Nemotron-Personas-Korea 트렌딩 1위 확인</li>
+                            <li>아시아경제: Nemotron Developer Days Seoul 보도 (2026.04.21)</li>
+                        </ol>
+
+                        <p class="mt-6"><strong>시장/정책 데이터</strong></p>
+                        <ol class="list-decimal ml-6 space-y-2" start="22">
+                            <li>행정안전부: 주민등록 인구통계 &mdash; 51,801,449명 (2024.08)</li>
+                            <li>OECD: Education at a Glance 2023 &mdash; 한국 고등교육 이수율 54.5% (OECD 1위)</li>
+                            <li>Korea Herald / Bloomberg: 한국 AI 관련 예산 10.1조 원 (2026)</li>
+                            <li>Fortune Business Insights / Mordor Intelligence: 합성 데이터 시장 $5.1억~$6.0억 (2025)</li>
+                            <li>GrandView Research / ResearchAndMarkets: 합성 데이터 시장 $17.9억~$37억 (2030~31, CAGR 31~39%)</li>
+                        </ol>
+                    </div>
+                </section>
+
+            </main>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div id="footer-placeholder"></div>
+
+    <!-- Scripts -->
+    <script src="/scripts/common-utils.js?v=20260426"></script>
+    <script>
+        PebblousPage.init({
+            mainTitle: "Nemotron-Personas-Korea \u2014 \ud55c\uad6d AI \uc790\ub9bd\uc758 \ucd9c\ubc1c\uc810",
+            subtitle: "\uc2e4\uc81c \uc778\uad6c\ud1b5\uacc4 \uae30\ubc18 \ud569\uc131 \ud398\ub974\uc18c\ub098\uac00 \uc18c\ubc84\ub9b0 LLM\uc758 \ud1a0\ub300\uac00 \ub418\ub294 \uc774\uc720",
+            pageTitle: "Nemotron-Personas-Korea \u2014 \ud55c\uad6d AI \uc790\ub9bd\uc758 \ucd9c\ubc1c\uc810 | \ud398\ube14\ub7ec\uc2a4",
+            category: "tech",
+            publishDate: "2026-04-26",
+            publisher: "(\uc8fc)\ud398\ube14\ub7ec\uc2a4 \ub370\uc774\ud130 \ucee4\ubba4\ub2c8\ucf00\uc774\uc158\ud300",
+            defaultTheme: "light",
+            articlePath: "report/nemotron-personas-korea-2026-04/ko/",
+            tags: ["Nemotron-Personas-Korea", "\ud569\uc131 \ub370\uc774\ud130", "\uc18c\ubc84\ub9b0 AI", "NVIDIA", "\ud398\ub974\uc18c\ub098", "\ud55c\uad6d AI", "\uc778\uad6c\ud1b5\uacc4", "DataClinic", "AI-Ready Data", "\ud5c8\uae45\ud398\uc774\uc2a4", "\uc0ac\ud68c\uacfc\ud559", "\uc6d4\ub4dc\ubaa8\ub378"],
+            faqs: [
+                { question: "\uae30\uc874 \ud55c\uad6d\uc5b4 \ub370\uc774\ud130\uc14b(KoAlpaca, KULLM \ub4f1)\uacfc \uc5b4\ub5bb\uac8c \ub2e4\ub978\uac00\uc694?", answer: "\uae30\uc874 \ub370\uc774\ud130\uc14b\uc740 \uc601\uc5b4 \ubc88\uc5ed \uae30\ubc18 \uba85\ub839\uc5b4 \ub370\uc774\ud130\uc774\uace0, Nemotron-Personas-Korea\ub294 \ud55c\uad6d \uacf5\uc2dd \ud1b5\uacc4(KOSIS, \ub300\ubc95\uc6d0)\uc5d0\uc11c \ucd9c\ubc1c\ud55c \ub124\uc774\ud2f0\ube0c \ud55c\uad6d\uc5b4 \ud398\ub974\uc18c\ub098 \ub370\uc774\ud130\uc14b\uc785\ub2c8\ub2e4. 26\uac1c \uad6c\uc870\ud654 \ud544\ub4dc, 700\ub9cc \ud398\ub974\uc18c\ub098 \uaddc\ubaa8\ub85c \uc778\uad6c\ud1b5\uacc4 \uc815\ud569\uc131\uc744 \uac16\ucd98 \ucd5c\ucd08\uc758 \ud55c\uad6d\uc5b4 \uc790\uc6d0\uc785\ub2c8\ub2e4. KoAlpaca/KULLM\uc740 SFT\uc6a9 \uba85\ub839\uc5b4 \ub370\uc774\ud130\uc774\uace0, Nemotron-Personas-Korea\ub294 \uc5d0\uc774\uc804\ud2b8 \uc2dc\ubbac\ub808\uc774\uc158\uacfc \ubb38\ud654 \uc815\ub82c \ud30c\uc778\ud29c\ub2dd\uc758 \uae30\ucd08 \uc790\uc6d0\uc73c\ub85c, \uc11c\ub85c \ubcf4\uc644 \uad00\uacc4\uc785\ub2c8\ub2e4." },
+                { question: "\ud569\uc131 \ud398\ub974\uc18c\ub098\uac00 \uc2e4\uc81c \ud55c\uad6d \uc778\uad6c\ub97c \uc5bc\ub9c8\ub098 \uc815\ud655\ud788 \ubc18\uc601\ud558\ub098\uc694?", answer: "17\uac1c \uc2dc\ub3c4, 252\uac1c \uc774\uc0c1 \uc2dc\uad70\uad6c, 2,000\uac1c \uc774\uc0c1 \uc9c1\uc5c5, 7\ub2e8\uacc4 \uad50\uc721\uc218\uc900 \ub4f1 \ud55c\uad6d \uacf5\uc2dd \ud1b5\uacc4\uc758 \ubd84\ud3ec\ub97c PGM(\ud655\ub960 \uadf8\ub798\ud504 \ubaa8\ub378)\uc774 \uc0d8\ud50c\ub9c1\ud569\ub2c8\ub2e4. \ub2e4\ub9cc \uc778\uad6c\ud1b5\uacc4 \ubcc0\uc218 \uac04 \ub3c5\ub9bd \uac00\uc815(\uc131\ubcc4\u00d7\uc804\uacf5 \uc0c1\ud638\uc791\uc6a9 \ubbf8\ubc18\uc601), 19\uc138 \ubbf8\ub9cc \ubbf8\ud3ec\ud568, \uc131 \uc815\uccb4\uc131 \ubbf8\ubc18\uc601 \ub4f1\uc758 \ud55c\uacc4\uac00 \uc788\uc2b5\ub2c8\ub2e4. Population-Aligned Persona \uc5f0\uad6c(arXiv:2509.10127)\uc5d0\uc11c \uc815\ub82c \uc624\ucc28 37.9~49.8% \uac10\uc18c\uac00 \uc2e4\uc99d\ub41c \ubc14 \uc788\uc2b5\ub2c8\ub2e4." },
+                { question: "\uc774 \ub370\uc774\ud130\uc14b\uc73c\ub85c \ud55c\uad6d\uc5b4 LLM\uc744 \ud30c\uc778\ud29c\ub2dd\ud558\uba74 \uc5b4\ub5a4 \ud6a8\uacfc\uac00 \uc788\ub098\uc694?", answer: "\ud398\ub974\uc18c\ub098 \ub370\uc774\ud130\uc14b\uc774\ubbc0\ub85c \uc9c1\uc811 SFT\uc5d0 \uc0ac\uc6a9\ud558\uae30\ubcf4\ub2e4, \ud398\ub974\uc18c\ub098 \uc870\uac74\ubd80 \ub300\ud654 \uc0dd\uc131, AI \uc5d0\uc774\uc804\ud2b8 \uc2dc\ubbac\ub808\uc774\uc158, \ubb38\ud654 \uc815\ub82c \ud30c\uc778\ud29c\ub2dd\uc758 \uae30\ucd08 \uc790\uc6d0\uc73c\ub85c \ud65c\uc6a9\ub429\ub2c8\ub2e4. \ud6c4\uc18d \ubcc0\ud658 \ud30c\uc774\ud504\ub77c\uc778(\ud398\ub974\uc18c\ub098 \u2192 \ub300\ud654/\uba85\ub839\uc5b4)\uc774 \ud544\uc694\ud569\ub2c8\ub2e4. Nemotron-4 340B\uc758 \uc815\ub82c \ub370\uc774\ud130 98%+ \ud569\uc131 \uc0ac\ub840\ucc98\ub7fc, \ud55c\uad6d \uc778\uad6c \ud2b9\uc131\uc744 \ubc18\uc601\ud55c \ud569\uc131 \ub370\uc774\ud130\ub85c \ubaa8\ub378\uc758 \ubb38\ud654\uc801 \ub300\ud45c\uc131\uc744 \ud655\ubcf4\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4." },
+                { question: "\ud569\uc131 \ub370\uc774\ud130\uc5d0\uc11c \uac1c\uc778\uc815\ubcf4 \uc720\ucd9c \uc704\ud5d8\uc740 \uc5c6\ub098\uc694?", answer: "\ub370\uc774\ud130\uc14b\uc740 PII(\uac1c\uc778\uc2dd\ubcc4\uc815\ubcf4) \uc81c\ub85c \uc124\uacc4\ub85c PIPA(\uac1c\uc778\uc815\ubcf4\ubcf4\ud638\ubc95)\ub97c \uc900\uc218\ud569\ub2c8\ub2e4. \ubaa8\ub4e0 \uc774\ub984, \uc8fc\uc18c, \uc18d\uc131\uc740 \ud1b5\uacc4\uc801 \ubd84\ud3ec\uc5d0\uc11c \ud569\uc131\ub41c \uac83\uc774\uba70, \uc2e4\uc81c \uac1c\uc778\uacfc \ub300\uc751\ub418\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ub2e4\ub9cc \ud559\uc220 \uc5f0\uad6c(arXiv:2403.07857)\uc5d0\uc11c \ud569\uc131 \ub370\uc774\ud130\uc758 \ud3b8\ud5a5 \uc99d\ud3ed(MIDS) \uc704\ud5d8\uc774 \uc785\uc99d\ub41c \ub9cc\ud07c, \ub3c5\ub9bd\uc801 \ubd84\ud3ec \uac10\uc0ac\ub97c \ud1b5\ud55c \uc9c0\uc18d\uc801 \ubaa8\ub2c8\ud130\ub9c1\uc774 \ud544\uc218\uc785\ub2c8\ub2e4." },
+                { question: "\uc18c\ubc84\ub9b0 AI(Sovereign LLM)\ub780 \uc815\ud655\ud788 \ubb34\uc5c7\uc774\uace0 \uc654 \ud55c\uad6d\uc5d0 \ud544\uc694\ud55c\uac00\uc694?", answer: "\uc18c\ubc84\ub9b0 AI\ub294 \ud575\uc2ec AI \uad6c\uc131\uc694\uc18c(\ub370\uc774\ud130, \ubaa8\ub378, \uc778\ud504\ub77c)\uc5d0 \ub300\ud55c \uad6d\uac00 \ud1b5\uc81c\uad8c \ud655\ubcf4\ub97c \uc758\ubbf8\ud569\ub2c8\ub2e4(arXiv:2511.15734). \ud55c\uad6d\uc740 AI \uae30\ubcf8\ubc95 \uc2dc\ud589(2026.01), \uc18c\ubc84\ub9b0 LLM 4\uac1c \ucee8\uc18c\uc2dc\uc5c4(2,400\uc5b5 \uc6d0), 10.1\uc870 \uc6d0 \uc608\uc0b0, $735B \ucd1d \ud22c\uc790\ub85c \uc801\uadf9 \ucd94\uc9c4 \uc911\uc785\ub2c8\ub2e4. \ud55c\uad6d\uc5b4 \ud559\uc2b5 \ub370\uc774\ud130\uac00 \uc601\uc5b4\uc758 1/10 \uc774\ud558\uc778 \uc0c1\ud669\uc5d0\uc11c, \uc778\uad6c\ud1b5\uacc4 \uae30\ubc18 \ud569\uc131 \ud398\ub974\uc18c\ub098\ub294 \ub370\uc774\ud130 \uc790\ub9bd\uc758 \uccab \ubc88\uc9f8 \uad6c\uccb4\uc801 \uc131\uacfc\ubb3c\uc785\ub2c8\ub2e4." },
+                { question: "\uc0ac\ud68c\uacfc\ud559 \uc5f0\uad6c\uc5d0\uc11c \ud569\uc131 \ud398\ub974\uc18c\ub098\ub97c \uc124\ubb38 \ub300\uc0c1\uc73c\ub85c \uc4f8 \uc218 \uc788\ub098\uc694?", answer: "Polypersona(arXiv:2512.14562) \ub4f1 \ubc29\ubc95\ub860\uc774 \ubc1c\uc804\ud558\uace0 \uc788\uc73c\ub098, \uad6c\uc870\uc801 \ube44\uc77c\uad00\uc131\uacfc \ub3d9\uc9c8\ud654 \ud604\uc0c1(arXiv:2507.02919)\uc774 \uacbd\uace0\ub429\ub2c8\ub2e4. '\ub300\uccb4'\uac00 \uc544\ub2cc '\ubcf4\uc644'\uc73c\ub85c \ud65c\uc6a9\ud574\uc57c \ud569\ub2c8\ub2e4. \ud30c\uc77c\ub7ff \uc2a4\ud130\ub514, \ud76c\uadc0 \uc778\uad6c\uc9d1\ub2e8 \uc2dc\ubbac\ub808\uc774\uc158, \uc815\ucc45 \uc2dc\ub098\ub9ac\uc624 \ud14c\uc2a4\ud2b8\uc5d0 \ud6a8\uacfc\uc801\uc774\uba70, \uc2e4\uc81c \uc124\ubb38\uacfc\uc758 \uad50\ucc28 \uac80\uc99d(WVS \ub4f1)\uc774 \ud544\uc218\uc785\ub2c8\ub2e4." },
+                { question: "CC BY 4.0 \ub77c\uc774\uc120\uc2a4\ub85c \uc0c1\uc5c5\uc801 \ud65c\uc6a9\uc774 \uac00\ub2a5\ud55c\uac00\uc694?", answer: "\uac00\ub2a5\ud569\ub2c8\ub2e4. \uc800\uc791\uc790 \ud45c\uc2dc\ub9cc \ud558\uba74 \uc0c1\uc5c5\uc801 \uc0ac\uc6a9, \uc218\uc815, \uc7ac\ubc30\ud3ec\uac00 \uc790\uc720\ub86d\uc2b5\ub2c8\ub2e4. PersonaHub(CC BY-NC-SA 4.0)\uc758 \ube44\uc0c1\uc5c5 \uc81c\ud55c\uacfc \ub300\ube44\ub429\ub2c8\ub2e4. \ud55c\uad6d \ub300\uae30\uc5c5\uc758 LLM \ub0b4\uc7ac\ud654, \uc2a4\ud0c0\ud2b8\uc5c5\uc758 AI \uc5d0\uc774\uc804\ud2b8 \uac1c\ubc1c, \uc5f0\uad6c\uae30\uad00\uc758 \ud559\uc220 \ud65c\uc6a9 \ubaa8\ub450\uc5d0\uc11c \uc81c\uc57d \uc5c6\uc774 \ud65c\uc6a9 \uac00\ub2a5\ud569\ub2c8\ub2e4." },
+                { question: "DataClinic\uc73c\ub85c \ud569\uc131 \ub370\uc774\ud130\uc758 \ud488\uc9c8\uc744 \uc5b4\ub5bb\uac8c \uc9c4\ub2e8\ud558\ub098\uc694?", answer: "\ud074\ub798\uc2a4\ubcc4 \ubd84\ud3ec \ubd84\uc11d(\uc5f0\ub839, \uc9c0\uc5ed, \uc9c1\uc5c5)\uc73c\ub85c \uc2e4\uc81c \uc778\uad6c \ub300\ube44 \uacfc\uc18c/\uacfc\ub300 \ub300\ud45c \uc601\uc5ed\uc744 \uc2dd\ubcc4\ud558\uace0, \ubc00\ub3c4 \ub4f1\uace0\uc120\uc73c\ub85c \uaf2c\ub9ac \ubd84\ud3ec \uc18c\uc2e4 \uc5ec\ubd80\ub97c \ubaa8\ub2c8\ud130\ub9c1\ud558\uba70, \uc784\ubca0\ub529 \ub9e4\ub2c8\ud3f4\ub4dc\ub85c \ubb38\ud654\uc801 \ud074\ub7ec\uc2a4\ud130\ub9c1 \ud328\ud134\uc744 \ubd84\uc11d\ud569\ub2c8\ub2e4. \ud3b8\ud5a5 \ud53c\ub4dc\ubc31 \ub8e8\ud504(arXiv:2403.07857)\uc758 \uc870\uae30 \ud0d0\uc9c0\uc640, PebbloSim\uc744 \ud1b5\ud55c \uc778\uad6c\ud1b5\uacc4 \uacf5\ubc31 \ubcf4\ucda9\uc73c\ub85c \uc774\uc5b4\uc9c0\ub294 Data Flywheel \uad6c\uc870\uac00 \uac00\ub2a5\ud569\ub2c8\ub2e4." }
+            ]
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 개요

NVIDIA 김현우 박사의 **Nemotron-Personas-Korea**(허깅페이스 전체 트렌딩 1위) 심층조사 보고서 KO 버전 초안.

**핵심 프레이밍**: 한국 AI 자립의 출발점 — 실제 인구통계 기반 합성 페르소나가 소버린 LLM의 토대가 되는 이유

## 파일

- `report/nemotron-personas-korea-2026-04/ko/index.html` (588줄)

## 콘텐츠 구성

| 섹션 | 내용 |
|------|------|
| Executive Summary | 4-card 스탯 그리드 (700만/26개/49.8%/$735B) |
| 01 | 데이터셋 구성 + PGM+LLM 파이프라인 + HF 1위 원인 분석 |
| 02 | 소버린 AI 학술 재정의 + WEIRD 편향 대비 + 데이터 자립 삼각구조 |
| 03 | Polypersona 방법론 + Silicon Sampling 한계 + 연구 활용 시나리오 |
| 04 | PGM+LLM 기술적 의의 + ToM + 한국 파운데이션 모델 연결 |
| 05 | 편향 전파 + 데이터셋 한계 + Synthetic-Real Gap |
| 06 | DataClinic/DataGreenhouse/PebbloSim 3제품 연결 + Data Flywheel |
| FAQ | 8개 |
| References | 26개 (논문 16 + 업계/정책 10) |

## 검증

- ✅ DOMContentLoaded: 0
- ✅ share-buttons.js: 0
- ✅ H1 빈값 (PebblousPage.init() 처리)
- ✅ FAQ 8개
- ✅ x-default → EN URL
- ✅ og:image → ko/image/index.png
- ✅ text-reinforce 완료 (스탯카드 전환, 3.3/4.3 보강)

## 미완료 (머지 후 진행)

- [ ] EN 로컬라이제이션
- [ ] OG 이미지
- [ ] articles.json 등록
- [ ] SEO 검증

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)