### PR TITLE
feat: sub-number-badge 표준 등록 + 폰트 조정 + frontend 적용

### DIFF
--- a/.claude/skills/blog-write/skill.md
+++ b/.claude/skills/blog-write/skill.md
@@ -203,6 +203,10 @@ PebblousPage.init({
 
 - **Text-First**: 차트/카드/다이어그램 앞에 설명 단락이 먼저
 - 섹션 구조: `<h2>` → `<h3>` (더 깊은 계층 금지)
+- **h3 서브섹션 번호**: `<span class="sub-number-badge">1.1</span>제목` 형식 사용. number-badge(h2)와 시각 계층 통일.
+  ```html
+  <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>서브섹션 제목</h3>
+  ```
 - 영어 아티클: publisher = "Pebblous Data Communication Team", "Reading time: ~Nmin"
 
 ## ⚠️ 이중 불릿 버그 (자주 반복 — 반드시 준수)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,12 @@ PebblousPage.init({ mainTitle: "...", subtitle: "...", faqs: [...] });
 </div>
 ```
 
+#### 3-1. h3 서브섹션 번호 (표준)
+```html
+<!-- ✅ 서브섹션 번호는 sub-number-badge 사용 -->
+<h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>서브섹션 제목</h3>
+```
+
 #### 4. fade-in-card 누락 (금지)
 ```html
 <!-- ❌ 절대 금지 -->

--- a/report/frontend-vibe-coders/en/index.html
+++ b/report/frontend-vibe-coders/en/index.html
@@ -216,7 +216,7 @@
                         Open AI-generated code and you'll find dozens of files: <code>package.json</code>, <code>tsconfig.json</code>, <code>vite.config.ts</code>, <code>.env</code>… Why are they all there? Complexity didn't appear overnight. Each file has a historical reason.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.1 Three Pivotal Shifts</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>Three Pivotal Shifts</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Frontend changed fundamentally three times over the past 30 years. Each shift emerged from the limits of what came before.
@@ -249,7 +249,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.2 Is React Still Dominant?</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>Is React Still Dominant?</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         The 2026 Stack Overflow developer survey (49,000 respondents) shows React usage at 44.7%, maintaining its lead over jQuery (38.5%) while growing 5.2% year-over-year. Weekly npm downloads hover around 85 million. The standard-bearer position holds.
@@ -277,7 +277,7 @@
                         Why do vibe coders always get told "use Next.js"? Behind that advice is the concept of <strong>rendering strategy</strong> — the first architectural decision in any frontend project.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.1 CSR, SSR, and Hydration</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>CSR, SSR, and Hydration</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Three approaches exist. The difference is simply: "where does the HTML get created?"
@@ -307,7 +307,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.2 Why Next.js Became the Default</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>Why Next.js Became the Default</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         In State of JS 2024, Next.js tops metaframework usage at 52.9%. Enterprise adoption is at 67%. These numbers aren't just popularity — they represent <strong>ecosystem momentum</strong>.
@@ -335,7 +335,7 @@
                         When AI generates a project, <code>package.json</code> fills up with dozens of dependencies. A <code>vite.config.ts</code> appears. A <code>tsconfig.json</code> materializes. You've heard "don't touch those" many times, but no one explained why they're there.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.1 Why Building Is Necessary</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>Why Building Is Necessary</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Browsers don't understand all modern JavaScript syntax. They don't understand TypeScript at all. That's why <strong>Transpiling</strong> is needed — converting modern code into JavaScript that older browsers can parse.
@@ -364,7 +364,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.2 Why Vite Beat Webpack</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>Why Vite Beat Webpack</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Until 2022, Webpack ruled as the bundler of choice. For new projects today, Vite is effectively the standard. State of JS 2025 shows Vite satisfaction at 98%. Webpack is still present in 84% of projects, but developer satisfaction has fallen to 26%.
@@ -392,7 +392,7 @@
                         Most moments where vibe coders get stuck come down to <strong>prompt precision</strong>. "Make this" and "Make this with these constraints" produce fundamentally different results. Folding the concepts covered above into your prompts changes the output quality.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.1 Specify the rendering strategy</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>Specify the rendering strategy</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -405,7 +405,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.2 Define the scope of state management</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>Define the scope of state management</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -418,7 +418,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.3 Provide context, not just the error</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>Provide context, not just the error</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -431,7 +431,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.4 Declare your deployment environment upfront</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.4</span>Declare your deployment environment upfront</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-good">
@@ -440,7 +440,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.5 Ask "why"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.5</span>Ask "why"</h3>
 
                     <div class="mb-8">
                         <div class="prompt-box prompt-good">
@@ -467,19 +467,19 @@
                         You don't need to know these immediately, but understanding them will help you make sense of the choices AI makes.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.1 React Server Components</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>React Server Components</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Enabled by default since Next.js 14, this runs components on the server and sends only HTML to the client. It shrinks JavaScript bundle size and speeds up rendering. State of JS 2024 shows adoption at 29% — but if you use Next.js, you're using it automatically.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.2 Islands Architecture</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>Islands Architecture</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Keep most of the page as static HTML and handle only the interactive parts as JavaScript "islands." Astro is the flagship implementation. It eliminates unnecessary JavaScript from content-heavy sites.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.3 AI's Impact on Frontend Development</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.3</span>AI's Impact on Frontend Development</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         84% of developers are using or planning to use AI coding tools. At the same time, research shows 45% of AI-generated code contains security vulnerabilities. The value of "people who can review AI-generated code" is only going up.

--- a/report/frontend-vibe-coders/ko/index.html
+++ b/report/frontend-vibe-coders/ko/index.html
@@ -216,7 +216,7 @@
                         AI가 만든 코드를 열면 수십 개의 파일이 있다. <code>package.json</code>, <code>tsconfig.json</code>, <code>vite.config.ts</code>, <code>.env</code>… 이것들은 왜 있는 걸까. 복잡성은 하루아침에 생겨난 것이 아니다. 각 파일에는 역사적 이유가 있다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.1 세 번의 전환</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>세 번의 전환</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         프론트엔드는 지난 30년간 세 번 근본적으로 바뀌었다. 각 전환은 이전 방식의 한계에서 비롯됐다.
@@ -249,7 +249,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">2.2 React는 여전히 지배적인가</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>React는 여전히 지배적인가</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         2026년 Stack Overflow 개발자 설문(49,000명 응답)에서 React 사용률은 44.7%다. 2위 jQuery(38.5%)와의 격차를 유지하면서도 전년 대비 5.2% 상승했다. npm 주간 다운로드는 약 8,500만 건. 사실상 표준 자리는 아직 건재하다.
@@ -277,7 +277,7 @@
                         바이브코더가 "Next.js를 써라"는 조언을 받는 이유는 뭘까. 그 배경에는 <strong>렌더링 전략</strong>이라는 개념이 있다. 이것이 프론트엔드 설계에서 가장 먼저 결정해야 할 사항이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.1 CSR, SSR, Hydration</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>CSR, SSR, Hydration</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         세 가지 방식이 있다. 차이는 "HTML이 어디서 만들어지는가"다.
@@ -307,7 +307,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">3.2 Next.js가 기본이 된 이유</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>Next.js가 기본이 된 이유</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         State of JS 2024에서 메타프레임워크 사용률 1위는 Next.js(52.9%)다. 엔터프라이즈 채택률은 67%. 이 수치는 단순한 인기가 아니라, <strong>생태계 관성</strong>이다.
@@ -335,7 +335,7 @@
                         AI가 프로젝트를 만들면 <code>package.json</code>에 수십 개의 의존성이 생긴다. <code>vite.config.ts</code>가 생기고, <code>tsconfig.json</code>이 생긴다. 이것들을 건드리지 말라는 말은 많이 들었지만, 왜 있는지는 아무도 설명해주지 않는다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.1 빌드가 필요한 이유</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>빌드가 필요한 이유</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         브라우저는 최신 JavaScript 문법을 모두 이해하지 못한다. TypeScript는 아예 모른다. 그래서 <strong>Transpiling(변환)</strong>이 필요하다. 최신 코드를 오래된 브라우저도 이해하는 JavaScript로 바꿔주는 과정이다.
@@ -364,7 +364,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">4.2 Vite가 Webpack을 이긴 이유</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>Vite가 Webpack을 이긴 이유</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         2022년까지 번들러의 왕은 Webpack이었다. 이제 신규 프로젝트 기준으로는 Vite가 사실상 표준이 됐다. State of JS 2025에서 Vite 만족도는 98%. Webpack은 여전히 84%의 프로젝트에서 쓰이지만, 개발자 만족도는 26%로 추락했다.
@@ -392,7 +392,7 @@
                         AI 코딩 도구를 쓸 때 막히는 대부분의 상황은 <strong>프롬프트의 정밀도</strong>에서 온다. "만들어줘"와 "이런 조건으로 만들어줘"의 결과물은 다르다. 앞에서 다룬 개념을 프롬프트에 녹이면 품질이 달라진다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.1 렌더링 전략을 명시하라</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>렌더링 전략을 명시하라</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -405,7 +405,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.2 상태 관리 범위를 정해라</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>상태 관리 범위를 정해라</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -418,7 +418,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.3 에러를 설명하지 말고 맥락을 줘라</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>에러를 설명하지 말고 맥락을 줘라</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-bad">
@@ -431,7 +431,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.4 배포 환경을 미리 정해라</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.4</span>배포 환경을 미리 정해라</h3>
 
                     <div class="mb-6">
                         <div class="prompt-box prompt-good">
@@ -440,7 +440,7 @@
                         </div>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">5.5 "왜"를 물어라</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.5</span>"왜"를 물어라</h3>
 
                     <div class="mb-8">
                         <div class="prompt-box prompt-good">
@@ -467,19 +467,19 @@
                         바이브코더가 당장 알 필요는 없지만, 알고 있으면 AI의 선택을 이해하는 데 도움이 되는 흐름들이 있다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.1 React Server Components</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>React Server Components</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         Next.js 14부터 기본으로 켜진 기능이다. 컴포넌트를 서버에서 실행하고 HTML만 클라이언트로 보낸다. JavaScript 번들 크기를 줄이고 렌더링을 빠르게 한다. State of JS 2024 기준 아직 사용률은 29%지만, Next.js를 쓰는 순간 자동으로 사용하는 구조다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.2 Islands Architecture</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>Islands Architecture</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         페이지의 대부분은 정적 HTML로 두고, 인터랙티브한 부분만 "섬(Island)"처럼 JavaScript로 따로 처리한다. Astro가 대표 구현체다. 콘텐츠 중심 사이트에서 불필요한 JavaScript를 없애는 접근법이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">6.3 AI가 프론트엔드 직군에 미치는 영향</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.3</span>AI가 프론트엔드 직군에 미치는 영향</h3>
 
                     <p class="themeable-text leading-relaxed mb-6">
                         개발자의 84%가 AI 코딩 도구를 사용 중이거나 사용 계획이 있다고 응답했다. 그러나 동시에, AI 생성 코드의 45%에서 보안 취약점이 발견된다는 연구도 있다. "AI가 쓴 코드를 검토할 수 있는 사람"의 가치는 오히려 높아지고 있다.

--- a/styles/common-styles.css
+++ b/styles/common-styles.css
@@ -816,7 +816,7 @@ main strong {
     background: rgba(248, 104, 37, 0.12);
     color: #F86825;
     font-weight: 700;
-    font-size: 0.85rem;
+    font-size: 1rem;
     margin-right: 0.5rem;
     flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- `.sub-number-badge` font-size `0.85rem` → `1rem` (h3 제목 대비 80% 비율로 조정)
- CLAUDE.md 3-1항에 h3 sub-number-badge 표준 패턴 추가
- blog-write 스킬 콘텐츠 원칙에 서브섹션 번호 규칙 추가
- frontend-vibe-coders KO/EN 14개 h3에 적용

## Test plan
- [ ] frontend-vibe-coders 페이지에서 서브섹션 번호 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)