### PR TITLE
fix(hub): PhysicalAI hub reverse-link — Semrush 진단 1차 (4쌍/8페이지)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -44,7 +44,10 @@
         "레드팀",
         "모델 품질",
         "데이터 품질"
-      ]
+      ],
+      "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
+      "wordCount": 8538,
+      "modified": "2026-05-22"
     },
     {
       "id": "llm-jailbreak-2026-en",
@@ -68,7 +71,10 @@
         "red teaming",
         "model quality",
         "data quality"
-      ]
+      ],
+      "publisher": "Pebblous Data Communication Team",
+      "wordCount": 15880,
+      "modified": "2026-05-22"
     },
     {
       "id": "factory-bench-industrial-ai-2026-ko",
@@ -360,7 +366,7 @@
         "데이터 운영"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 16675,
+      "wordCount": 16810,
       "modified": "2026-05-13"
     },
     {
@@ -391,7 +397,7 @@
         "data operations"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 27468,
+      "wordCount": 27776,
       "modified": "2026-05-13"
     },
     {
@@ -568,7 +574,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 16236,
-      "modified": "2026-05-16"
+      "modified": "2026-05-22"
     },
     {
       "id": "openmetadata-ai-ready-data-2026-04-ko",
@@ -613,7 +619,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 14413,
+      "wordCount": 14690,
       "modified": "2026-04-24"
     },
     {
@@ -636,7 +642,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 15836,
+      "wordCount": 16131,
       "modified": "2026-04-26"
     },
     {
@@ -659,7 +665,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 8290,
+      "wordCount": 8421,
       "modified": "2026-04-26"
     },
     {
@@ -681,7 +687,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 7610,
+      "wordCount": 7737,
       "modified": "2026-04-24"
     },
     {
@@ -6849,8 +6855,8 @@
       ],
       "language": "ko",
       "publisher": "페블러스 데이터 커뮤니케이션 팀",
-      "wordCount": 6814,
-      "modified": "2026-04-29"
+      "wordCount": 6895,
+      "modified": "2026-05-22"
     },
     {
       "id": "iso5259-dataclinic-mapping",
@@ -9184,8 +9190,8 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 13764,
-      "modified": "2026-04-29"
+      "wordCount": 13882,
+      "modified": "2026-05-22"
     },
     {
       "id": "iso5259-dataclinic-mapping-en",
@@ -9216,8 +9222,8 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 8816,
-      "modified": "2026-04-29"
+      "wordCount": 8934,
+      "modified": "2026-05-22"
     },
     {
       "id": "iso5259-2-cheatsheet-en",
@@ -12837,7 +12843,7 @@
         "디지털 트윈"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 12195,
+      "wordCount": 12324,
       "modified": "2026-05-10"
     },
     {
@@ -12859,7 +12865,7 @@
         "Digital Twin"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 19877,
+      "wordCount": 20146,
       "modified": "2026-04-29"
     },
     {

--- a/project/PhysicalAI/en/index.html
+++ b/project/PhysicalAI/en/index.html
@@ -116,6 +116,22 @@
                     <a href="/project/PhysicalAI/digital-twin-physical-ai-market/en/" class="text-lg font-semibold" style="color: #F86825;">Digital Twin x Physical AI: Opportunities at the Intersection of Two Mega Markets</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">Digital Twin ($21–29B in 2025) and Physical AI ($5.1–5.4B) — two mega markets converging to create a $20–40B intersection opportunity by 2030. Analyzes the competitive landscape and Pebblous' data quality layer strategy.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/vla-architecture-comparison/en/" class="text-lg font-semibold" style="color: #F86825;">Three Teams, Three Robot Brains — A Head-to-Head Comparison of GR00T, Gemini, and π Architectures</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">In 2025, NVIDIA GR00T N1.7, Google Gemini Robotics 1.5, and Physical Intelligence π0.5 took three sharply different paths to give robots a brain. A 13-dimension comparison: slow reasoning + fast reflexes, language-first thinking, and diffusion flow.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/physical-ai-industry-landscape/en/" class="text-lg font-semibold" style="color: #F86825;">Money Is Pouring Into Physical AI — Big Tech, Startups, and Korea Read the Board</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">2025 robotics VC at $13.8B, humanoid-specific up 300% YoY. Dissecting the Physical AI ecosystem in three tiers: full-stack Big Tech (NVIDIA, Google, Tesla), hardware + AI startups (Figure AI, Skild AI, π), and Korea (Rainbow Robotics, K-Humanoid Alliance).</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/en/" class="text-lg font-semibold" style="color: #F86825;">Giving Robots Eyes — How 3DGS Is Reshaping Synthetic Data</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">98% of GR00T's training data is synthetic. 3D Gaussian Splatting closes the sim-to-real gap at 200+ FPS photorealistic rendering. SplatSim 86.25%, RoboSplat 87.8%. The NVIDIA NuRec+Warp+Cosmos+Marble four-layer stack, examined.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/multiagent-industrial-data-operations/en/" class="text-lg font-semibold" style="color: #F86825;">Multi-Agent AI Beyond Finance: Industrial Data Ops</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">TradingAgents has 60K GitHub stars, but cannot beat buy-and-hold. Where does the multi-agent pattern break when moved into manufacturing, logistics, healthcare, and energy? A triangulated architecture: DeerFlow + DataGreenhouse + domain adapters.</p>
+                </div>
             </div>
         </div>
 
@@ -155,7 +171,11 @@
                 'DataClinic/data-greenhouse',
                 'blog/john-deere-right-to-repair-2026',
                 'blog/neural-computers-meta',
-                'report/artemis-lunar-operations'
+                'report/artemis-lunar-operations',
+                'report/vla-architecture-comparison',
+                'report/physical-ai-industry-landscape',
+                'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',
+                'report/multiagent-industrial-data-operations'
             ],
             language: 'en'
         });

--- a/project/PhysicalAI/ko/index.html
+++ b/project/PhysicalAI/ko/index.html
@@ -116,6 +116,22 @@
                     <a href="/project/PhysicalAI/digital-twin-physical-ai-market/ko/" class="text-lg font-semibold" style="color: #F86825;">디지털트윈 x 피지컬AI: 두 거대 시장의 교차점에서 찾는 기회</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">디지털 트윈(2025년 $210~290억)과 피지컬 AI($51~54억), 두 거대 시장이 수렴하며 2030년 $200~400억 교차 기회를 형성합니다. NVIDIA, Siemens 경쟁 환경과 페블러스의 데이터 품질 레이어 전략을 분석합니다.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/vla-architecture-comparison/ko/" class="text-lg font-semibold" style="color: #F86825;">로봇의 뇌, 세 팀이 다르게 만들었다 — GR00T, Gemini, π 아키텍처 직접 비교</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">2025년 NVIDIA GR00T N1.7, Google Gemini Robotics 1.5, Physical Intelligence π0.5 — 세 VLA 모델의 아키텍처를 13개 차원으로 직접 비교합니다. 느린 추론 + 빠른 반사, 언어 우선 사고, 확산 흐름이라는 세 갈래 길.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/physical-ai-industry-landscape/ko/" class="text-lg font-semibold" style="color: #F86825;">Physical AI에 돈이 몰린다 — 빅테크, 스타트업, 그리고 한국, 각자의 판 읽기</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">2025년 로봇 스타트업 VC $138억, 휴머노이드 300% 급증. 풀스택 빅테크(NVIDIA, Google, Tesla), 하드웨어+AI 스타트업(Figure AI, Skild AI, π), 한국(Rainbow Robotics, K-Humanoid)을 세 층위로 해부합니다.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/ko/" class="text-lg font-semibold" style="color: #F86825;">로봇에게 눈을 주다 — 3DGS가 바꾸는 합성데이터의 미래</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">GR00T 학습 데이터의 98%가 합성. 3D Gaussian Splatting이 200+ FPS 포토리얼리스틱 렌더링으로 sim-to-real gap을 닫는다. SplatSim 86.25%, RoboSplat 87.8%. NVIDIA NuRec+Warp+Cosmos+Marble 4중 스택을 본다.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/multiagent-industrial-data-operations/ko/" class="text-lg font-semibold" style="color: #F86825;">멀티에이전트 AI, 금융 넘어 제조·물류까지 확산</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">TradingAgents가 60K 스타를 받았지만 buy-and-hold조차 못 이긴다. 산업 운영(제조·물류·헬스케어·에너지)에서 멀티에이전트 패턴은 어디서 무너지는가. DeerFlow + DataGreenhouse + 도메인의 삼각 통합 아키텍처를 제안.</p>
+                </div>
             </div>
         </div>
 
@@ -155,7 +171,11 @@
                 'DataClinic/data-greenhouse',
                 'blog/john-deere-right-to-repair-2026',
                 'blog/neural-computers-meta',
-                'report/artemis-lunar-operations'
+                'report/artemis-lunar-operations',
+                'report/vla-architecture-comparison',
+                'report/physical-ai-industry-landscape',
+                'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',
+                'report/multiagent-industrial-data-operations'
             ],
             language: 'ko'
         });

--- a/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/en/index.html
+++ b/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/en/index.html
@@ -105,7 +105,7 @@
                             NVIDIA's ecosystem is scaling this convergence to production. A four-layer stack of NuRec (reconstruction) + Warp (physics) + Cosmos (generative infill) + Marble (environment generation) forms an enterprise-grade pipeline. The Khronos glTF 3DGS standard (RC released, Q2 2026 ratification expected) and OpenUSD 3DGS support (ratified April 2026) are making 3DGS the "JPEG of 3D." With the synthetic data market projected to reach $1.79-3.7B by 2030 (CAGR 35-42%), quality assurance infrastructure for 3DGS-based synthetic data becomes the trust layer this market needs.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            For Pebblous, this shift is immediate. PebbloSim orchestrates Isaac Sim (physics simulation) and 3DGS (photorealistic rendering) in tandem, and Data Greenhouse's "zero-physical hallucination" quality guarantee is its core value proposition.
+                            For Pebblous, this shift is immediate. PebbloSim orchestrates Isaac Sim (physics simulation) and 3DGS (photorealistic rendering) in tandem, and Data Greenhouse's "zero-physical hallucination" quality guarantee is its core value proposition. This piece is the synthetic-data chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; how do we paint the world a robot will learn from?
                         </p>
                     </div>
 
@@ -669,6 +669,14 @@
                         <li>Jeong, M. et al. "DC4GS: Directional Consistency-Driven Adaptive Density Control for 3D Gaussian Splatting." NeurIPS 2025. arXiv: 2510.26921.</li>
                     </ol>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/ko/index.html
+++ b/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/ko/index.html
@@ -105,7 +105,7 @@
                             NVIDIA 생태계는 이 결합을 산업 수준으로 끌어올리고 있다. NuRec(재구성) + Warp(물리) + Cosmos(생성 보강) + Marble(환경 생성)의 4중 스택이 엔터프라이즈급 파이프라인을 구성한다. Khronos glTF 3DGS 표준(2026 Q2 비준 예정)과 OpenUSD 3DGS 지원(2026년 4월 비준)은 3DGS를 "3D의 JPEG"로 공식화했다. 합성데이터 시장이 2024년 $310-576M에서 2030년 $1.79-3.7B로 성장(CAGR 35-42%)하는 가운데, 3DGS 기반 합성데이터의 품질 검증 인프라는 이 시장의 신뢰 계층이 된다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            페블러스에게 이 전환은 직접적이다. 페블로심(PebbloSim)은 Isaac Sim(물리 시뮬레이터) + 3DGS(실감 렌더링)를 동시 제어하는 시스템이며, 데이터그린하우스가 생성하는 합성데이터의 "zero-physical hallucination" 품질 보증이 핵심 가치다.
+                            페블러스에게 이 전환은 직접적이다. 페블로심(PebbloSim)은 Isaac Sim(물리 시뮬레이터) + 3DGS(실감 렌더링)를 동시 제어하는 시스템이며, 데이터그린하우스가 생성하는 합성데이터의 "zero-physical hallucination" 품질 보증이 핵심 가치다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 합성데이터 편으로, 로봇이 학습할 세계를 어떻게 그릴 것인가를 다룬다.
                         </p>
                     </div>
 
@@ -742,6 +742,14 @@
                         <li>Jeong, M. et al. "DC4GS: Directional Consistency-Driven Adaptive Density Control for 3D Gaussian Splatting." NeurIPS 2025. <a href="https://arxiv.org/abs/2510.26921" target="_blank" rel="noopener" class="text-orange-500 hover:text-orange-400">arXiv: 2510.26921</a></li>
                     </ol>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/multiagent-industrial-data-operations/en/index.html
+++ b/report/multiagent-industrial-data-operations/en/index.html
@@ -100,7 +100,7 @@
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">While TradingAgents was crossing 60K stars on GitHub, multi-agent LLMs quietly became the default narrative in finance — the most structured domain we have. Then an independent reproducibility study at ACM Fintech 2026 reported that the same system could not consistently beat a plain buy-and-hold strategy. 60K stars verifies that the <em>direction</em> is interesting; it does not verify that the pattern <em>transfers</em> outside finance.</p>
                         <p class="themeable-text leading-relaxed mt-4">Take the TradingAgents pattern out of finance and drop it into industrial data operations — manufacturing, logistics, healthcare, and the grid. Where does it break? Three findings stand out. First, multi-agent architectures have already converged across domains — specialized roles, central orchestration, tool calls, a verification layer. Second, industry, unlike finance, has no clean post-hoc ground truth: backtesting collapses. Third, none of today's multi-agent infrastructures (LangGraph, DeerFlow, Anthropic Managed Agents) standardize a data-quality assurance layer. The evidence is damning on all three fronts: Shumailov et al. (Nature 2024) showed model collapse triggered by synthetic data at 1/1000 of the training mix; A2A baselines leaked 60–100% of payloads; MCP exhibited 5.5% tool-poisoning surface; 88% of AI pilots fail. Different faces, same root cause.</p>
-                        <p class="themeable-text leading-relaxed mt-4">Pebblous DataGreenhouse and DataClinic are positioned to close that gap. Standardize a data-readiness verification layer on top of MCP and you have an "Agentic Data Operations Quality OS" that any agent ecosystem can call into. Korea's sovereign-AI consortium, CJ Logistics' NextGen AI, Samsung's AI Factory roadmap, and KEPCO's grid paradigm shift are all waiting for the same middleware. The report proposes a triangulated architecture — DeerFlow + DataGreenhouse + domain adapters — and a "complement, not compete" strategy that places Pebblous's quality and trust layer above the orchestrator and LLM camps rather than against them.</p>
+                        <p class="themeable-text leading-relaxed mt-4">Pebblous DataGreenhouse and DataClinic are positioned to close that gap. Standardize a data-readiness verification layer on top of MCP and you have an "Agentic Data Operations Quality OS" that any agent ecosystem can call into. Korea's sovereign-AI consortium, CJ Logistics' NextGen AI, Samsung's AI Factory roadmap, and KEPCO's grid paradigm shift are all waiting for the same middleware. The report proposes a triangulated architecture — DeerFlow + DataGreenhouse + domain adapters — and a "complement, not compete" strategy that places Pebblous's quality and trust layer above the orchestrator and LLM camps rather than against them. This piece is the industrial-operations chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; where multi-agent patterns meet manufacturing and logistics, and where they break.</p>
                     </div>
                 </section>
 
@@ -785,6 +785,14 @@
 
                 <!-- FAQ placeholder -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/multiagent-industrial-data-operations/ko/index.html
+++ b/report/multiagent-industrial-data-operations/ko/index.html
@@ -100,7 +100,7 @@
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">TradingAgents가 GitHub에서 60K 스타를 넘기는 동안, 우리는 멀티에이전트 LLM이 금융이라는 가장 정형화된 도메인에서 새로운 패러다임으로 자리 잡는 광경을 보았다. 그러나 ACM Fintech 2026 재현성 연구는 같은 시스템이 buy-and-hold 단순 전략조차 추월하지 못함을 밝혔다. 60K 스타는 "방향성 검증"이지 "산업 transferability 검증"이 아니다.</p>
                         <p class="themeable-text leading-relaxed mt-4">TradingAgents 패턴을 산업 데이터 운영 — 제조, 물류, 헬스케어, 에너지 — 으로 옮기면 어디가 무너지는가. 결론은 셋이다. 첫째, 멀티에이전트 아키텍처는 이미 도메인 간 수렴했다 — 역할 분화 + 중앙 오케스트레이션 + 도구 호출 + 검증 레이어. 둘째, 산업 도메인은 금융과 달리 "정답이 사후에 명확해지는" 백테스팅이 불가능하다. 셋째, LangGraph·DeerFlow·Anthropic Managed Agents 어느 쪽도 데이터 품질 보증층을 표준으로 갖추지 않았다. 1/1000 합성 데이터로도 모델이 붕괴된다는 Shumailov et al. (Nature 2024)의 결과, A2A 베이스라인 60~100% 데이터 누출, MCP 5.5% 도구 포이즈닝, 88% 파일럿 실패 — 모두 같은 원인의 다른 얼굴이다.</p>
-                        <p class="themeable-text leading-relaxed mt-4">페블러스 DataGreenhouse / DataClinic은 이 공백을 채운다. MCP 표준 위에 데이터 readiness 검증 레이어를 표준화하면, 모든 에이전트 생태계에 cross-cut 가능한 "Agentic Data Operations Quality OS"가 된다. 한국 sovereign AI 컨소시엄, CJ대한통운 NextGen AI, 삼성 AI Factory, KEPCO 그리드 패러다임 시프트가 모두 같은 미들웨어를 기다리고 있다. 본 보고서는 DeerFlow + DataGreenhouse + 도메인의 삼각 통합 아키텍처를 제안하며, 페블러스가 오케스트레이터·LLM 진영과 경쟁하지 않고 그 위에 품질·신뢰 레이어를 얹는 "complement, not compete" 전략을 제시한다.</p>
+                        <p class="themeable-text leading-relaxed mt-4">페블러스 DataGreenhouse / DataClinic은 이 공백을 채운다. MCP 표준 위에 데이터 readiness 검증 레이어를 표준화하면, 모든 에이전트 생태계에 cross-cut 가능한 "Agentic Data Operations Quality OS"가 된다. 한국 sovereign AI 컨소시엄, CJ대한통운 NextGen AI, 삼성 AI Factory, KEPCO 그리드 패러다임 시프트가 모두 같은 미들웨어를 기다리고 있다. 본 보고서는 DeerFlow + DataGreenhouse + 도메인의 삼각 통합 아키텍처를 제안하며, 페블러스가 오케스트레이터·LLM 진영과 경쟁하지 않고 그 위에 품질·신뢰 레이어를 얹는 "complement, not compete" 전략을 제시한다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 산업 운영 편으로, 멀티에이전트가 제조·물류로 확산될 때 어디가 무너지는지를 본다.</p>
                     </div>
                 </section>
 
@@ -798,6 +798,14 @@
 
                 <!-- FAQ placeholder -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/physical-ai-industry-landscape/en/index.html
+++ b/report/physical-ai-industry-landscape/en/index.html
@@ -277,7 +277,7 @@
                             This report dissects the Physical AI ecosystem across three tiers: <span style="font-weight:600;">full-stack Big Tech</span> (NVIDIA, Google, Tesla, Amazon), <span style="font-weight:600;">hardware + AI startups</span> (Figure AI, Skild AI, Apptronik, 1X, PI), and <span style="font-weight:600;">Korea</span> (Rainbow Robotics, HD Hyundai, K-Humanoid Alliance). Each player has entered this market with distinct roles and strategies.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            The real competition is not about a single robot. <span style="font-weight:600;">"Who will control the robot OS"</span> is the central question of this war. NVIDIA has already drawn Figure AI, Boston Dynamics, Agility, and Skild AI into its Isaac ecosystem. The winner of this platform war will collect a software tax on every piece of hardware.
+                            The real competition is not about a single robot. <span style="font-weight:600;">"Who will control the robot OS"</span> is the central question of this war. NVIDIA has already drawn Figure AI, Boston Dynamics, Agility, and Skild AI into its Isaac ecosystem. The winner of this platform war will collect a software tax on every piece of hardware. This piece is the industry-landscape chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; reading where capital and platforms actually flow.
                         </p>
                     </div>
 
@@ -923,6 +923,14 @@
                         </div>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/physical-ai-industry-landscape/ko/index.html
+++ b/report/physical-ai-industry-landscape/ko/index.html
@@ -266,7 +266,7 @@
                             이 리포트는 Physical AI 생태계를 세 층위로 해부한다. <span style="font-weight:600;">풀스택 빅테크</span>(NVIDIA, Google, Tesla, Amazon), <span style="font-weight:600;">하드웨어+AI 스타트업</span>(Figure AI, Skild AI, Apptronik, 1X, PI), 그리고 <span style="font-weight:600;">한국</span>(Rainbow Robotics, HD Hyundai, K-Humanoid Alliance). 각 플레이어는 서로 다른 역할과 전략으로 이 시장에 참전했다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            진짜 경쟁은 로봇 한 대가 아니다. <span style="font-weight:600;">"누가 로봇 OS를 장악하는가"</span>가 이 전쟁의 핵심이다. NVIDIA는 Isaac 생태계로 이미 Figure AI, Boston Dynamics, Agility, Skild AI를 끌어들였다. 이 플랫폼 전쟁의 승자가 하드웨어 위의 소프트웨어 세금을 걷는다.
+                            진짜 경쟁은 로봇 한 대가 아니다. <span style="font-weight:600;">"누가 로봇 OS를 장악하는가"</span>가 이 전쟁의 핵심이다. NVIDIA는 Isaac 생태계로 이미 Figure AI, Boston Dynamics, Agility, Skild AI를 끌어들였다. 이 플랫폼 전쟁의 승자가 하드웨어 위의 소프트웨어 세금을 걷는다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 산업 지형 편으로, 자본과 플랫폼이 어디로 흐르는지를 읽는 자리다.
                         </p>
                     </div>
 
@@ -912,6 +912,14 @@
                         </div>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/vla-architecture-comparison/en/index.html
+++ b/report/vla-architecture-comparison/en/index.html
@@ -176,7 +176,7 @@
                             These architectural choices cascade into training data strategy and hardware dependency. GR00T leverages over 20,000 hours of human egocentric video (EgoScale) combined with Isaac simulator synthetic data, uncovering a manipulation scaling law along the way. Gemini Robotics uses Motion Transfer to unify data from heterogeneous robot platforms into a single representation space. &pi;0.5 stacks Flow Matching on top of PaliGemma 3B and demonstrates laundry-folding-level dexterous manipulation. Each model also takes a fundamentally different stance on how &mdash; or whether &mdash; to integrate a world model.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            2025 is the "OpenAI moment" for robot foundation models. Which architecture will survive real-world deployment remains an open question. This report compares the three models across 13 dimensions, examining what each team solved and where their limits lie.
+                            2025 is the "OpenAI moment" for robot foundation models. Which architecture will survive real-world deployment remains an open question. This report compares the three models across 13 dimensions, examining what each team solved and where their limits lie. This piece is the VLA architecture comparison chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; a close reading of how three teams chose to design a robot's brain.
                         </p>
                     </div>
                 </section>
@@ -716,6 +716,14 @@ flowchart LR
                         </p>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/vla-architecture-comparison/ko/index.html
+++ b/report/vla-architecture-comparison/ko/index.html
@@ -176,7 +176,7 @@
                             기술적 차이는 아키텍처 선택에서 시작해 학습 데이터 전략과 하드웨어 종속성까지 이어진다. GR00T는 2만여 시간의 인간 1인칭 영상(EgoScale)과 Isaac 시뮬레이터 합성 데이터로 스케일링 법칙을 발견했다. Gemini Robotics는 Motion Transfer로 서로 다른 로봇 플랫폼의 데이터를 하나의 표현 공간에 통합했다. π0.5는 PaliGemma 3B 위에 Flow Matching을 올려 세탁물 접기 수준의 정밀 조작을 가능하게 했다. 세 모델 모두 "월드 모델"과의 경계에서 서로 다른 선택을 했다는 점도 중요한 분기점이다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            2025년은 로봇 파운데이션 모델의 "오픈AI 모멘트"다. 어떤 아키텍처가 실제 배포 환경에서 살아남을지는 아직 열려 있다. 이 리포트는 세 모델을 13개 차원으로 직접 비교해, 각 팀이 어떤 문제를 풀었고 어떤 한계를 안고 있는지를 해부한다.
+                            2025년은 로봇 파운데이션 모델의 "오픈AI 모멘트"다. 어떤 아키텍처가 실제 배포 환경에서 살아남을지는 아직 열려 있다. 이 리포트는 세 모델을 13개 차원으로 직접 비교해, 각 팀이 어떤 문제를 풀었고 어떤 한계를 안고 있는지를 해부한다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 VLA 아키텍처 비교 편으로, 로봇의 뇌가 어떻게 설계되는지를 보는 자리다.
                         </p>
                     </div>
                 </section>
@@ -716,6 +716,14 @@ flowchart LR
                         </p>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 1차 해결
- 영향 페이지 54개 중 8개(4쌍 KO+EN) 처리
- PhysicalAI hub와 시리즈 글 사이 양방향 reverse-link 정착

## 처리한 글 (4쌍)

| 글 | 시리즈 내 포지셔닝 |
|---|---|
| `report/vla-architecture-comparison` | VLA 아키텍처 비교 편 (GR00T / Gemini / π) |
| `report/physical-ai-industry-landscape` | 산업 지형 편 (자본·플랫폼 흐름) |
| `report/isaac-sim-3dgs-vla-synthetic-data-2026-04` | 합성데이터 편 (3DGS) |
| `report/multiagent-industrial-data-operations` | 산업 운영 편 (멀티에이전트 확산) |

## 적용 패턴 — `docs/hub-reverse-link.md` 그대로

- **(A) Executive Summary 마지막 `<p>` 끝**: inline 백링크 한 문장 (글마다 포지셔닝 차별화)
- **(B) `</main>` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 양방향 완성

`project/PhysicalAI/{ko,en}/index.html`:
- "시리즈 가이드" 섹션에 4개 정적 카드 추가 (SEO용 forward-link)
- `extraPaths`에 4개 추가 (동적 카드 그리드 자동 등록)

## 진단 근거

```
Page URL → 정적 HTML 내부 nav 링크
이전: 0개 (CSS/이미지/hreflang만)
이후: 2개 (hub로 inline + Notice)
```

PebblousRelatedPosts JS 모듈은 UX용으로 살려두되 SEO 카운트로는 의존하지 않음 (Semrush·일부 GoogleBot이 JS 미실행).

## 후속 작업

Semrush 영향 페이지 54개 중 이번 PR은 8개 해결. 나머지 **46개는 별도 PR로 단계적 진행 예정**:
- DataClinic hub 흡수 (dataclinic-story 시리즈 등)
- BizReport hub 흡수 (circle-analysis 등)
- 새 hub 신설 후보: AnthropicClaude (6쌍 글 묶음)
- 단발 글 cross-link (yann-lecun-jepa ↔ vla-architecture 등)

## Test Plan

- [ ] 페이지 빌드 후 `curl` 로 정적 HTML에 `/project/PhysicalAI/{lang}/` 링크 2개씩 들어가 있는지 확인
- [ ] PhysicalAI hub에서 신규 4개 카드가 시리즈 가이드 + 동적 그리드 둘 다 보이는지 시각 확인
- [ ] Semrush 다음 크롤 후 영향 페이지 수 감소 추적 (54 → 46 기대)