### PR TITLE
chore(gitignore): _workspace 중복 정리 + NanoClaw 런타임 주석

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ blog/font-test*
 report/korea-ai-fund-report-2026-03/source/
 files-index.json
 project/IR/press-room/downloads/pebblous-pitch-deck-en old.pdf
-_workspace/
+# Local workspace + NanoClaw pipeline run state (#133)
 _workspace/


### PR DESCRIPTION
## 배경

이슈 #133에서 NanoClaw Blog MCP의 `_workspace/.runs/` 런타임 상태 저장소가 `.gitignore`에 추가되어야 한다고 명시.

## 변경

`.gitignore` 46-47번째 줄에 `_workspace/` 가 중복되어 있던 것을 정리하고, NanoClaw 런타임 용도임을 명시하는 주석 추가.

```diff
-_workspace/
+# Local workspace + NanoClaw pipeline run state (#133)
 _workspace/
```

## 영향

- 동작 변화 없음 (이미 `_workspace/`로 매칭되고 있어 `_workspace/.runs/`도 자동 제외 중)
- 의도가 명확해져서 차후 에이전트가 `_workspace/` entry를 잘못 건드릴 위험 감소

Refs #133