### PR TITLE
fix: issues #127-129 반영 (category 검증 + 브랜치 안내 + untracked 정리)

### DIFF
--- a/.claude/skills/blog-publish/skill.md
+++ b/.claude/skills/blog-publish/skill.md
@@ -21,6 +21,24 @@ description: "blog.pebblous.ai 퍼블리싱 파이프라인 — OG 이미지 생
 
 ## 파이프라인 (순서 엄수)
 
+### ⛔ -1. 현재 브랜치 확인 (Issue #128)
+
+작업 파일이 어느 브랜치에 있는지 먼저 확인한다. 다른 브랜치에서 작성된 파일이라면 해당 브랜치로 체크아웃해야 Step 0의 파일 존재 확인이 통과된다.
+
+```bash
+BRANCH=$(git branch --show-current)
+echo "현재 브랜치: $BRANCH"
+git status --short
+```
+
+- **main 브랜치**에서 신규 작업 파일이 보이지 않으면 → 작업한 feature branch로 `git checkout` 후 진행
+- **feature branch**에서 실행 중이면 → 그대로 진행 (퍼블리시 후 PR로 머지)
+- 사용자가 특정 브랜치를 지정하지 않았다면 사용자에게 브랜치 결정을 물어볼 것 (CLAUDE.md Branch Policy 참조)
+
+> ⚠️ **교훈 (2026-05-05, Issue #128)**: feature branch에서 작성한 파일을 main에서 publish 시도 → Step 0 "❌ KO 없음" 오류로 시간 낭비.
+
+---
+
 ### ⛔ 0. KO + EN HTML 존재 확인 (파이프라인 시작 전 필수)
 
 **파이프라인을 시작하기 전, KO + EN HTML 파일이 모두 존재하는지 반드시 확인한다.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,18 @@ docs/<주제>     — 문서 변경
 - rebase 후 push 전에 `git fetch`로 다른 에이전트의 새 커밋 확인
 - 다른 에이전트가 같은 브랜치에 커밋했을 가능성이 보이면 push 보류하고 사용자에게 보고
 
+### 세션 종료 시 untracked 정리 (Issue #129)
+
+세션을 마무리하기 전 반드시 `git status`로 untracked 파일을 확인한다. 멀티 에이전트 환경에서 untracked 파일이 남으면 다음 세션의 `git pull`이나 `git checkout`에서 충돌을 일으킨다.
+
+작업 상태별 처리:
+- **작업 완료 + 커밋 가능** → feature branch에 커밋 후 push
+- **작업 중단(WIP)** → `git stash push -u -m "WIP: <설명>"`으로 보관
+- **이미 remote에 있는 파일과 동일** → `git status`로 확인 후 안전하게 삭제 (다음 pull에서 정상 받음)
+- **불필요한 임시 파일** → 삭제 또는 `.gitignore` 추가
+
+> ⚠️ **교훈 (2026-05-05, Issue #129)**: 다른 에이전트가 남긴 untracked 파일이 main의 동일 파일과 충돌하여 `git pull` 차단됨.
+
 ## Build & Development Commands
 
 ```bash

--- a/tools/validate-articles.py
+++ b/tools/validate-articles.py
@@ -229,6 +229,14 @@ def main():
 
     # === Global validations (전체 articles 대상) ===
 
+    # Category 정의 검증 (Issue #127): articles.json의 categories 오브젝트에 정의된 키만 허용
+    defined_categories = set(data.get("categories", {}).keys())
+    if defined_categories:
+        for a in articles:
+            cat = a.get("category")
+            if cat and cat not in defined_categories:
+                err(a.get("id", "?"), f"category '{cat}' 미정의 — 허용: {sorted(defined_categories)}")
+
     # Featured: 카테고리당 최대 3개
     featured_by_cat = {}
     for a in articles:


### PR DESCRIPTION
## 요약

오늘 발생한 3건의 운영 이슈를 동시에 해결.

## #127 — articles.json 카테고리 사전 검증 (`tools/validate-articles.py`)

- `data['categories']`에 정의되지 않은 `category` 사용 시 로컬에서 즉시 오류
- CI `validate` 잡에서만 잡히던 오류를 push 전에 차단
- 8줄 추가 (Global validations 섹션)

## #128 — blog-publish 스킬 브랜치 확인 단계 추가 (`.claude/skills/blog-publish/skill.md`)

- 새 `Step -1` 신설: `git branch --show-current` 출력 + 작업 파일 위치 안내
- main에서 feature branch 파일을 찾는 사고 방지
- 사용자가 브랜치를 지정하지 않았으면 사용자에게 결정 위임 (CLAUDE.md Branch Policy 연계)

## #129 — 세션 종료 시 untracked 정리 규칙 (`CLAUDE.md`)

- 작업 상태별 처리 가이드 추가 (커밋 / stash / 삭제 / .gitignore)
- 멀티 에이전트 환경에서 untracked 파일이 다음 세션의 pull/checkout 차단하는 문제 예방

## 검증

```
python3 tools/validate-articles.py
요약: 오류 0개 / 경고 16개 / 자동수정 0개
```

Closes #127 #128 #129