### PR TITLE
fix(bibliography): karpathy-llm-wiki 참고문헌 표준 정렬 (KO+EN)

### DIFF
--- a/report/karpathy-llm-wiki/en/index.html
+++ b/report/karpathy-llm-wiki/en/index.html
@@ -616,27 +616,43 @@
                 <!-- References -->
                 <section id="references" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">References</h2>
-                    <ol class="space-y-3 themeable-text text-sm">
-                        <li><strong>[1]</strong> Karpathy, A. (2026-04-03). X post on LLM knowledge base. https://x.com/karpathy/status/2039805659525644595</li>
-                        <li><strong>[2]</strong> Karpathy, A. (2026-04-04). GitHub Gist: LLM knowledge base methodology. https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f</li>
-                        <li><strong>[3]</strong> Berners-Lee, T., Hendler, J., &amp; Lassila, O. (2001). The Semantic Web. Scientific American, 284(5), 34–43. (~30,000 citations)</li>
-                        <li><strong>[4]</strong> Pan, S. et al. (2024). Unifying Large Language Models and Knowledge Graphs: A Roadmap. IEEE Transactions on Knowledge and Data Engineering. arXiv:2306.08302</li>
-                        <li><strong>[5]</strong> Ovadia, O. et al. (2024). Fine-Tuning or Retrieval? Comparing Knowledge Injection in LLMs. EMNLP 2024. arXiv:2312.05934</li>
-                        <li><strong>[6]</strong> Gunasekar, S. et al. (2023). Textbooks Are All You Need (phi-1). Microsoft Research. arXiv:2306.11644</li>
-                        <li><strong>[7]</strong> Tanwar, S. et al. (2024). The Impact of Hallucinations in Finetuned LLMs. arXiv:2510.09359</li>
-                        <li><strong>[8]</strong> Zhang, T. et al. (2024). RAFT: Adapting Language Model to Domain Specific RAG. arXiv:2403.10131</li>
-                        <li><strong>[9]</strong> LLM-empowered Knowledge Graph Construction and Reasoning Survey (2025). arXiv:2510.20345</li>
-                        <li><strong>[10]</strong> Edge, D. et al. (2024). From Local to Global: A Graph RAG Approach to Query-Focused Summarization. Microsoft. arXiv:2404.16130</li>
-                        <li><strong>[11]</strong> Guo, T. et al. (2024). LightRAG: Simple and Fast Retrieval-Augmented Generation. arXiv:2410.05779</li>
-                        <li><strong>[12]</strong> FineTuneBench (2024). Evaluating LLMs on Fine-Tuning New Information. arXiv:2411.05059</li>
-                        <li><strong>[13]</strong> Amazon Science (2024). Quality Matters More Than Quantity in LLM Training. arXiv:2409.16341</li>
-                        <li><strong>[14]</strong> Hybrid synthetic+real data approach (2024). arXiv:2410.09168</li>
-                        <li><strong>[15]</strong> McKinsey Global Institute (2012). The Social Economy: Unlocking Value and Productivity Through Social Technologies.</li>
-                        <li><strong>[16]</strong> MarketsandMarkets (2025). Knowledge Graph Market – Global Forecast to 2030.</li>
-                        <li><strong>[17]</strong> Graph Praxis (2026-02-01). The Ontology Tax: Why Enterprise KGs Stall at 27% Production Rate.</li>
-                        <li><strong>[18]</strong> ZipRecruiter (2025). Ontology Engineer Salary Report, United States.</li>
-                        <li><strong>[19]</strong> Gretel AI (2024). Synthetic Data Performance Benchmarks vs. Human-Curated Data.</li>
-                    </ol>
+
+                    <!-- Download Citation -->
+                    <div class="flex gap-2 mb-6">
+                        <button onclick="downloadCitation('bibtex')" class="text-xs px-3 py-1 rounded border themeable-border themeable-text hover:border-orange-500 transition-colors">BibTeX</button>
+                        <button onclick="downloadCitation('ris')" class="text-xs px-3 py-1 rounded border themeable-border themeable-text hover:border-orange-500 transition-colors">RIS</button>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Primary Sources (Karpathy)</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">1.</span><span class="ref-body">Karpathy, A. (2026-04-03). X post on LLM knowledge base. <a href="https://x.com/karpathy/status/2039805659525644595" target="_blank" rel="noopener">x.com</a></span></li>
+                        <li><span class="ref-num">2.</span><span class="ref-body">Karpathy, A. (2026-04-04). GitHub Gist: LLM knowledge base methodology. <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f" target="_blank" rel="noopener">gist.github.com</a></span></li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Academic Papers</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">3.</span><span class="ref-body">Berners-Lee, T., Hendler, J., &amp; Lassila, O. (2001). The Semantic Web. <em>Scientific American</em>, 284(5), 34–43. (~30,000 citations)</span></li>
+                        <li><span class="ref-num">4.</span><span class="ref-body">Pan, S. et al. (2024). Unifying Large Language Models and Knowledge Graphs: A Roadmap. <em>IEEE Transactions on Knowledge and Data Engineering</em>. <a href="https://arxiv.org/abs/2306.08302" target="_blank" rel="noopener">arXiv:2306.08302</a></span></li>
+                        <li><span class="ref-num">5.</span><span class="ref-body">Ovadia, O. et al. (2024). Fine-Tuning or Retrieval? Comparing Knowledge Injection in LLMs. <em>EMNLP 2024</em>. <a href="https://arxiv.org/abs/2312.05934" target="_blank" rel="noopener">arXiv:2312.05934</a></span></li>
+                        <li><span class="ref-num">6.</span><span class="ref-body">Gunasekar, S. et al. (2023). Textbooks Are All You Need (phi-1). <em>Microsoft Research</em>. <a href="https://arxiv.org/abs/2306.11644" target="_blank" rel="noopener">arXiv:2306.11644</a></span></li>
+                        <li><span class="ref-num">7.</span><span class="ref-body">Tanwar, S. et al. (2024). The Impact of Hallucinations in Finetuned LLMs. <a href="https://arxiv.org/abs/2510.09359" target="_blank" rel="noopener">arXiv:2510.09359</a></span></li>
+                        <li><span class="ref-num">8.</span><span class="ref-body">Zhang, T. et al. (2024). RAFT: Adapting Language Model to Domain Specific RAG. <a href="https://arxiv.org/abs/2403.10131" target="_blank" rel="noopener">arXiv:2403.10131</a></span></li>
+                        <li><span class="ref-num">9.</span><span class="ref-body">LLM-empowered Knowledge Graph Construction and Reasoning: A Survey (2025). <a href="https://arxiv.org/abs/2510.20345" target="_blank" rel="noopener">arXiv:2510.20345</a></span></li>
+                        <li><span class="ref-num">10.</span><span class="ref-body">Edge, D. et al. (2024). From Local to Global: A Graph RAG Approach to Query-Focused Summarization. <em>Microsoft Research</em>. <a href="https://arxiv.org/abs/2404.16130" target="_blank" rel="noopener">arXiv:2404.16130</a></span></li>
+                        <li><span class="ref-num">11.</span><span class="ref-body">Guo, T. et al. (2024). LightRAG: Simple and Fast Retrieval-Augmented Generation. <a href="https://arxiv.org/abs/2410.05779" target="_blank" rel="noopener">arXiv:2410.05779</a></span></li>
+                        <li><span class="ref-num">12.</span><span class="ref-body">FineTuneBench (2024). Evaluating LLMs on Fine-Tuning New Information. <a href="https://arxiv.org/abs/2411.05059" target="_blank" rel="noopener">arXiv:2411.05059</a></span></li>
+                        <li><span class="ref-num">13.</span><span class="ref-body">Amazon Science (2024). Quality Matters More Than Quantity in LLM Training. <a href="https://arxiv.org/abs/2409.16341" target="_blank" rel="noopener">arXiv:2409.16341</a></span></li>
+                        <li><span class="ref-num">14.</span><span class="ref-body">Hybrid synthetic+real data approach (2024). <a href="https://arxiv.org/abs/2410.09168" target="_blank" rel="noopener">arXiv:2410.09168</a></span></li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Industry &amp; Market Reports</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">15.</span><span class="ref-body">McKinsey Global Institute (2012). The Social Economy: Unlocking Value and Productivity Through Social Technologies.</span></li>
+                        <li><span class="ref-num">16.</span><span class="ref-body">MarketsandMarkets (2025). Knowledge Graph Market — Global Forecast to 2030.</span></li>
+                        <li><span class="ref-num">17.</span><span class="ref-body">Graph Praxis (2026-02-01). The Ontology Tax: Why Enterprise KGs Stall at 27% Production Rate.</span></li>
+                        <li><span class="ref-num">18.</span><span class="ref-body">ZipRecruiter (2025). Ontology Engineer Salary Report, United States.</span></li>
+                        <li><span class="ref-num">19.</span><span class="ref-body">Gretel AI (2024). Synthetic Data Performance Benchmarks vs. Human-Curated Data.</span></li>
+                    </ul>
                 </section>
 
                 <!-- Hub Series Notice -->
@@ -656,6 +672,22 @@
 
     <!-- Scripts -->
     <script src="/scripts/common-utils.js?v=20260404"></script>
+
+    <!-- Citation download (BibTeX/RIS) -->
+    <script src="https://cdn.jsdelivr.net/npm/citation-js@0.7/build/citation.min.js" defer></script>
+    <script>
+        async function downloadCitation(format) {
+            const res = await fetch('../references.json');
+            const data = await res.json();
+            const cite = new Cite(data);
+            const output = format === 'bibtex' ? cite.format('bibtex') : cite.format('ris');
+            const blob = new Blob([output], { type: 'text/plain' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'references.' + (format === 'bibtex' ? 'bib' : 'ris');
+            a.click();
+        }
+    </script>
     <script>
         document.addEventListener('DOMContentLoaded', async function() {
             const config = {

--- a/report/karpathy-llm-wiki/ko/index.html
+++ b/report/karpathy-llm-wiki/ko/index.html
@@ -566,27 +566,43 @@
                 <!-- References -->
                 <section id="references" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">참고문헌</h2>
-                    <ol class="space-y-3 themeable-text text-sm">
-                        <li><strong>[1]</strong> Karpathy, A. (2026-04-03). X post on LLM knowledge base. https://x.com/karpathy/status/2039805659525644595</li>
-                        <li><strong>[2]</strong> Karpathy, A. (2026-04-04). GitHub Gist: LLM knowledge base methodology. https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f</li>
-                        <li><strong>[3]</strong> Berners-Lee, T., Hendler, J., & Lassila, O. (2001). The Semantic Web. Scientific American, 284(5), 34–43. (~30,000 citations)</li>
-                        <li><strong>[4]</strong> Pan, S. et al. (2024). Unifying Large Language Models and Knowledge Graphs: A Roadmap. IEEE Transactions on Knowledge and Data Engineering. arXiv:2306.08302</li>
-                        <li><strong>[5]</strong> Ovadia, O. et al. (2024). Fine-Tuning or Retrieval? Comparing Knowledge Injection in LLMs. EMNLP 2024. arXiv:2312.05934</li>
-                        <li><strong>[6]</strong> Gunasekar, S. et al. (2023). Textbooks Are All You Need (phi-1). Microsoft Research. arXiv:2306.11644</li>
-                        <li><strong>[7]</strong> Tanwar, S. et al. (2024). The Impact of Hallucinations in Finetuned LLMs. arXiv:2510.09359</li>
-                        <li><strong>[8]</strong> Zhang, T. et al. (2024). RAFT: Adapting Language Model to Domain Specific RAG. arXiv:2403.10131</li>
-                        <li><strong>[9]</strong> LLM-empowered Knowledge Graph Construction and Reasoning Survey (2025). arXiv:2510.20345</li>
-                        <li><strong>[10]</strong> Edge, D. et al. (2024). From Local to Global: A Graph RAG Approach to Query-Focused Summarization. Microsoft. arXiv:2404.16130</li>
-                        <li><strong>[11]</strong> Guo, T. et al. (2024). LightRAG: Simple and Fast Retrieval-Augmented Generation. arXiv:2410.05779</li>
-                        <li><strong>[12]</strong> FineTuneBench (2024). Evaluating LLMs on Fine-Tuning New Information. arXiv:2411.05059</li>
-                        <li><strong>[13]</strong> Amazon Science (2024). Quality Matters More Than Quantity in LLM Training. arXiv:2409.16341</li>
-                        <li><strong>[14]</strong> Hybrid synthetic+real data approach (2024). arXiv:2410.09168</li>
-                        <li><strong>[15]</strong> McKinsey Global Institute (2012). The Social Economy: Unlocking Value and Productivity Through Social Technologies.</li>
-                        <li><strong>[16]</strong> MarketsandMarkets (2025). Knowledge Graph Market – Global Forecast to 2030.</li>
-                        <li><strong>[17]</strong> Graph Praxis (2026-02-01). The Ontology Tax: Why Enterprise KGs Stall at 27% Production Rate.</li>
-                        <li><strong>[18]</strong> ZipRecruiter (2025). Ontology Engineer Salary Report, United States.</li>
-                        <li><strong>[19]</strong> Gretel AI (2024). Synthetic Data Performance Benchmarks vs. Human-Curated Data.</li>
-                    </ol>
+
+                    <!-- Download Citation -->
+                    <div class="flex gap-2 mb-6">
+                        <button onclick="downloadCitation('bibtex')" class="text-xs px-3 py-1 rounded border themeable-border themeable-text hover:border-orange-500 transition-colors">BibTeX</button>
+                        <button onclick="downloadCitation('ris')" class="text-xs px-3 py-1 rounded border themeable-border themeable-text hover:border-orange-500 transition-colors">RIS</button>
+                    </div>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">1차 소스 (카파시)</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">1.</span><span class="ref-body">Karpathy, A. (2026-04-03). X post on LLM knowledge base. <a href="https://x.com/karpathy/status/2039805659525644595" target="_blank" rel="noopener">x.com</a></span></li>
+                        <li><span class="ref-num">2.</span><span class="ref-body">Karpathy, A. (2026-04-04). GitHub Gist: LLM knowledge base methodology. <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f" target="_blank" rel="noopener">gist.github.com</a></span></li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">학술 논문</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">3.</span><span class="ref-body">Berners-Lee, T., Hendler, J., &amp; Lassila, O. (2001). The Semantic Web. <em>Scientific American</em>, 284(5), 34–43. (~30,000 citations)</span></li>
+                        <li><span class="ref-num">4.</span><span class="ref-body">Pan, S. et al. (2024). Unifying Large Language Models and Knowledge Graphs: A Roadmap. <em>IEEE Transactions on Knowledge and Data Engineering</em>. <a href="https://arxiv.org/abs/2306.08302" target="_blank" rel="noopener">arXiv:2306.08302</a></span></li>
+                        <li><span class="ref-num">5.</span><span class="ref-body">Ovadia, O. et al. (2024). Fine-Tuning or Retrieval? Comparing Knowledge Injection in LLMs. <em>EMNLP 2024</em>. <a href="https://arxiv.org/abs/2312.05934" target="_blank" rel="noopener">arXiv:2312.05934</a></span></li>
+                        <li><span class="ref-num">6.</span><span class="ref-body">Gunasekar, S. et al. (2023). Textbooks Are All You Need (phi-1). <em>Microsoft Research</em>. <a href="https://arxiv.org/abs/2306.11644" target="_blank" rel="noopener">arXiv:2306.11644</a></span></li>
+                        <li><span class="ref-num">7.</span><span class="ref-body">Tanwar, S. et al. (2024). The Impact of Hallucinations in Finetuned LLMs. <a href="https://arxiv.org/abs/2510.09359" target="_blank" rel="noopener">arXiv:2510.09359</a></span></li>
+                        <li><span class="ref-num">8.</span><span class="ref-body">Zhang, T. et al. (2024). RAFT: Adapting Language Model to Domain Specific RAG. <a href="https://arxiv.org/abs/2403.10131" target="_blank" rel="noopener">arXiv:2403.10131</a></span></li>
+                        <li><span class="ref-num">9.</span><span class="ref-body">LLM-empowered Knowledge Graph Construction and Reasoning: A Survey (2025). <a href="https://arxiv.org/abs/2510.20345" target="_blank" rel="noopener">arXiv:2510.20345</a></span></li>
+                        <li><span class="ref-num">10.</span><span class="ref-body">Edge, D. et al. (2024). From Local to Global: A Graph RAG Approach to Query-Focused Summarization. <em>Microsoft Research</em>. <a href="https://arxiv.org/abs/2404.16130" target="_blank" rel="noopener">arXiv:2404.16130</a></span></li>
+                        <li><span class="ref-num">11.</span><span class="ref-body">Guo, T. et al. (2024). LightRAG: Simple and Fast Retrieval-Augmented Generation. <a href="https://arxiv.org/abs/2410.05779" target="_blank" rel="noopener">arXiv:2410.05779</a></span></li>
+                        <li><span class="ref-num">12.</span><span class="ref-body">FineTuneBench (2024). Evaluating LLMs on Fine-Tuning New Information. <a href="https://arxiv.org/abs/2411.05059" target="_blank" rel="noopener">arXiv:2411.05059</a></span></li>
+                        <li><span class="ref-num">13.</span><span class="ref-body">Amazon Science (2024). Quality Matters More Than Quantity in LLM Training. <a href="https://arxiv.org/abs/2409.16341" target="_blank" rel="noopener">arXiv:2409.16341</a></span></li>
+                        <li><span class="ref-num">14.</span><span class="ref-body">Hybrid synthetic+real data approach (2024). <a href="https://arxiv.org/abs/2410.09168" target="_blank" rel="noopener">arXiv:2410.09168</a></span></li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">업계·시장 소스</h3>
+                    <ul class="reference-list mb-6">
+                        <li><span class="ref-num">15.</span><span class="ref-body">McKinsey Global Institute (2012). The Social Economy: Unlocking Value and Productivity Through Social Technologies.</span></li>
+                        <li><span class="ref-num">16.</span><span class="ref-body">MarketsandMarkets (2025). Knowledge Graph Market — Global Forecast to 2030.</span></li>
+                        <li><span class="ref-num">17.</span><span class="ref-body">Graph Praxis (2026-02-01). The Ontology Tax: Why Enterprise KGs Stall at 27% Production Rate.</span></li>
+                        <li><span class="ref-num">18.</span><span class="ref-body">ZipRecruiter (2025). Ontology Engineer Salary Report, United States.</span></li>
+                        <li><span class="ref-num">19.</span><span class="ref-body">Gretel AI (2024). Synthetic Data Performance Benchmarks vs. Human-Curated Data.</span></li>
+                    </ul>
                 </section>
 
                 <!-- Hub Series Notice -->
@@ -606,6 +622,23 @@
 
     <!-- Scripts -->
     <script src="/scripts/common-utils.js?v=20260404"></script>
+
+    <!-- Citation download (BibTeX/RIS) -->
+    <script src="https://cdn.jsdelivr.net/npm/citation-js@0.7/build/citation.min.js" defer></script>
+    <script>
+        async function downloadCitation(format) {
+            const res = await fetch('../references.json');
+            const data = await res.json();
+            const cite = new Cite(data);
+            const output = format === 'bibtex' ? cite.format('bibtex') : cite.format('ris');
+            const blob = new Blob([output], { type: 'text/plain' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'references.' + (format === 'bibtex' ? 'bib' : 'ris');
+            a.click();
+        }
+    </script>
+
     <script>
         document.addEventListener('DOMContentLoaded', async function() {
             const config = {

--- a/report/karpathy-llm-wiki/references.json
+++ b/report/karpathy-llm-wiki/references.json
@@ -1,0 +1,186 @@
+[
+  {
+    "id": "karpathy2026x",
+    "type": "post-weblog",
+    "title": "X post on LLM knowledge base",
+    "author": [{"family": "Karpathy", "given": "Andrej"}],
+    "issued": {"date-parts": [[2026, 4, 3]]},
+    "container-title": "X (Twitter)",
+    "URL": "https://x.com/karpathy/status/2039805659525644595",
+    "note": "Primary source [1]. Karpathy's original announcement of LLM knowledge base methodology."
+  },
+  {
+    "id": "karpathy2026gist",
+    "type": "post-weblog",
+    "title": "GitHub Gist: LLM knowledge base methodology",
+    "author": [{"family": "Karpathy", "given": "Andrej"}],
+    "issued": {"date-parts": [[2026, 4, 4]]},
+    "container-title": "GitHub Gist",
+    "URL": "https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f",
+    "note": "Primary source [2]. Detailed methodology with raw/, wiki/, schema layers."
+  },
+  {
+    "id": "bernerslee2001semantic",
+    "type": "article-magazine",
+    "title": "The Semantic Web",
+    "author": [
+      {"family": "Berners-Lee", "given": "Tim"},
+      {"family": "Hendler", "given": "James"},
+      {"family": "Lassila", "given": "Ora"}
+    ],
+    "issued": {"date-parts": [[2001]]},
+    "container-title": "Scientific American",
+    "volume": "284",
+    "issue": "5",
+    "page": "34-43",
+    "note": "Foundational [3]. ~30,000 citations. The original Semantic Web vision."
+  },
+  {
+    "id": "pan2024unifying",
+    "type": "article-journal",
+    "title": "Unifying Large Language Models and Knowledge Graphs: A Roadmap",
+    "author": [{"family": "Pan", "given": "Shirui"}],
+    "issued": {"date-parts": [[2024]]},
+    "container-title": "IEEE Transactions on Knowledge and Data Engineering",
+    "URL": "https://arxiv.org/abs/2306.08302",
+    "note": "Reference [4]. arXiv:2306.08302. Comprehensive survey on LLM + KG unification."
+  },
+  {
+    "id": "ovadia2024finetuning",
+    "type": "paper-conference",
+    "title": "Fine-Tuning or Retrieval? Comparing Knowledge Injection in Language Models",
+    "author": [{"family": "Ovadia", "given": "Oded"}],
+    "issued": {"date-parts": [[2024]]},
+    "container-title": "EMNLP 2024",
+    "URL": "https://arxiv.org/abs/2312.05934",
+    "note": "Reference [5]. arXiv:2312.05934. RAG 0.875 vs FT 0.504 on new knowledge."
+  },
+  {
+    "id": "gunasekar2023textbooks",
+    "type": "article",
+    "title": "Textbooks Are All You Need",
+    "author": [{"family": "Gunasekar", "given": "Suriya"}],
+    "issued": {"date-parts": [[2023]]},
+    "container-title": "Microsoft Research",
+    "URL": "https://arxiv.org/abs/2306.11644",
+    "note": "Reference [6]. arXiv:2306.11644. phi-1 model — quality over quantity in training data."
+  },
+  {
+    "id": "tanwar2024hallucinations",
+    "type": "article",
+    "title": "The Impact of Hallucinations in Finetuned LLMs",
+    "author": [{"family": "Tanwar", "given": "Sambhav"}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2510.09359",
+    "note": "Reference [7]. arXiv:2510.09359."
+  },
+  {
+    "id": "zhang2024raft",
+    "type": "article",
+    "title": "RAFT: Adapting Language Model to Domain Specific RAG",
+    "author": [{"family": "Zhang", "given": "Tianjun"}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2403.10131",
+    "note": "Reference [8]. arXiv:2403.10131."
+  },
+  {
+    "id": "kg2025survey",
+    "type": "article",
+    "title": "LLM-empowered Knowledge Graph Construction and Reasoning: A Survey",
+    "author": [{"family": "Various", "given": ""}],
+    "issued": {"date-parts": [[2025]]},
+    "URL": "https://arxiv.org/abs/2510.20345",
+    "note": "Reference [9]. arXiv:2510.20345."
+  },
+  {
+    "id": "edge2024graphrag",
+    "type": "article",
+    "title": "From Local to Global: A Graph RAG Approach to Query-Focused Summarization",
+    "author": [{"family": "Edge", "given": "Darren"}],
+    "issued": {"date-parts": [[2024]]},
+    "container-title": "Microsoft Research",
+    "URL": "https://arxiv.org/abs/2404.16130",
+    "note": "Reference [10]. arXiv:2404.16130. Microsoft GraphRAG foundational paper."
+  },
+  {
+    "id": "guo2024lightrag",
+    "type": "article",
+    "title": "LightRAG: Simple and Fast Retrieval-Augmented Generation",
+    "author": [{"family": "Guo", "given": "Tianyu"}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2410.05779",
+    "note": "Reference [11]. arXiv:2410.05779."
+  },
+  {
+    "id": "finetunebench2024",
+    "type": "article",
+    "title": "FineTuneBench: Evaluating LLMs on Fine-Tuning New Information",
+    "author": [{"family": "Various", "given": ""}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2411.05059",
+    "note": "Reference [12]. arXiv:2411.05059."
+  },
+  {
+    "id": "amazon2024quality",
+    "type": "article",
+    "title": "Quality Matters More Than Quantity in LLM Training",
+    "author": [{"family": "Amazon Science", "given": ""}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2409.16341",
+    "note": "Reference [13]. arXiv:2409.16341."
+  },
+  {
+    "id": "hybrid2024synthetic",
+    "type": "article",
+    "title": "Hybrid synthetic+real data approach for LLM training",
+    "author": [{"family": "Various", "given": ""}],
+    "issued": {"date-parts": [[2024]]},
+    "URL": "https://arxiv.org/abs/2410.09168",
+    "note": "Reference [14]. arXiv:2410.09168."
+  },
+  {
+    "id": "mckinsey2012social",
+    "type": "report",
+    "title": "The Social Economy: Unlocking Value and Productivity Through Social Technologies",
+    "author": [{"family": "McKinsey Global Institute", "given": ""}],
+    "issued": {"date-parts": [[2012]]},
+    "publisher": "McKinsey Global Institute",
+    "note": "Reference [15]. Source of '1.8 hours daily information search' statistic."
+  },
+  {
+    "id": "mam2025kgmarket",
+    "type": "report",
+    "title": "Knowledge Graph Market — Global Forecast to 2030",
+    "author": [{"family": "MarketsandMarkets", "given": ""}],
+    "issued": {"date-parts": [[2025]]},
+    "publisher": "MarketsandMarkets",
+    "note": "Reference [16]. KG market $1.07B (2024) → $6.94B (2030), CAGR 36.6%."
+  },
+  {
+    "id": "graphpraxis2026ontology",
+    "type": "post-weblog",
+    "title": "The Ontology Tax: Why Enterprise KGs Stall at 27% Production Rate",
+    "author": [{"family": "Graph Praxis", "given": ""}],
+    "issued": {"date-parts": [[2026, 2, 1]]},
+    "container-title": "Graph Praxis",
+    "note": "Reference [17]. Coined 'Ontology Tax' framing."
+  },
+  {
+    "id": "ziprecruiter2025ontology",
+    "type": "report",
+    "title": "Ontology Engineer Salary Report, United States",
+    "author": [{"family": "ZipRecruiter", "given": ""}],
+    "issued": {"date-parts": [[2025]]},
+    "publisher": "ZipRecruiter",
+    "note": "Reference [18]. $107,282-$206,907/year salary range cited in the article."
+  },
+  {
+    "id": "gretel2024synthetic",
+    "type": "report",
+    "title": "Synthetic Data Performance Benchmarks vs. Human-Curated Data",
+    "author": [{"family": "Gretel AI", "given": ""}],
+    "issued": {"date-parts": [[2024]]},
+    "publisher": "Gretel AI",
+    "note": "Reference [19]. Synthetic data benchmark comparisons."
+  }
+]


### PR DESCRIPTION
## Summary

karpathy-llm-wiki 참고문헌 마크업을 bibliography 스킬 표준으로 정렬.

## 문제

사용자 스크린샷에서 \"1. [1]\" 같은 이중 번호 표시 발견:
- \`<ol>\` 자동 번호 + \`<strong>[N]</strong>\` 수동 번호 중복
- references.json (SSOT) 없음 → BibTeX/RIS 다운로드 불가

## 수정

### 1. references.json 신설 (CSL-JSON 19항목)
- 1차 소스 2건 (카파시 X / Gist)
- 학술 논문 12건 (arXiv/EMNLP/IEEE)
- 업계·시장 5건 (McKinsey, MarketsandMarkets 등)

### 2. HTML 마크업 표준화 (KO+EN)
- \`<ol class=\"space-y-3\">\` → \`<ul class=\"reference-list\">\`
- \`<strong>[N]</strong>\` → \`<span class=\"ref-num\">N.</span><span class=\"ref-body\">\`
- 카테고리별 h3 분류
- arXiv/DOI를 클릭 가능한 \`<a>\` 링크로

### 3. BibTeX/RIS 다운로드 버튼
- citation-js@0.7 defer 로드

## Test plan

- [ ] 프리뷰에서 번호 한 번만 표시되는지
- [ ] 카테고리별 h3 분류 보이는지
- [ ] BibTeX 버튼 클릭 시 .bib 다운로드 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)