### PR TITLE
fix(voice): NanoClaw Exec Summary를 voice-edit default voice로 리라이트 (KO+EN)

### DIFF
--- a/report/nanoclaw-architecture-deep-dive/en/index.html
+++ b/report/nanoclaw-architecture-deep-dive/en/index.html
@@ -128,13 +128,13 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            NanoClaw (v1.2.12) is an open-source framework that implements a container-isolated, multi-channel AI agent on top of a radically compact codebase: 21 source files totaling 5,526 lines. A single Node.js process orchestrates the entire lifecycle — from message ingestion and container provisioning to scheduling and response delivery — by wrapping the Claude Agent SDK to delegate the agent execution loop.
+                            21 files. 5,526 lines. When I first opened NanoClaw (v1.2.12), it was hard to believe an entire multi-channel AI agent lived inside something this small. A single Node.js process takes the message, spins up a container, schedules the work, and sends the reply back. The reasoning loop is handed off to the Claude Agent SDK — but everything around that loop, this one process carries by hand.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Its 27,690 GitHub stars and 12,607 forks signal strong community interest, yet real-world constraints are equally clear: a single-file SQLite dependency, no horizontal scaling, and only two active channel adapters (Slack and Gmail) as of v1.2.12.
+                            27,690 stars on GitHub, 12,607 forks. That kind of attention does not gather around a small codebase by accident. And yet the limits are just as clear. NanoClaw leans on a single SQLite file, refuses to scale horizontally, and lights up only two channels in real life: Slack and Gmail. Keeping things small comes with reasons. It also comes with a cost.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            This report positions NanoClaw through a three-way comparison with Claude Agent SDK (a library, v0.2.118, 16.8M monthly npm downloads) and Anthropic Managed Agents (a hosted platform, launched April 2026), examining the design choices and trade-offs of self-hosted AI agent architectures.
+                            This piece reads NanoClaw alongside two other answers to the same moment — the Claude Agent SDK (a library, v0.2.118, 16.8M monthly npm downloads) and Anthropic Managed Agents (a hosted platform, launched April 2026). Three shapes for the same problem: a library you embed, a self-hosted framework you run, and a fully managed service you rent. Some choices are elegant. Some choices pay a price. This report walks through them one at a time.
                         </p>
                     </div>
                 </section>

--- a/report/nanoclaw-architecture-deep-dive/ko/index.html
+++ b/report/nanoclaw-architecture-deep-dive/ko/index.html
@@ -129,13 +129,13 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            NanoClaw(v1.2.12)는 21개 소스 파일, 5,526줄이라는 극단적으로 응축된 코드베이스 위에 컨테이너 격리 기반 멀티채널 AI 에이전트를 구현한 오픈소스 프레임워크다. 단일 Node.js 프로세스가 메시지 수신부터 컨테이너 기동, 스케줄링, 응답 전달까지 전 과정을 오케스트레이션하며, Claude Agent SDK를 래핑하여 에이전트 실행 루프를 위임한다.
+                            21개 파일, 5,526줄. 처음 NanoClaw(v1.2.12)의 소스를 열었을 때, 이 안에 멀티채널 AI 에이전트의 전 생애가 담겨 있다는 사실이 잘 믿기지 않았다. 단일 Node.js 프로세스가 메시지를 받고, 컨테이너를 띄우고, 스케줄을 잡고, 다시 답을 돌려 보낸다. 추론 루프는 Claude Agent SDK에 맡겼지만, 그 바깥의 모든 것을 이 한 프로세스가 손수 챙긴다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            GitHub 27,690 스타, 12,607 포크라는 수치가 보여주듯 커뮤니티의 관심은 뜨겁지만, SQLite 단일 파일 의존, 수평 확장 불가, 활성 채널 2개(Slack, Gmail)라는 현실적 한계도 뚜렷하다.
+                            GitHub 27,690 스타, 12,607 포크. 작은 코드베이스에 이 정도의 관심이 모인 이유는 따로 있다. 그러나 동시에 한계도 분명하다. SQLite 단일 파일에 매달려 있고, 수평 확장이 막혀 있고, 실제로 살아 움직이는 채널은 Slack과 Gmail 두 개뿐이다. 작게 만든 것에는 이유가 있지만, 작게 만든 것에는 대가도 있다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            본 보고서는 NanoClaw를 Claude Agent SDK(라이브러리, v0.2.118, 월 1,680만 npm 다운로드)와 Anthropic Managed Agents(호스팅 플랫폼, 2026년 4월 출시)와의 3자 비교를 통해 자체 호스팅 AI 에이전트 아키텍처의 설계 선택과 트레이드오프를 규명한다.
+                            이 글은 NanoClaw를 Claude Agent SDK(라이브러리, v0.2.118, 월 1,680만 npm 다운로드)와 Anthropic Managed Agents(호스팅 플랫폼, 2026년 4월 출시)와 나란히 놓고 따라가 본다. 같은 에이전트 시대의 세 가지 다른 답이 있다. 라이브러리, 자체 호스팅 프레임워크, 그리고 완전 관리형. 어떤 선택은 우아하고, 어떤 선택은 대가를 치른다. 이 보고서는 그 선택들을 하나씩 열어 보는 과정이다.
                         </p>
                     </div>
                 </section>


### PR DESCRIPTION
## Summary

voice-edit 시스템 첫 시연 검증. NanoClaw가 voice-essay v2 시점에 발행되었으나 자기검증 grep(\"본 보고서 ... 규명한다\") 1건 위반이 남아 있었음 — PR #157에서 발견.

KO/EN Exec Summary 각 3단락만 변경 (각 3줄 diff). 본문은 건드리지 않음.

## 변경 요약

**Before** (위키체):
> 본 보고서는 NanoClaw를 ... 규명한다.

**After** (default voice):
> 21개 파일, 5,526줄. 처음 NanoClaw의 소스를 열었을 때, 이 안에 멀티채널 AI 에이전트의 전 생애가 담겨 있다는 사실이 잘 믿기지 않았다. ...
> 어떤 선택은 우아하고, 어떤 선택은 대가를 치른다. 이 보고서는 그 선택들을 하나씩 열어 보는 과정이다.

## 자기검증

- KO: 위키체 0, 광고 0, 1인칭 흔적 2건 ✓
- EN: 광고 0, 1인칭 1건 ✓

## voice-edit 시스템 검증 메모

- voices/default.md \"Before/After\" 예시가 같은 도메인(NanoClaw)을 가상 사례로 썼던 게 시연에 강력하게 작용
- 정본 도메인(예술)과 대상 도메인(기술 보고서) 거리는 default voice의 자연스러운 한계

## Test plan

- [x] 로컬 프리뷰에서 KO/EN 렌더 확인
- [x] 자기검증 grep 통과
- [x] before/after 3건 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)