### PR TITLE
fix: EN OG 이미지 경로 수정 + 3레이어 재발 방지

### DIFF
--- a/.claude/skills/bilingual/SKILL.md
+++ b/.claude/skills/bilingual/SKILL.md
@@ -157,6 +157,10 @@ If the original post does not have an Executive Summary section, add one to both
 - Check all relative paths resolve correctly (CSS, JS, images, PDFs)
 - Verify hreflang tags match between KO and EN versions
 - **CRITICAL**: Confirm PebblousPage.init config includes `mainTitle` and `subtitle` in BOTH versions — these are REQUIRED for Hero h1 rendering, breadcrumbs, Article Schema, and TOC alignment. If the original post was missing them, add them now.
+- **⛔ EN OG 이미지 경로 검증 (MUST)**: EN HTML 생성 후 반드시 아래 명령 실행. 출력이 있으면 `/ko/image/`를 `/en/image/`로 수정한다.
+  ```bash
+  grep -n "/ko/image/" [EN HTML 파일]  # → 0줄이어야 함
+  ```
 
 ### 10. Post-Task Chain (MUST follow after completion)
 1. **`/seo-check`** on both KO and EN versions — verify hreflang, canonical, OG tags

--- a/.claude/skills/blog-write/skill.md
+++ b/.claude/skills/blog-write/skill.md
@@ -243,4 +243,12 @@ grep -n '<li>•\|<li> •' <파일>.html
 # 결과가 있으면 해당 <ul>에 list-style:none 추가
 ```
 
+### ⛔ EN OG 이미지 경로 검증 (bilingual 작성 시)
+
+EN HTML을 KO에서 복사하여 만들 때, og:image/twitter:image 경로가 `/ko/image/`로 남는 실수가 반복된다.
+EN HTML 생성 후 반드시 실행:
+```bash
+grep -n "/ko/image/" [EN HTML 파일]  # → 0줄이어야 함. 있으면 /en/image/로 수정
+```
+
 상세 HTML 전체 구조 → `references/html-conventions.md`

--- a/.claude/skills/seo-check/SKILL.md
+++ b/.claude/skills/seo-check/SKILL.md
@@ -34,6 +34,7 @@ When this skill is invoked:
    - `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`
    - OG image dimensions (1200x630 recommended)
    - **OG image file exists**: Extract the path from `og:image` content, convert the URL to a local file path (e.g., `https://blog.pebblous.ai/story/.../image/index.png` → `story/.../image/index.png`), and verify the file exists on disk. FAIL if the file is missing — the image will be a broken link on social media shares.
+   - **⛔ EN 페이지 OG 이미지 언어 불일치 검증**: `<html lang="en">` 페이지에서 `og:image` 또는 `twitter:image` 경로에 `/ko/image/`가 포함되어 있으면 **CRITICAL FAIL**: "EN 페이지가 KO OG 이미지를 참조 — SNS 공유 시 한글 이미지 노출. `/en/image/`로 수정 필요." (원인: KO 복사 후 경로 미변경)
 
    **Layer 3 — JSON-LD Schema**:
    - BreadcrumbList (auto via PebblousPage — verify config)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Pebblous Blog pre-commit hook
+# EN HTML 페이지에서 KO OG 이미지 경로 참조 방지
+
+# staged된 EN HTML 파일에서 /ko/image/ 참조 검사
+files=$(git diff --cached --name-only --diff-filter=ACM | grep '/en/index\.html$')
+
+if [ -z "$files" ]; then
+    exit 0
+fi
+
+errors=""
+for f in $files; do
+    matches=$(git diff --cached -- "$f" | grep '^\+' | grep -v '^\+\+\+' | grep '/ko/image/')
+    if [ -n "$matches" ]; then
+        errors="$errors\n  $f"
+    fi
+done
+
+if [ -n "$errors" ]; then
+    echo ""
+    echo "⛔ EN OG image path error detected!"
+    echo "   The following EN files reference /ko/image/ (should be /en/image/):"
+    echo "$errors"
+    echo ""
+    echo "   Fix: change /ko/image/ to /en/image/ in og:image and twitter:image tags"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/report/openmetadata-ai-ready-data-2026-04/en/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/en/index.html
@@ -24,7 +24,7 @@
     <meta property="og:title" content="OpenMetadata Completes the AI Ready Data Stack">
     <meta property="og:description" content="GitHub Trending #1 — How OpenMetadata's ontology-based metadata governance anchors the AI Ready Data pipeline. A neuro-symbolic analysis.">
     <meta property="og:url" content="https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/">
-    <meta property="og:image" content="https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/image/index.png">
+    <meta property="og:image" content="https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/image/index.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="OpenMetadata Completes the AI Ready Data Stack — Report">
@@ -37,7 +37,7 @@
     <meta name="twitter:creator" content="@pebblous_ai">
     <meta name="twitter:title" content="OpenMetadata Completes the AI Ready Data Stack">
     <meta name="twitter:description" content="GitHub Trending #1 — How OpenMetadata's ontology-based metadata governance anchors the AI Ready Data pipeline. A neuro-symbolic analysis.">
-    <meta name="twitter:image" content="https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/image/index.png">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/image/index.png">
     <meta name="twitter:image:alt" content="OpenMetadata Completes the AI Ready Data Stack — Report">
 
     <!-- Favicon -->
@@ -68,7 +68,7 @@
       "dateModified": "2026-04-26",
       "author": { "@type": "Organization", "name": "Pebblous Data Communication Team" },
       "publisher": { "@type": "Organization", "name": "Pebblous", "url": "https://blog.pebblous.ai" },
-      "image": "https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/image/index.png",
+      "image": "https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/image/index.png",
       "url": "https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/",
       "inLanguage": "en",
       "keywords": ["OpenMetadata", "metadata governance", "AI Ready Data", "neuro-symbolic", "data catalog"]


### PR DESCRIPTION
## Summary
- OpenMetadata EN 페이지의 og:image/twitter:image/JSON-LD image가 `/ko/image/`를 참조하여 SNS 공유 시 한글 OG 이미지가 노출되던 문제 수정
- 3레이어 재발 방지책 적용:
  - **스킬 체크**: bilingual, blog-write 스킬에 EN 생성 후 `grep` 검증 단계 추가
  - **seo-check**: EN 페이지에서 `/ko/image/` 참조 시 CRITICAL FAIL 규칙 추가
  - **pre-commit hook**: EN HTML 커밋 시 `/ko/image/` 경로 자동 차단 (`hooks/pre-commit`)

## Test plan
- [ ] EN 페이지 OG 이미지가 영문으로 표시되는지 확인
- [ ] `grep -rn "/ko/image/" report/openmetadata-ai-ready-data-2026-04/en/index.html` 결과 0줄

🤖 Generated with [Claude Code](https://claude.com/claude-code)