### PR TITLE
refactor(report): 멀티에이전트 보고서 제목 신문 헤드라인 스타일로 변경

### DIFF
--- a/report/multiagent-industrial-data-operations/en/index.html
+++ b/report/multiagent-industrial-data-operations/en/index.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="index, follow">
     <meta name="revisit-after" content="7 days">
 
-    <title>Multi-Agent AI Beyond Finance: Industrial Data Ops | Pebblous</title>
+    <title>Multi-Agent AI Expands From Finance to Manufacturing and Logistics | Pebblous</title>
     <meta name="description" content="TradingAgents hit 60K GitHub stars — but the same multi-agent pattern breaks the moment it moves to manufacturing, logistics, healthcare, and the grid. A triangulated architecture (DeerFlow + DataGreenhouse + domain adapters) and Pebblous's data-quality OS positioning.">
     <meta name="keywords" content="multi-agent AI, TradingAgents, DeerFlow, DataGreenhouse, DataClinic, industrial AI, data quality, agent orchestration, MCP, LangGraph, AI agent, agentic AI, model collapse, ISO 42001, AI-Ready Data">
 
@@ -20,7 +20,7 @@
     <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="What Multi-Agent AI Finds Beyond Finance">
+    <meta property="og:title" content="Multi-Agent AI Expands From Finance to Manufacturing and Logistics">
     <meta property="og:description" content="What TradingAgents' 60K stars really asked — triangulating DeerFlow, DataGreenhouse, and domain adapters into a data-quality OS for industrial agentic AI.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/en/">
@@ -35,7 +35,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@pebblous_ai">
     <meta name="twitter:creator" content="@pebblous_ai">
-    <meta name="twitter:title" content="What Multi-Agent AI Finds Beyond Finance">
+    <meta name="twitter:title" content="Multi-Agent AI Expands From Finance to Manufacturing and Logistics">
     <meta name="twitter:description" content="What TradingAgents' 60K stars really asked — triangulating DeerFlow, DataGreenhouse, and domain adapters into a data-quality OS for industrial agentic AI.">
     <meta name="twitter:image" content="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/en/image/index.png">
     <meta name="twitter:image:alt" content="Multi-Agent AI Industrial Data Operations Triangulated Architecture">
@@ -796,9 +796,9 @@
     <script src="/scripts/common-utils.js?v=20260504"></script>
     <script>
         PebblousPage.init({
-            mainTitle: "What Multi-Agent AI Finds Beyond Finance",
-            subtitle: "What TradingAgents' 60K Stars Really Asked — Triangulating DeerFlow, DataGreenhouse, and Domain Adapters",
-            pageTitle: "Multi-Agent AI Beyond Finance: Industrial Data Ops | Pebblous",
+            mainTitle: "Multi-Agent AI Expands From Finance to Manufacturing and Logistics",
+            subtitle: "TradingAgents Hits 60K Stars, but Returns Miss — 'Data Quality Is the Real Problem'",
+            pageTitle: "Multi-Agent AI Expands From Finance to Manufacturing and Logistics | Pebblous",
             category: "tech",
             publishDate: "2026-05-04",
             publisher: "Pebblous Data Communication Team",

--- a/report/multiagent-industrial-data-operations/ko/index.html
+++ b/report/multiagent-industrial-data-operations/ko/index.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="index, follow">
     <meta name="revisit-after" content="7 days">
 
-    <title>멀티에이전트 AI, 금융을 넘어 산업 데이터 운영으로 — 통합 아키텍처 제안 | 페블러스</title>
+    <title>멀티에이전트 AI, 금융 넘어 제조·물류까지 확산 | 페블러스</title>
     <meta name="description" content="TradingAgents 60K 스타가 던진 진짜 질문 — 멀티에이전트 LLM이 금융을 떠나 제조·물류·헬스케어·에너지로 이동할 때 무엇이 무너지는가. DeerFlow + DataGreenhouse + 도메인의 삼각 통합 아키텍처와 페블러스의 데이터 품질 OS 포지셔닝.">
     <meta name="keywords" content="멀티에이전트, Multi-agent AI, TradingAgents, DeerFlow, DataGreenhouse, DataClinic, 산업 AI, 데이터 품질, 에이전트 오케스트레이션, MCP, LangGraph, AI Agent, Industrial AI, 데이터 운영, Model Collapse, ISO 42001">
 
@@ -20,7 +20,7 @@
     <link rel="alternate" hreflang="x-default" href="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="에이전트는 금융을 떠나면 무엇을 만나는가 — 산업 데이터 운영의 멀티에이전트 아키텍처">
+    <meta property="og:title" content="멀티에이전트 AI, 금융 넘어 제조·물류까지 확산">
     <meta property="og:description" content="TradingAgents 60K 스타가 던진 진짜 질문 — DeerFlow + DataGreenhouse + 도메인의 삼각 통합 설계와 페블러스의 데이터 품질 OS 포지셔닝.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/">
@@ -35,7 +35,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@pebblous_ai">
     <meta name="twitter:creator" content="@pebblous_ai">
-    <meta name="twitter:title" content="에이전트는 금융을 떠나면 무엇을 만나는가 — 산업 데이터 운영의 멀티에이전트 아키텍처">
+    <meta name="twitter:title" content="멀티에이전트 AI, 금융 넘어 제조·물류까지 확산">
     <meta name="twitter:description" content="TradingAgents 60K 스타가 던진 진짜 질문 — DeerFlow + DataGreenhouse + 도메인의 삼각 통합 설계와 페블러스의 데이터 품질 OS 포지셔닝.">
     <meta name="twitter:image" content="https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/image/index.png">
     <meta name="twitter:image:alt" content="멀티에이전트 AI 산업 데이터 운영 통합 아키텍처">
@@ -809,9 +809,9 @@
     <script src="/scripts/common-utils.js?v=20260504"></script>
     <script>
         PebblousPage.init({
-            mainTitle: "에이전트는 금융을 떠나면 무엇을 만나는가 — 산업 데이터 운영의 멀티에이전트 아키텍처",
-            subtitle: "TradingAgents 60K 스타가 던진 진짜 질문 — DeerFlow + DataGreenhouse + 도메인의 삼각 통합 설계",
-            pageTitle: "멀티에이전트 AI, 금융을 넘어 산업 데이터 운영으로 — 통합 아키텍처 제안 | 페블러스",
+            mainTitle: "멀티에이전트 AI, 금융 넘어 제조·물류까지 확산",
+            subtitle: "TradingAgents 60K 스타에도 수익은 미달…'데이터 품질이 핵심'",
+            pageTitle: "멀티에이전트 AI, 금융 넘어 제조·물류까지 확산 | 페블러스",
             category: "tech",
             publishDate: "2026-05-04",
             publisher: "(주)페블러스 데이터 커뮤니케이션팀",


### PR DESCRIPTION
## 변경 내용

KO/EN 제목을 수사의문문 스타일에서 신문 헤드라인 스타일로 변경

### KO
- **mainTitle**: 에이전트는 금융을 떠나면 무엇을 만나는가 → 멀티에이전트 AI, 금융 넘어 제조·물류까지 확산
- **subtitle**: TradingAgents 60K 스타가 던진 진짜 질문 → TradingAgents 60K 스타에도 수익은 미달…'데이터 품질이 핵심'

### EN
- **mainTitle**: What Multi-Agent AI Finds Beyond Finance → Multi-Agent AI Expands From Finance to Manufacturing and Logistics
- **subtitle**: What TradingAgents' 60K Stars Really Asked → TradingAgents Hits 60K Stars, but Returns Miss — 'Data Quality Is the Real Problem'

title, og:title, twitter:title, pageTitle, subtitle 모두 일관되게 수정됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)