### PR TITLE
docs(blog-service): foundation — 통합 우선 결정 + 3-자산 비전

### DIFF
--- a/docs/blog-service/README.md
+++ b/docs/blog-service/README.md
@@ -1,0 +1,32 @@
+# Blog Service
+
+> 본 디렉토리는 페블러스 블로그 시스템을 외부 클라이언트(Web/API/MCP)에 노출하기 위한 **Blog Service**의 설계·명세·운영 문서를 모아둔다.
+
+## 비전 한 줄 요약
+
+DataClinic이 자기 능력을 API로 노출했듯, 본 블로그 레포의 콘텐츠 작성·발행 능력을 **HTTP API + MCP** 두 가지 인터페이스로 노출하여 다양한 클라이언트(NanoClaw 채널, Web UI, 외부 에이전트, CI/CD)가 호출할 수 있게 한다.
+
+## 현재 상태
+
+**Phase 0 — 통합 + 문서화** (지금 단계)
+
+본 디렉토리는 본 레포(`pebblous.github.io`) 안에 임시로 위치한다. 자산 분리(아래 참조)가 진행되면 별도 레포로 이전된다.
+
+## 문서 인덱스
+
+| 문서 | 내용 |
+|------|------|
+| [architecture.md](architecture.md) | 3-자산 분리 비전과 단계별 로드맵 |
+| [decision-log.md](decision-log.md) | 주요 결정 이력 (통합 우선 / OpenAPI / 분리 트리거 등) |
+| `openapi.yaml` *(예정)* | REST API 스펙 — C단계 산출물 |
+| `mcp-tools.md` *(예정)* | MCP 인터페이스 스펙 |
+| `design.md` *(예정)* | Pipeline Engine 설계 |
+
+## 관련 자료
+
+- 이슈 #137 — Blog Service 독립화 로드맵
+- 이슈 #133 — NanoClaw Blog MCP 구현 (closed, 정보성)
+- `docs/nanoclaw/blog-mcp-stdio.ts` — 현재 동작 중인 MCP 구현 참조 사본
+- 이슈 #102 — DataClinic MCP 외부 에이전트 접근 방안 (closed)
+- 이슈 #88 — Wiki/블로그 브랜치 워크플로우 + Preview Deploy
+- 이슈 #122 — preview-tunnel 스킬 (closed)

--- a/docs/blog-service/architecture.md
+++ b/docs/blog-service/architecture.md
@@ -1,0 +1,133 @@
+# Architecture — 3-Asset Separation
+
+> 본 레포는 현재 세 가지 다른 종류의 자산을 한 곳에 보관하고 있다. Blog Service 독립화는 이 세 자산을 단계적으로 분리하는 큰 그림 안에서 진행된다.
+
+## 현재 상태 — 통합
+
+```
+pebblous.github.io/  (현재)
+│
+├─ [자산 1: 콘텐츠 발행 사이트]
+│   ├─ blog/, report/, story/, project/, pebblopedia/   ← 실제 글 (수백 건)
+│   ├─ articles.json, sitemap.xml, rss.xml              ← 인덱싱
+│   ├─ index.html, css/, scripts/index/                 ← 사이트 UI
+│   └─ image/, og 이미지                                ← 미디어 자산
+│
+├─ [자산 2: 콘텐츠 작성 메서드론]
+│   ├─ .claude/skills/*                                  ← 30+ 스킬
+│   ├─ .claude/agents/*                                  ← 에이전트 정의
+│   ├─ CLAUDE.md, AGENT-POLICY.md                        ← 정책
+│   └─ docs/style.md, content-guidelines.md              ← 가이드
+│
+└─ [자산 3: 발행 도구 + Blog Service]
+    ├─ tools/generate-og-image.js, validate-articles.py  ← 결정론적 도구
+    ├─ scripts/scan-html-files.py, generate-rss.js       ← 인덱싱 도구
+    ├─ .github/workflows/*                               ← CI
+    └─ (미래) Blog Service API/MCP                       ← 추가 예정
+```
+
+세 자산이 한 레포에 있는 이유는 역사적 편의 때문이다. 콘텐츠가 수백 건으로 늘어남에 따라 자산 1이 압도적으로 커지고 있어, 자산 2/3과 분리할 필요가 점점 명확해진다.
+
+## 미래 비전 — 3-Repo 분리
+
+```
+[자산 1] pebblous/blog-content
+        ── 콘텐츠 발행 사이트, GitHub Pages 호스팅
+        ── 글 PR만 들어옴 → CI 단순, 트래픽 많은 main
+
+[자산 2] pebblous/blog-toolkit
+        ── 콘텐츠 작성 스킬/에이전트 + 가이드
+        ── 메서드론 진화 중심
+
+[자산 3] pebblous/blog-service
+        ── 발행 도구 + Blog Service (API/MCP/인프라)
+        ── 외부 클라이언트가 의존하는 안정적 인터페이스
+```
+
+**의존 방향**: 자산 3 → 자산 2 → 자산 1
+(서비스가 스킬을 호출하고, 스킬이 콘텐츠를 만든다)
+
+## Blog Service (자산 3) 내부 구조
+
+```
+                    ┌─────────────────────────────────────┐
+                    │  Blog Service (단일 시스템)          │
+                    │  ─────────────────────────────────  │
+   Web/API Client → │  HTTP/SSE API (REST + 스트리밍)     │
+                    │           ↕                          │
+   AI Agent      →  │  MCP Server (stdio + HTTP MCP)      │
+                    │           ↕                          │
+                    │  Pipeline Engine (공통)              │
+                    │  - phase별 Claude Code spawn         │
+                    │  - 상태 저장 (`_workspace/.runs/`)    │
+                    │  - 비동기 게이트                     │
+                    │           ↕                          │
+                    │  블로그 레포 (자산 1, 마운트/clone)   │
+                    └─────────────────────────────────────┘
+```
+
+핵심: **HTTP API와 MCP가 같은 Pipeline Engine을 공유**한다. 인터페이스만 두 개, 로직은 하나.
+
+NanoClaw는 이 서비스의 "한 클라이언트"가 되어 채널 통합 본연의 역할에 집중한다.
+
+## 단계별 로드맵 (수정판 — 통합 우선)
+
+**Phase 0** *(현재)* — 통합 + 문서화
+- 본 디렉토리(`docs/blog-service/`)에서 비전·결정·스펙 작성
+- 새 코드는 본 레포 안에 통합 상태로 시작
+- 분리는 트리거가 발동하면 시작
+
+**Phase 1** — Blog Service 코드 통합 작성
+- C: OpenAPI 스펙 (`docs/blog-service/openapi.yaml`)
+- D: HTTP API 구현 (본 레포 내부, 예: `service/blog-service-api/`)
+- E: MCP 외부 노출 모드 추가
+- 본 레포에서 작동하는 서비스로 검증
+
+**Phase 2** — Web UI 추가
+- F: 페블러스 내부 자동화용 Web UI
+- 메신저보다 풍부한 UX (게이트 리뷰, 진행 모니터링, PR 관리)
+
+**Phase 3** — 자산 분리 시작
+- 분리 트리거 발동 시 (다음 절 참조)
+- 자산 3을 먼저 별도 레포로 이전
+- 자산 2도 차례로 분리
+- 본 레포는 자산 1만 남김
+
+**Phase 4** *(장기)* — 외부 노출
+- G: 멀티 테넌시, 빌링, 사용량 추적
+- 페블러스 외부 사용자 단계적 개방
+
+## 분리 트리거 (Phase 3 진입 조건)
+
+분리는 비용이 큰 작업이다. 다음 트리거가 발동하면 Phase 3 진입을 진지하게 검토:
+
+### 자산 3 분리 트리거 (가장 먼저)
+- [ ] Blog Service 코드가 자산 1보다 많은 PR을 생성하기 시작 (개발 활동 분리 신호)
+- [ ] 외부 클라이언트(non-Pebblous)가 Blog Service 사용 시작
+- [ ] Blog Service 의존성(npm 패키지 등)이 본 레포 의존성 트리를 무겁게 만듦
+- [ ] CI/CD 시간이 분리 가치를 넘어섬
+
+### 자산 2 분리 트리거 (그 다음)
+- [ ] 다른 회사가 toolkit을 자기 콘텐츠 레포에 적용 요청
+- [ ] 스킬 변경 PR이 콘텐츠 PR보다 많아짐 (메서드론 활동이 콘텐츠 발행을 추월)
+- [ ] 스킬 자체에 대한 외부 기여자 발생
+
+### 자산 1 정리 트리거 (마지막)
+- [ ] 콘텐츠 글이 1,000건 초과
+- [ ] GitHub Pages 빌드 시간이 N분 초과 (체감 지연 발생)
+- [ ] 자산 2/3이 이미 분리되어 본 레포가 사실상 콘텐츠 전용
+
+## 분리 전 준비사항
+
+자산 분리 시 어려움을 줄이기 위해 통합 상태에서 미리 처리:
+
+1. **스킬 인터페이스 추상화** — 콘텐츠 경로를 인자로 받기, 하드코딩 금지
+2. **Blog Service의 본 레포 의존성 명시** — 환경변수 `BLOG_REPO_PATH`로 위치 인자화
+3. **결정론적 부분과 LLM 부분 분리** — `tools/`(결정론적)는 Blog Service로, `.claude/`(LLM)는 toolkit으로
+4. **테스트 격리** — 각 자산의 테스트가 다른 자산 없이도 돌아가게
+
+## 현재 결정 (Decision Log 참조)
+
+- **통합 우선, 분리 차차** — Phase 0/1/2를 본 레포에서 진행
+- **OpenAPI 정식 스펙** — Markdown 초안이 아닌 정식 명세 채택
+- **3-자산 비전 박아두기** — 분리 시점이 와도 같은 그림 안에서 진행

--- a/docs/blog-service/decision-log.md
+++ b/docs/blog-service/decision-log.md
@@ -1,0 +1,114 @@
+# Decision Log
+
+> Blog Service 설계·운영의 주요 결정 이력. 새 결정이 생기면 맨 위에 추가.
+
+---
+
+## 2026-05-06 — 통합 우선, 분리 차차
+
+**상황**: 본 레포(`pebblous.github.io`)에 세 종류의 자산(콘텐츠 / 메서드론 / 도구)이 통합되어 있고, 콘텐츠가 수백 건으로 늘어남. Blog Service를 새로 만들면서 별도 레포로 시작할지, 본 레포 안에서 시작할지가 쟁점.
+
+**결정**: 본 레포에서 통합 상태로 시작하고, 트리거가 발동하면 분리.
+
+**이유**:
+- 새 레포 생성·CI 셋업·문서 분리 등 초기 비용이 크다
+- Blog Service의 가치는 "동작하는가"가 우선이고, "어디 있는가"는 부차적
+- 통합 상태에서 본 레포의 스킬·콘텐츠를 직접 참조하며 빠르게 검증 가능
+- 분리 트리거 4개를 명시적으로 박아두어 미루지 않을 안전장치 마련
+
+**적용 방법**:
+- `docs/blog-service/` 디렉토리에 모든 설계·스펙·운영 문서 집중
+- 추후 Blog Service 코드도 본 레포 내부 디렉토리(예: `service/blog-service-api/`)로 작성
+- 분리 시 `git filter-repo`로 히스토리 보존하며 새 레포로 이전
+
+**관련**: 이슈 #137, [architecture.md](architecture.md)
+
+---
+
+## 2026-05-06 — OpenAPI 정식 스펙 채택 (Markdown 초안 아님)
+
+**상황**: API 스펙 작성 방식 결정. (1) Markdown 초안, (2) 정식 OpenAPI YAML.
+
+**결정**: 정식 OpenAPI YAML 채택.
+
+**이유**:
+- B(코드 분리) 단계에서 FastAPI/Hono 라우터 자동 생성 가능 → 30-50% 개발 시간 절감
+- 클라이언트 SDK 자동 생성 → NanoClaw 측 호출 코드 작성 부담 감소
+- F(Web UI) 단계에서 같은 OpenAPI에서 TypeScript 타입 생성 가능
+- G(외부 노출) 단계에서 개발자에게 표준 문서 제공
+- `blog-mcp-stdio.ts`가 이미 9개 툴 시그니처를 명확히 가지고 있어 OpenAPI 작성이 어렵지 않다
+
+**트레이드오프**:
+- 작성 시간 1-2시간 (Markdown 초안은 30-60분)
+- → B 작업 시간 단축으로 회수
+
+**적용 방법**:
+- `docs/blog-service/openapi.yaml`로 작성
+- MCP 인터페이스는 별도 문서(`mcp-tools.md`)로 분리 (MCP는 JSON-RPC 기반이라 OpenAPI에 안 맞음)
+
+**관련**: 이슈 #137 (Step C)
+
+---
+
+## 2026-05-06 — Pipeline Engine 공통화 (REST/MCP 듀얼 인터페이스)
+
+**상황**: HTTP API와 MCP를 어떻게 둘 다 제공할 것인가.
+
+**결정**: 두 인터페이스가 같은 Pipeline Engine을 공유한다.
+
+**이유**:
+- 로직이 한 곳에 있어야 일관성·테스트·유지보수 용이
+- 새 인터페이스(예: gRPC, GraphQL) 추가 시 인터페이스 레이어만 추가
+- DataClinic의 검증된 패턴 (REST + MCP 듀얼)
+
+**구조**:
+```
+HTTP/SSE API ─┐
+              ├─→ Pipeline Engine ─→ Claude Code spawn → 블로그 레포
+MCP Server  ─┘
+```
+
+**관련**: [architecture.md](architecture.md) "Blog Service 내부 구조"
+
+---
+
+## 2026-05-06 — NanoClaw는 Blog Service의 한 클라이언트가 됨
+
+**상황**: 현재 Blog MCP가 NanoClaw 컨테이너 내부 stdio 전용. 이를 어떻게 진화시킬 것인가.
+
+**결정**: Blog Service를 NanoClaw 밖으로 분리. NanoClaw는 외부 서비스를 호출하는 클라이언트가 됨.
+
+**이유**:
+- NanoClaw 본연의 역할(채널 통합·사용자 컨텍스트)에 집중
+- Blog MCP가 다른 클라이언트(Web UI, Claude Desktop, 외부 에이전트)에서도 사용 가능
+- NanoClaw 변경과 Blog Service 변경의 개발 사이클 분리
+
+**호환성**: stdio MCP 모드는 유지하여 기존 NanoClaw 통합 깨지지 않음. HTTP MCP 모드를 추가로 노출.
+
+**관련**: [architecture.md](architecture.md), 이슈 #137
+
+---
+
+## 2026-05-06 — 분리 트리거 4종 명시
+
+**상황**: "통합 우선"을 결정했으나 분리 시점이 모호하면 영원히 안 한다.
+
+**결정**: 자산별 4가지 분리 트리거를 박아두고, 발동하면 진지하게 검토.
+
+**자산 3 (Blog Service) 트리거**:
+- Blog Service 코드 PR이 콘텐츠 PR을 추월
+- 외부 클라이언트 사용 시작
+- Blog Service 의존성이 본 레포 의존성 트리를 무겁게 만듦
+- CI/CD 시간이 분리 가치를 넘어섬
+
+**자산 2 (toolkit) 트리거**:
+- 외부 회사가 toolkit 적용 요청
+- 스킬 PR이 콘텐츠 PR보다 많아짐
+- 스킬에 대한 외부 기여자 발생
+
+**자산 1 (content) 정리 트리거**:
+- 글 1,000건 초과
+- GitHub Pages 빌드 시간 임계 초과
+- 다른 자산이 이미 분리되어 본 레포가 사실상 콘텐츠 전용
+
+**관련**: [architecture.md](architecture.md) "분리 트리거"


### PR DESCRIPTION
## Summary

이슈 #137 후속. Blog Service 독립화의 비전·결정·로드맵을 본 레포에 통합 상태로 박아둔다.

## 신규 파일

`docs/blog-service/`
- `README.md` — 비전 한 줄 요약 + 문서 인덱스
- `architecture.md` — 3-자산 분리 비전, Phase 0-4 로드맵, 분리 트리거
- `decision-log.md` — 주요 결정 5건 이력

## 핵심 결정 5건

1. **통합 우선, 분리 차차** — 본 레포에서 Phase 0/1/2 진행, 트리거 발동 시 분리
2. **3-자산 비전 명시** — 콘텐츠/메서드론/도구를 별도 레포로 분리할 미래 그림
3. **OpenAPI 정식 스펙** — Markdown 초안이 아닌 yaml 채택 (B 작업 시간 단축)
4. **Pipeline Engine 공통화** — REST/MCP 듀얼 인터페이스가 같은 엔진 공유
5. **NanoClaw는 클라이언트로 진화** — Blog Service 분리 후 한 클라이언트가 됨

## 분리 트리거

4종 트리거를 박아두어 "통합 우선"이 영원히 유지되지 않도록 안전장치.

## 다음 액션

C단계: `docs/blog-service/openapi.yaml` 작성

Refs #137