### PR TITLE
feat: h3 서브섹션 번호 배지 (.sub-number-badge)

### DIFF
--- a/report/openmetadata-ai-ready-data-2026-04/en/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/en/index.html
@@ -149,17 +149,17 @@
                         In April 2026, OpenMetadata claimed the #1 spot on GitHub Trending globally. A single day saw <strong>1,962 new stars</strong>, bringing the total to <strong>13,535</strong> — surpassing LinkedIn-originated DataHub (<strong>11,844</strong> stars), despite launching three years later. Behind this surge: four sequential milestone events over six months that compounded into a structural narrative shift.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.1 The Six-Month Momentum Cascade</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>The Six-Month Momentum Cascade</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         In February 2026, the <strong>1.12 release</strong> shipped the Metadata AI SDK and an MCP (Model Context Protocol) server. That same month, OpenMetadata joined the <strong>OSI (Open Semantic Interchange)</strong> standard. In March, it joined the <strong>Linux Foundation</strong>. April brought OpenMetadata Standards v1.13. Each event was a technical milestone in isolation; together they crystallized a narrative: <em>metadata catalogs are becoming the semantic layer for AI agents</em>. The developer community heard it clearly.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.2 The MCP Server — Metadata as an AI Agent Tool</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>The MCP Server — Metadata as an AI Agent Tool</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         The MCP server exposes OpenMetadata's entire catalog as LLM-callable tools. AI agents can perform semantic search, lineage traversal, impact analysis, and data quality tests via the <code>/mcp</code> endpoint — in natural language. With adapters for LangChain and OpenAI Function Calling, any agent framework can now treat a metadata catalog as a first-class tool. This is what ignited developer imagination.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.3 Project Health Metrics</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.3</span>Project Health Metrics</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         Stars alone do not tell the full story. OpenMetadata's issue resolution rate stands at <strong>94.7%</strong>, with a median PR merge time of <strong>0.9 hours</strong> — among the highest for any open-source data infrastructure project. DataHub leads in Forks (3,457 vs OpenMetadata's lower count), but that reflects DataHub's three-year head start and deeper enterprise customization history.
                     </p>
@@ -233,7 +233,7 @@
                         At the technical core of OpenMetadata sit three interlocking layers: <strong>700+ JSON Schema definitions</strong>, an <strong>RDF-OWL ontology</strong>, and <strong>SHACL (Shapes Constraint Language)</strong> validation. Together they form a knowledge graph — not just schema definitions but a semantic map of how data assets relate to each other. When column-level lineage is overlaid with a business glossary, the result is a complete semantic atlas of your organization's data.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.1 Metadata Through a Neuro-Symbolic Lens</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>Metadata Through a Neuro-Symbolic Lens</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         Pure neural approaches (embedding-based semantic search) excel at finding similarities but cannot enforce domain rules and constraints. Pure symbolic approaches (rule-based validation) are rigorous but inflexible. OpenMetadata combines both. The ontology (Symbolic) structures domain knowledge; the Metadata AI SDK's embeddings (Neural) power similarity search and discovery.
                     </p>
@@ -247,7 +247,7 @@
                         </p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.2 SHACL — From Schema Validation to a Data Quality Standard</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>SHACL — From Schema Validation to a Data Quality Standard</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         VLDB 2024's Re-SHACL proved the efficient integration of SHACL and ontology reasoning. CEUR-WS Vol-4093 mapped <strong>69 data quality (DQ) metrics</strong> to SHACL shapes, showing that SHACL can evolve from a schema validation mechanism into the next-generation standard for data quality assessment. OpenMetadata's SHACL adoption reflects a design philosophy: guarantee data quality at the metadata layer itself, not downstream.
                     </p>
@@ -270,12 +270,12 @@
                         Gartner warns that <strong>60%</strong> of AI projects will fail by 2026 due to lack of AI-ready data. The root causes: <strong>63%</strong> of organizations have no AI-specific data management practices, and only <strong>11%</strong> have reached high metadata management maturity. Poor data quality costs the average organization <strong>$12.9M per year</strong> (Gartner). The stakes could not be higher.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.1 Defining "AI Ready Data"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>Defining "AI Ready Data"</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         AI Ready Data means data with guaranteed quality, structure, and context that enables AI models to learn and reason effectively. The ACM Computing Surveys (2024) Data Readiness for AI (DRAI) survey standardized a step-by-step framework from raw data to AI-ready state, defining "Data Readiness Levels" that map the progression from raw to production-ready AI training data.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.2 A Four-Stage Pipeline Blueprint</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>A Four-Stage Pipeline Blueprint</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         The following pipeline maps a concrete path from raw data to AI-ready. Each stage corresponds to a Data Readiness Level, and each handoff is designed to be observable, auditable, and measurable.
                     </p>
@@ -329,7 +329,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.3 The Causal Path: Data Quality → ML Performance</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>The Causal Path: Data Quality → ML Performance</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         Does this pipeline translate to measurable results? The evidence is accumulating. The End-to-End DQ Framework (arXiv:2512.19723) demonstrated a <strong>12% improvement in ML model performance</strong> from data quality integration in a real-world steel manufacturing process. Gartner reports that successful AI organizations invest <strong>up to 4x more</strong> in data quality, governance, and talent (April 2026). The causal chain — "metadata governance → data quality → ML performance" — is validated from both academic and practitioner perspectives.
                     </p>
@@ -386,7 +386,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.1 Lessons from Real-World Adoption</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>Lessons from Real-World Adoption</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         <strong>Gorgias</strong> (customer support platform) centralized <strong>45,000+</strong> data assets through OpenMetadata, dramatically reducing time-to-discovery for its data team. <strong>Thndr</strong> (Egyptian fintech, 6-person data team) automated PII classification for 3M+ user accounts and achieved enterprise-grade governance with a lean team.
                     </p>
@@ -408,7 +408,7 @@
                         The data catalog market is projected to grow from <strong>USD 1.06B (2024)</strong> to <strong>4.54B (2032)</strong>, CAGR <strong>19.9–24.4%</strong> (Fortune Business Insights). The broader metadata management tools market stands at <strong>USD 11.69B (2024)</strong> (Grand View Research). AI governance accelerates fastest at <strong>CAGR 45.3%</strong> (2024–2029, MarketsandMarkets). With <strong>86%</strong> of enterprises planning to expand data management investment in 2026, and <strong>98%</strong> planning governance budget increases (average +24%), the sector has graduated from "nice-to-have" to "mandatory infrastructure."
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.1 The Three-Axis Competitive Realignment</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>The Three-Axis Competitive Realignment</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         The market split along three axes — open-source (OpenMetadata, DataHub), commercial SaaS (Atlan, Collibra, Alation), and cloud-native (Unity Catalog, Polaris, Knowledge Catalog) — is now being reorganized around a single dimension: <strong>AI governance strategy</strong>.
                     </p>
@@ -428,7 +428,7 @@
                         </li>
                     </ul>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.2 Convergence on Open Standards</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>Convergence on Open Standards</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OSI (Open Semantic Interchange), ODCS (Open Data Contract Standard), and Iceberg REST are converging as vendor-neutral infrastructure. Snowflake's OSI adoption, dbt Coalesce 2025's "Context as Infrastructure" declaration, and Google's Dataplex → Knowledge Catalog rebrand all accelerate this convergence. The return of Gartner's Magic Quadrant for Metadata Management — after a five-year hiatus — signals that this category has been officially re-recognized as enterprise core infrastructure.
                     </p>
@@ -451,7 +451,7 @@
                         OpenMetadata's rise intersects directly with Pebblous's AI Ready Data vision. Two angles illuminate this connection.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.1 Technical Mapping: OpenMetadata Ontology ↔ DataGreenhouse Symbolic Layer</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>Technical Mapping: OpenMetadata Ontology ↔ DataGreenhouse Symbolic Layer</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OpenMetadata's RDF class hierarchy (om:Service &rarr; dcat:DataService) and SHACL shapes map directly to the Symbolic (ontology) component of DataGreenhouse's Observation Layer within its five-tier architecture. Concretely: the metadata that OpenMetadata's <strong>84+ connectors</strong> harvest from Snowflake, Databricks, and Kafka becomes the input consumed by DataGreenhouse's Platform Adapter Layer. OpenMetadata builds the map; DataGreenhouse runs the <strong>Observe → Orchestrate → Act → Govern</strong> loop on top of that map.
                     </p>
@@ -459,7 +459,7 @@
                         The three-layer ontology framework proposed in arXiv:2604.00555 (domain / task / workflow ontologies) provides direct academic grounding for using OpenMetadata's ontology as the Symbolic Layer in DataGreenhouse. The domain-specific ontology grounding effect demonstrated across 600 experiments suggests that industry-vertical customers (manufacturing, healthcare, finance) can achieve outcomes that general-purpose tools cannot replicate.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.2 The Quality Cascade: OpenMetadata → DataClinic</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>The Quality Cascade: OpenMetadata → DataClinic</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         For DataClinic to run a precise dataset diagnosis, it needs context: where this data came from, what transformations it underwent, and who owns it. OpenMetadata's native data profiling (distribution, uniqueness, completeness) provides metadata context to DataClinic's dual-embedding analysis. Column-level lineage traces quality issues back to their upstream transformation origins. SHACL shapes define quality gates that fire before any DataClinic diagnostic run.
                     </p>
@@ -467,12 +467,12 @@
                         With a <strong>12% ML performance improvement</strong> proven from data quality integration (arXiv:2512.19723), the cascade — metadata governance → DataClinic diagnosis → PebbloSim synthetic data generation — translates to measurable outcomes. A Hyundai Motor validation demonstrated weld defect detection rising from <strong>50% to 97–99%</strong>, defect rate dropping from <strong>16 PPM to 3.4 PPM</strong>, with an ROI of <strong>8,150%</strong> (1.8-month payback). That is the ceiling of this pipeline's potential.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.3 GTM Path: A Value Layer Above Free Infrastructure</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.3</span>GTM Path: A Value Layer Above Free Infrastructure</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OpenMetadata (Apache-2.0, free) is the lowest-friction entry point for metadata governance in the enterprise. Building DataGreenhouse (paid data operating system) on top positions it as a complement, not a competitor. With no documented solution combining diagnosis, synthesis, and operations in a single platform, Pebblous's <strong>DataClinic diagnosis → PebbloSim precision synthesis → improved diagnosis → higher-quality synthesis</strong> Data Flywheel creates a structural moat that compounds over time.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.4 Open Questions for the Next Phase</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.4</span>Open Questions for the Next Phase</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         Based on the direction confirmed in this report, several questions merit deeper exploration.
                     </p>

--- a/report/openmetadata-ai-ready-data-2026-04/ko/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/ko/index.html
@@ -162,17 +162,17 @@
                         2026년 4월, OpenMetadata가 GitHub 트렌딩 일일 1위를 차지했다. 하루에 <strong>1,962개</strong>의 스타가 쏟아졌고, 누적 스타 수는 <strong>13,535개</strong>에 달한다. 2021년에 출발한 후발 주자가 LinkedIn 출신의 DataHub(<strong>11,844</strong> stars)를 추월한 것이다. 이 급성장의 배경에는 6개월간 연쇄적으로 터진 네 가지 이벤트가 있다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.1 6개월 모멘텀 캐스케이드</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>6개월 모멘텀 캐스케이드</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         2026년 2월 <strong>1.12 릴리스</strong>에서 Metadata AI SDK와 MCP(Model Context Protocol) 서버가 탑재되었다. 같은 달 <strong>OSI(Open Semantic Interchange)</strong> 표준에 합류했고, 3월에는 <strong>Linux Foundation</strong>에 가입했다. 4월에는 OpenMetadata Standards v1.13이 공개되었다. 개별적으로는 기술적 이정표에 불과하지만, 이것이 연쇄적으로 발생하면서 "메타데이터 카탈로그가 AI 에이전트의 시맨틱 레이어가 된다"는 내러티브가 개발자 커뮤니티에서 강력하게 공명했다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.2 MCP 서버 — 메타데이터를 AI 에이전트의 도구로</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>MCP 서버 — 메타데이터를 AI 에이전트의 도구로</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         MCP 서버는 OpenMetadata의 전체 카탈로그를 LLM 도구로 노출한다. AI 에이전트가 <code>/mcp</code> 엔드포인트를 통해 시맨틱 검색, 리니지 탐색, 임팩트 분석, 데이터 품질 테스트를 자연어로 수행할 수 있다. LangChain과 OpenAI Function Calling 어댑터를 제공하여 기존 AI 에이전트 프레임워크에 메타데이터 카탈로그를 "도구"로 편입시킨다. 이 설계가 개발자들의 상상력을 자극한 핵심이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1.3 프로젝트 건강도</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.3</span>프로젝트 건강도</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         Stars만으로 프로젝트의 건강함을 평가할 수 없다. OpenMetadata의 이슈 해결률은 <strong>94.7%</strong>, PR 중간값 머지 시간은 <strong>0.9시간</strong>으로 오픈소스 프로젝트 중 최상위다. Forks에서는 DataHub(3,457)가 앞서지만, 이는 DataHub가 3년 더 오래된 프로젝트라는 점을 감안해야 한다.
                     </p>
@@ -246,7 +246,7 @@
                         OpenMetadata의 기술적 심장부는 <strong>700+ JSON Schema</strong>, <strong>RDF-OWL 온톨로지</strong>, <strong>SHACL(Shapes Constraint Language)</strong>의 3층 구조다. 이것은 단순한 스키마 정의가 아니라, 데이터 자산 간의 의미적 관계를 구조화하는 "지식 그래프"를 형성한다. 컬럼 수준 리니지와 비즈니스 용어집이 결합되면, 조직 내 모든 데이터 자산의 의미적 지도가 완성된다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.1 뉴로-심볼릭 관점에서 본 메타데이터</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>뉴로-심볼릭 관점에서 본 메타데이터</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         순수 Neural 접근(임베딩 기반 시맨틱 검색)은 유사성을 찾는 데 뛰어나지만, 도메인 규칙과 제약 조건을 보장하지 못한다. 반대로 순수 Symbolic 접근(규칙 기반 검증)은 엄밀하지만 유연성이 부족하다. OpenMetadata는 두 접근을 결합한다. 온톨로지(Symbolic)로 도메인 지식을 구조화하고, Metadata AI SDK의 임베딩(Neural)으로 유사성 탐색을 수행한다.
                     </p>
@@ -260,7 +260,7 @@
                         </p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.2 SHACL — 스키마 검증을 넘어 데이터 품질 표준으로</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>SHACL — 스키마 검증을 넘어 데이터 품질 표준으로</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         VLDB 2024에서 발표된 Re-SHACL은 SHACL과 온톨로지 추론의 효율적 통합을 증명했다. CEUR-WS Vol-4093은 <strong>69개 데이터 품질(DQ) 메트릭</strong>에 대한 SHACL shapes 정의를 제시하며, SHACL이 단순 스키마 검증을 넘어 데이터 품질 평가의 차세대 표준으로 확장 가능함을 보여준다. OpenMetadata가 SHACL을 채택한 것은 데이터 품질을 메타데이터 계층에서 직접 보장하겠다는 설계 철학의 반영이다.
                     </p>
@@ -283,12 +283,12 @@
                         Gartner는 2026년까지 AI 프로젝트 <strong>60%</strong>가 AI-ready data 부재로 포기될 것이라 경고한다. 이 경고의 근본 원인은 무엇인가? <strong>63%</strong>의 조직이 AI용 데이터 관리 관행을 갖추지 못했고, <strong>11%</strong>만이 높은 메타데이터 관리 성숙도를 보유한다. 불량 데이터 품질로 조직당 연평균 <strong>$12.9M</strong> 손실이 발생한다(Gartner).
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.1 "AI Ready Data"의 정의</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>"AI Ready Data"의 정의</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         "AI Ready Data"란 AI 모델이 학습하고 추론할 수 있도록 품질, 구조, 문맥이 보장된 데이터를 의미한다. ACM Computing Surveys(2024)에 게재된 Data Readiness for AI(DRAI) 서베이는 원시 데이터에서 AI-ready 데이터까지의 단계적 프레임워크를 표준화했다. 이 "Data Readiness Levels"은 데이터가 한 단계씩 AI 학습에 적합한 상태로 올라가는 과정을 정의한다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.2 4단계 파이프라인 청사진</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>4단계 파이프라인 청사진</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         아래 파이프라인은 데이터를 "원시 상태"에서 "AI-ready"로 끌어올리는 구체적 경로다. 각 단계는 Data Readiness Levels 프레임워크와 대응된다.
                     </p>
@@ -342,7 +342,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.3 데이터 품질 &rarr; ML 성능의 인과 경로</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>데이터 품질 &rarr; ML 성능의 인과 경로</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         이 파이프라인이 실제로 작동하는가? 정량적 증거가 축적되고 있다. End-to-End DQ Framework(arXiv:2512.19723)는 실제 철강 제조 공정에서 데이터 품질 통합으로 <strong>ML 성능 12% 향상</strong>을 실증했다. Gartner는 성공적 AI 조직이 데이터 품질/거버넌스/인력에 <strong>최대 4배</strong> 더 투자한다고 보고한다(2026.04). "메타데이터 거버넌스 &rarr; 데이터 품질 &rarr; ML 성능"이라는 인과 경로가 학술과 업계 양방향에서 확인되고 있는 것이다.
                     </p>
@@ -399,7 +399,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.1 도입 사례에서 배우는 실행 패턴</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>도입 사례에서 배우는 실행 패턴</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         <strong>Gorgias</strong>(고객 지원 플랫폼)는 OpenMetadata로 <strong>45,000+</strong> 데이터 자산을 중앙화하여 데이터 팀의 검색 시간을 대폭 줄였다. <strong>Thndr</strong>(이집트 핀테크, 데이터 팀 6명)은 300만+ 사용자 계정의 PII 분류를 자동화하고, 6명이라는 소규모 팀으로 엔터프라이즈급 거버넌스를 달성했다.
                     </p>
@@ -421,7 +421,7 @@
                         데이터 카탈로그 시장은 <strong>USD 1.06B(2024)</strong>에서 <strong>4.54B(2032)</strong>로, CAGR <strong>19.9~24.4%</strong>의 성장이 전망된다(Fortune Business Insights). 메타데이터 관리 도구 시장은 <strong>USD 11.69B(2024)</strong>로 더 넓은 범위를 포괄한다(Grand View Research). AI 거버넌스 시장은 <strong>CAGR 45.3%</strong>(2024~2029)로 가장 빠르게 성장한다(MarketsandMarkets). 국내 데이터 산업도 <strong>27.1조 원(2023)</strong>에서 <strong>49조 원+(2028)</strong>으로 확대될 전망이다(KDATA).
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.1 3축 경쟁 구도의 재편</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>3축 경쟁 구도의 재편</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         시장은 오픈소스(OpenMetadata, DataHub), 상용 SaaS(Atlan, Collibra, Alation), 클라우드 네이티브(Unity Catalog, Polaris, Knowledge Catalog)의 3축으로 나뉘어 있었다. 그러나 2025~2026년에 걸쳐 이 구도가 <strong>"AI 거버넌스 방향성"</strong>으로 재편되고 있다.
                     </p>
@@ -441,7 +441,7 @@
                         </li>
                     </ul>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.2 오픈 표준의 수렴</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>오픈 표준의 수렴</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OSI(Open Semantic Interchange), ODCS(Open Data Contract Standard), Iceberg REST 등 오픈 시맨틱 표준이 벤더 중립 인프라로 수렴하고 있다. Snowflake의 OSI 합류, dbt Coalesce 2025의 "Context as Infrastructure" 선언, Google의 Dataplex &rarr; Knowledge Catalog 리브랜딩이 이 흐름을 가속한다. Gartner MQ(Magic Quadrant)가 5년 만에 메타데이터 관리 카테고리로 부활한 것은, 이 분야가 엔터프라이즈 핵심 인프라로 재인정받았다는 신호다.
                     </p>
@@ -464,7 +464,7 @@
                         OpenMetadata의 부상은 페블러스의 AI Ready Data 비전과 직접적으로 교차한다. 두 가지 관점에서 이 연결을 살펴본다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.1 기술 매핑: OpenMetadata 온톨로지와 DataGreenhouse Symbolic Layer</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>기술 매핑: OpenMetadata 온톨로지와 DataGreenhouse Symbolic Layer</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OpenMetadata의 RDF 계층적 클래스 구조(om:Service &rarr; dcat:DataService)와 SHACL shapes는 DataGreenhouse 5계층 아키텍처의 Observation Layer 중 Symbolic(온톨로지) 파트와 직접 대응된다. 구체적으로, OpenMetadata가 <strong>84+ 커넥터</strong>로 Snowflake, Databricks, Kafka 등에서 수집하는 메타데이터는 DataGreenhouse의 Platform Adapter Layer가 소비하는 입력이 된다. OpenMetadata가 "데이터 자산의 지도"를 만들면, DataGreenhouse가 그 지도 위에서 <strong>관측 &rarr; 판단 &rarr; 행동 &rarr; 증명</strong> 루프를 실행하는 구조다.
                     </p>
@@ -472,7 +472,7 @@
                         arXiv:2604.00555가 제안한 3계층 온톨로지 프레임워크(도메인/작업/워크플로 온톨로지)는 DataGreenhouse가 OpenMetadata 온톨로지를 Symbolic Layer로 활용할 때의 직접적 학술 근거가 된다. 600회 실험에서 확인된 온톨로지 grounding의 도메인 특화 효과는, 산업별 고객(제조, 의료, 금융)에게 범용 도구를 넘어서는 가치를 제공할 수 있음을 시사한다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.2 데이터 품질의 연쇄 효과: OpenMetadata &rarr; DataClinic</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>데이터 품질의 연쇄 효과: OpenMetadata &rarr; DataClinic</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         DataClinic이 데이터셋을 정밀 진단하려면, "데이터가 어디서 왔고, 어떤 변환을 거쳤으며, 누가 소유하는지"에 대한 컨텍스트가 필요하다. OpenMetadata의 네이티브 데이터 프로파일링(분포, 유일성, 완전성)은 DataClinic의 듀얼 임베딩 분석에 메타데이터 컨텍스트를 제공한다. 컬럼 수준 리니지는 "이 데이터셋의 품질 문제가 어떤 upstream 변환에서 발생했는가"를 추적하는 데 쓰인다. SHACL shapes로 정의된 데이터 계약은 DataClinic 진단 이전의 품질 게이트 역할을 수행한다.
                     </p>
@@ -480,12 +480,12 @@
                         데이터 품질 통합으로 ML 성능 <strong>12% 향상</strong>이 실증된 만큼(arXiv:2512.19723), 메타데이터 거버넌스 &rarr; DataClinic 진단 &rarr; PebbloSim 합성 데이터 생성의 연쇄는 측정 가능한 성과로 이어진다. 현대자동차에서 검증된 용접 결함 감지율 <strong>50% &rarr; 97~99%</strong>, 불량률 <strong>16PPM &rarr; 3.4PPM</strong>, ROI <strong>8,150%</strong>(회수 1.8개월)가 이 파이프라인의 최종 성과다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.3 GTM 경로: 무료 인프라 위의 가치 계층</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.3</span>GTM 경로: 무료 인프라 위의 가치 계층</h3>
                     <p class="themeable-text leading-relaxed mb-6">
                         OpenMetadata(Apache-2.0, 무료)는 기업이 메타데이터 거버넌스를 시작하는 가장 낮은 진입 장벽이다. 이 위에 DataGreenhouse(유료 데이터 운영 OS)를 얹는 구조는, 경쟁이 아닌 보완 관계로 포지셔닝된다. 시장에서 진단, 합성, 운영을 단일 플랫폼으로 통합한 사례가 확인되지 않는 가운데, 페블러스의 <strong>DataClinic 진단 &rarr; PebbloSim 정밀 합성 &rarr; 진단 정확도 향상 &rarr; 합성 품질 개선</strong>의 Data Flywheel 순환 구조는 시간이 지날수록 경쟁자가 복제하기 어려운 구조적 해자를 형성한다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.4 앞으로 탐구할 질문들</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.4</span>앞으로 탐구할 질문들</h3>
                     <p class="themeable-text leading-relaxed mb-4">
                         이 보고서를 통해 확인한 방향성에서, 페블러스가 다음 단계에서 탐구해야 할 질문들이 있다.
                     </p>

--- a/styles/common-styles.css
+++ b/styles/common-styles.css
@@ -804,6 +804,23 @@ main strong {
     box-shadow: 0 10px 15px -3px rgba(248, 104, 37, 0.4), 0 4px 6px -2px rgba(248, 104, 37, 0.3);
 }
 
+/* Sub-section number badge (h3: 1.1, 2.3 등) — number-badge의 경량 계층 */
+.sub-number-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 1.5rem;
+    padding: 0 0.4rem;
+    border-radius: 0.25rem;
+    background: rgba(248, 104, 37, 0.12);
+    color: #F86825;
+    font-weight: 700;
+    font-size: 0.85rem;
+    margin-right: 0.5rem;
+    flex-shrink: 0;
+}
+
 /* ========================================
    Article Content Components
    ======================================== */


### PR DESCRIPTION
## Summary
- h2 `number-badge`와 시각적 계층을 맞추는 경량 h3 번호 배지 추가
- 연한 오렌지 배경(`rgba(248,104,37,0.12)`) + 오렌지 텍스트(`#F86825`)
- openmetadata KO/EN 15개 h3에 적용하여 번호-제목 구별 강화

## Test plan
- [ ] http://localhost:8000/report/openmetadata-ai-ready-data-2026-04/ko/ 에서 h3 번호 배지 확인
- [ ] h2 number-badge와 시각적 계층이 자연스러운지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)