### PR TITLE
fix(layout): OpenMetadata EN header-placeholder 교정 (로고 포함 글로벌 헤더 복구)

### DIFF
--- a/report/openmetadata-ai-ready-data-2026-04/en/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/en/index.html
@@ -79,8 +79,8 @@
     <!-- GTM noscript -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PFJMHG3S" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-    <!-- Navigation -->
-    <div id="nav-placeholder"></div>
+    <!-- Header -->
+    <div id="header-placeholder"></div>
 
     <!-- Page Layout -->
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12 max-w-[1400px]">


### PR DESCRIPTION
## Summary
- EN 페이지에서 페블러스 글로벌 헤더(로고 포함)가 렌더링되지 않던 문제 수정
- `report/openmetadata-ai-ready-data-2026-04/en/index.html` 83라인 `<div id="nav-placeholder">` → `<div id="header-placeholder">`

## Root Cause
`scripts/common-utils.js` 135라인의 `headerLoader`는 `document.getElementById('header-placeholder')`로 헤더 주입 위치를 찾는다. EN 파일이 `nav-placeholder`라는 비표준 id를 사용해서 헤더가 어디에도 그려지지 않았음.

## Scope Check
- 코드베이스 전체 표준: `header-placeholder` (918개 파일)
- 비표준 `nav-placeholder` 사용: 2개 파일 (이 파일 + 동일 파일의 worktree 사본)
- KO 파일은 정상 (이미 `header-placeholder` 사용)
- 푸터 placeholder는 KO/EN 둘 다 정상

## Test plan
- [x] `grep "header-placeholder"` 결과 EN 파일에서 정상 노출
- [x] 로컬 http://localhost:8000/report/openmetadata-ai-ready-data-2026-04/en/ 응답에 placeholder 포함 확인
- [x] common-utils.js 정상 로드 확인
- [ ] 브라우저에서 헤더(로고+메뉴) 렌더링 시각 확인 (리뷰어 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)