### PR TITLE
chore(skills): Google Sitemap Ping API 제거 (deprecated)

### DIFF
--- a/.claude/skills/blog-publish/skill.md
+++ b/.claude/skills/blog-publish/skill.md
@@ -114,14 +114,14 @@ git commit -m "feat: [아티클 제목] — KO 아티클 추가"
 git push
 ```
 
-### 6. Google Sitemap Ping
+### 6. Sitemap 크롤링 (Google ping API는 deprecated)
 
-```bash
-curl -s "https://www.google.com/ping?sitemap=https://blog.pebblous.ai/sitemap.xml"
-```
+Google은 2023-06부로 `/ping?sitemap=...` API를 제거했다. 대신:
 
-- git push 후 실행 — sitemap 갱신을 Google에 즉시 알려 크롤링을 앞당김
-- 응답에 "Sitemap Notification Received"가 포함되면 성공
+- `sitemap.xml`의 `<lastmod>` 값을 보고 자동 재크롤링한다 (CI가 push 후 자동 갱신)
+- 출처: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping
+- 빠른 인덱싱이 필요하면 Google Search Console의 "URL 검사" → "색인 생성 요청" (수동, 배치 안 됨)
+- 별도 ping curl 호출은 더 이상 필요/유효하지 않음
 
 ## 에러 핸들링
 

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -32,12 +32,11 @@ When this skill is invoked:
    - Check if `history/changelog.jsonl` was updated in this session
    - If not, remind the user to run `/changelog` before committing
 
-7. **Google Sitemap Ping** (sitemap 갱신을 Google에 즉시 알림):
-   ```bash
-   curl -s "https://www.google.com/ping?sitemap=https://blog.pebblous.ai/sitemap.xml"
-   ```
-   - 새 포스트 발행 시 Google 크롤링을 앞당기는 효과
-   - 응답이 "Sitemap Notification Received"면 성공
+7. **Sitemap 크롤링 안내** (Google ping API는 2023-06부로 deprecated):
+   - Google은 `sitemap.xml`의 `<lastmod>` 값을 보고 자동으로 재크롤링한다 — 별도 ping 불필요
+   - 출처: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping
+   - **참고**: `sitemap.xml`은 CI(`update-sitemap.yml`)가 push 후 자동 갱신하므로 로컬에서 건드리지 않는다
+   - 빠른 인덱싱이 필요하면 Google Search Console의 "URL 검사" → "색인 생성 요청"을 사용 (수동, 배치 안 됨)
 
 8. **Hand off to `/commit`**: Suggest the user run `/commit` to stage, commit, and push with smart exclusions.
 


### PR DESCRIPTION
## 배경

Google은 2023-06-26부로 `/ping?sitemap=...` API를 deprecate했고, 현재는 404를 반환한다.
출처: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping

## 변경

`publish` 스킬과 `blog-publish` 스킬의 'Google Sitemap Ping' 단계를 제거하고, 다음 안내로 교체:

- `sitemap.xml`의 `<lastmod>` 값으로 Google이 자동 재크롤링
- CI(`update-sitemap.yml`)가 push 후 sitemap을 자동 갱신
- 빠른 인덱싱이 필요하면 Google Search Console의 'URL 검사' → '색인 생성 요청' 사용

## 영향

- 실제 동작 변화 없음 (이미 ping API가 작동 안 함)
- 스킬 문서가 deprecated 안내를 직접 노출하지 않게 됨
- 다음 `/publish` 실행 시 404 응답으로 인한 혼동 방지