### PR TITLE
fix(layout): neuro-symbolic-ai-architecture + karpathy-llm-wiki 레이아웃 표준 회복

### DIFF
--- a/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/en/index.html
+++ b/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/en/index.html
@@ -551,7 +551,7 @@
             </nav>
 
             <!-- Main Article -->
-            <main class="w-full lg:max-w-[800px] lg:mx-auto">
+            <main class="max-w-[800px] px-4 sm:px-6">
                 <!-- Hero Section -->
                 <header id="hero-section" class="text-left mb-12">
                     <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight" ></h1>
@@ -1076,9 +1076,6 @@
 
             </main>
 
-            <!-- Right Sidebar -->
-            <aside class="hidden lg:block lg:w-[240px] lg:shrink-0">
-            </aside>
         </div>
     </div>
 

--- a/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/ko/index.html
+++ b/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/ko/index.html
@@ -550,7 +550,7 @@
             </nav>
 
             <!-- Main Article -->
-            <main class="w-full lg:max-w-[800px] lg:mx-auto">
+            <main class="max-w-[800px] px-4 sm:px-6">
                 <!-- Hero Section -->
                 <header id="hero-section" class="text-left mb-12">
                     <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight" ></h1>
@@ -1075,9 +1075,6 @@
 
             </main>
 
-            <!-- Right Sidebar -->
-            <aside class="hidden lg:block lg:w-[240px] lg:shrink-0">
-            </aside>
         </div>
     </div>
 

--- a/report/karpathy-llm-wiki/en/index.html
+++ b/report/karpathy-llm-wiki/en/index.html
@@ -197,8 +197,7 @@
 
                 <!-- Hero Section -->
                 <header class="text-left mb-12">
-                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-6 leading-tight"></h1>
-                                    <div id="share-buttons-placeholder" class="flex justify-start"></div>
+                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
                 </header>
 
                 <!-- Executive Summary -->

--- a/report/karpathy-llm-wiki/en/index.html
+++ b/report/karpathy-llm-wiki/en/index.html
@@ -201,26 +201,6 @@
                                     <div id="share-buttons-placeholder" class="flex justify-start"></div>
                 </header>
 
-                <!-- Stat Cards -->
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-16">
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">$10M–$20M</div>
-                        <div class="stat-label themeable-muted">Enterprise KG build cost</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">1.5M+</div>
-                        <div class="stat-label themeable-muted">Obsidian monthly active users</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">2×</div>
-                        <div class="stat-label themeable-muted">RAG accuracy on new facts<br>(vs. fine-tuning)</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">1.8 hrs</div>
-                        <div class="stat-label themeable-muted">Daily time spent searching<br>for information (McKinsey)</div>
-                    </div>
-                </div>
-
                 <!-- Executive Summary -->
                 <section id="executive-summary" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
@@ -228,6 +208,26 @@
                         <p class="themeable-text leading-relaxed">On April 3–4, 2026, Andrej Karpathy shared an LLM-powered personal knowledge base (PKB) methodology on X and GitHub Gist. This is not a productivity tip. It is a direct challenge to the knowledge representation paradigm — two decades built on OWL, SPARQL, and the specialized profession of ontology engineering. Traditional enterprise knowledge graphs demand $10M–$20M in upfront investment and years of expert labor, yet reach production deployment at a rate of only 27%. Karpathy achieves the same knowledge representation functionality with LLMs, Markdown, and Obsidian.</p>
                         <p class="themeable-text leading-relaxed mt-4">What Pebblous editor JH has called "Cheap Ontology" is exactly the right framing. The methodology runs on three layers: raw source materials stored immutably in a <code>raw/</code> directory (Layer 1); a Markdown wiki compiled and maintained by LLMs (Layer 2); and a schema document — a CLAUDE.md or AGENTS.md — that governs how the LLM operates (Layer 3). The key innovation is compounding. Traditional RAG performs a one-time retrieval against a vector database per query. In the Karpathy wiki, even query outputs get filed back into the wiki, so the knowledge asset grows with every use.</p>
                         <p class="themeable-text leading-relaxed mt-4">Context window expansion is what made this practical. From 2K tokens in GPT-3 (2020) to 2M tokens in Gemini 2.0 Pro (2025) — a 1,000× expansion in five years. Since Gemini 1.5 Pro hit 1M tokens in 2024, loading an entire wiki into a single context has become technically viable without any vector database. The critical bottleneck in this pipeline is the front door: if the raw data is noisy, errors propagate into the wiki, and if that wiki is then used to generate synthetic Q&amp;A for fine-tuning, those errors get baked into model weights permanently. Data quality diagnosis — what DataClinic provides — is the prerequisite for everything downstream. This article is part of the <a href="/project/NeuroSymbolicOntology/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Neuro-Symbolic × Ontology hub</a> series — tracing how twenty years of ontology engineering is being quietly democratized in the LLM era.</p>
+                    </div>
+
+                    <!-- Stat Cards -->
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-8">
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">$10M–$20M</div>
+                            <div class="stat-label themeable-muted">Enterprise KG build cost</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">1.5M+</div>
+                            <div class="stat-label themeable-muted">Obsidian monthly active users</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">2×</div>
+                            <div class="stat-label themeable-muted">RAG accuracy on new facts<br>(vs. fine-tuning)</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">1.8 hrs</div>
+                            <div class="stat-label themeable-muted">Daily time spent searching<br>for information (McKinsey)</div>
+                        </div>
                     </div>
 
                     <div class="quote-block mt-8">

--- a/report/karpathy-llm-wiki/ko/index.html
+++ b/report/karpathy-llm-wiki/ko/index.html
@@ -199,26 +199,6 @@
                                     <div id="share-buttons-placeholder" class="flex justify-start"></div>
                 </header>
 
-                <!-- Stat Cards -->
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-16">
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">$10M~$20M</div>
-                        <div class="stat-label themeable-muted">엔터프라이즈 KG 구축 비용</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">1.5M+</div>
-                        <div class="stat-label themeable-muted">Obsidian 월간 활성 사용자</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">2×</div>
-                        <div class="stat-label themeable-muted">RAG의 새 지식 정확도<br>(파인튜닝 대비)</div>
-                    </div>
-                    <div class="stat-card themeable-bg-secondary">
-                        <div class="stat-number text-orange-500">1.8시간</div>
-                        <div class="stat-label themeable-muted">직장인 일일 정보 검색 시간<br>(McKinsey)</div>
-                    </div>
-                </div>
-
                 <!-- Executive Summary -->
                 <section id="executive-summary" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
@@ -226,6 +206,26 @@
                         <p class="themeable-text leading-relaxed">2026년 4월 3~4일, 안드레이 카파시가 X(트위터)와 GitHub Gist에 공개한 LLM 기반 개인 지식 베이스(PKB) 방법론은 단순한 생산성 팁이 아니다. 이것은 20년간 OWL·SPARQL·온톨로지 엔지니어로 대표되던 지식 표현(knowledge representation) 패러다임에 대한 실질적 도전이다. 전통 엔터프라이즈 KG가 $1,000만~$2,000만 달러 비용에 수년의 전문가 투입을 요구하며 프로덕션 도입률 27%에 그치는 반면, 카파시는 LLM + 마크다운 + Obsidian 스택으로 동일한 지식 표현 기능을 구현한다.</p>
                         <p class="themeable-text leading-relaxed mt-4">페블러스 편집장 JH가 명명한 "저렴이 온톨로지"는 정확한 포지셔닝이다. 카파시의 방법론은 세 개 레이어로 구성된다. raw/ 디렉터리에 원본을 불변 저장하고(Layer 1), LLM이 이를 마크다운 위키로 컴파일·유지하며(Layer 2), CLAUDE.md나 AGENTS.md 형식의 스키마 문서가 LLM의 동작을 제어한다(Layer 3). 핵심 혁신은 지식이 복리 효과로 축적된다는 점이다. 기존 RAG가 쿼리마다 벡터 DB를 탐색하는 일회성 검색인 반면, 카파시 위키는 쿼리 결과조차 다시 위키에 파일링된다.</p>
                         <p class="themeable-text leading-relaxed mt-4">컨텍스트 윈도 확장이 이 방법론을 현실화했다. GPT-3의 2K 토큰(2020)에서 Gemini 2.0 Pro의 2M 토큰(2025)까지 5년간 1,000배 확장. 2024년 Gemini 1.5 Pro의 1M 토큰 달성 이후 "RAG 없이 전체 위키를 컨텍스트에 로드"하는 전략이 기술적으로 타당해졌다. 이 방법론의 핵심 병목은 파이프라인의 입구다. raw 데이터 품질이 낮으면 LLM이 생성하는 위키에 오류가 내재되고, 위키 기반의 합성 Q&A 데이터로 파인튜닝하면 오류가 모델 가중치에 고착된다. DataClinic이 제공하는 데이터 품질 진단은 이 파이프라인의 선결 조건이다. 이 글은 <a href="/project/NeuroSymbolicOntology/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">뉴로-심볼릭 × 온톨로지 허브</a>에서 큐레이션하는 시리즈의 일부로, 20년 온톨로지 공학이 LLM 시대에 어떻게 민주화되는지를 추적합니다.</p>
+                    </div>
+
+                    <!-- Stat Cards -->
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-8">
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">$10M~$20M</div>
+                            <div class="stat-label themeable-muted">엔터프라이즈 KG 구축 비용</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">1.5M+</div>
+                            <div class="stat-label themeable-muted">Obsidian 월간 활성 사용자</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">2×</div>
+                            <div class="stat-label themeable-muted">RAG의 새 지식 정확도<br>(파인튜닝 대비)</div>
+                        </div>
+                        <div class="stat-card themeable-bg-secondary">
+                            <div class="stat-number text-orange-500">1.8시간</div>
+                            <div class="stat-label themeable-muted">직장인 일일 정보 검색 시간<br>(McKinsey)</div>
+                        </div>
                     </div>
 
                     <div class="quote-block mt-8">

--- a/report/karpathy-llm-wiki/ko/index.html
+++ b/report/karpathy-llm-wiki/ko/index.html
@@ -194,9 +194,8 @@
             <main class="max-w-[800px] px-4 sm:px-6">
 
                 <!-- Hero Section -->
-                <header class="text-center mb-16">
-                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-6 leading-tight"></h1>
-                                    <div id="share-buttons-placeholder" class="flex justify-start"></div>
+                <header class="text-left mb-12">
+                    <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
                 </header>
 
                 <!-- Executive Summary -->


### PR DESCRIPTION
## Summary

PR #159 머지 후 발견된 두 글의 레이아웃 비표준 문제 수정. 두 글 모두 4월 발행 시점부터 비표준이었음 — 어제 reverse-link 작업과 무관.

## 이슈

### 1. neuro-symbolic-ai-architecture — 빈 우측 aside
- main class: \`w-full lg:max-w-[800px] lg:mx-auto\` → \`max-w-[800px] px-4 sm:px-6\` (표준)
- 비어 있던 \`<aside class=\"hidden lg:block lg:w-[240px]\"></aside>\` 제거
- KO+EN

### 2. karpathy-llm-wiki — stat-card가 Exec Summary 밖에 있음
- 4개 stat-card가 hero 직후, Executive Summary 헤딩 **이전**에 노출되던 문제
- Exec Summary section 내부, key-insight 직후로 이동 (openmetadata 표준 패턴)
- \`mb-16\` → \`mt-8\` 마진 조정
- KO+EN

## Test plan

- [ ] 프리뷰에서 neuro-symbolic-ai-architecture 본문 폭이 정상으로 보이는지
- [ ] 프리뷰에서 karpathy-llm-wiki stat-card가 \"Executive Summary\" 헤딩 아래에 있는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)