### PR TITLE
fix(hub): DataClinic hub reverse-link — Semrush 진단 2차 (3쌍/6페이지)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -367,7 +367,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 16810,
-      "modified": "2026-05-13"
+      "modified": "2026-05-22"
     },
     {
       "id": "multiagent-industrial-data-operations-en",
@@ -398,7 +398,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 27776,
-      "modified": "2026-05-13"
+      "modified": "2026-05-22"
     },
     {
       "id": "dataclinic-report-102-whitestarmnist-story-pb-ko",
@@ -422,7 +422,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 7876,
+      "wordCount": 7999,
       "modified": "2026-05-05"
     },
     {
@@ -447,7 +447,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 16243,
+      "wordCount": 16527,
       "modified": "2026-05-05"
     },
     {
@@ -472,7 +472,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 6768,
+      "wordCount": 6895,
       "modified": "2026-05-03"
     },
     {
@@ -497,7 +497,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 13195,
+      "wordCount": 13485,
       "modified": "2026-05-03"
     },
     {
@@ -620,7 +620,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 14690,
-      "modified": "2026-04-24"
+      "modified": "2026-05-22"
     },
     {
       "id": "vla-architecture-comparison-en",
@@ -643,7 +643,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 16131,
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "vla-architecture-comparison-ko",
@@ -666,7 +666,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 8421,
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "physical-ai-industry-landscape-ko",
@@ -688,7 +688,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 7737,
-      "modified": "2026-04-24"
+      "modified": "2026-05-22"
     },
     {
       "id": "web3-data-economy-ko",
@@ -10221,7 +10221,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "modified": "2026-04-22"
+      "modified": "2026-05-22"
     },
     {
       "id": "physicalai-hub-en",
@@ -10249,7 +10249,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "modified": "2026-04-22"
+      "modified": "2026-05-22"
     },
     {
       "id": "shareholder-letter-2026-03-ko",
@@ -12460,7 +12460,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 4108,
+      "wordCount": 4233,
       "modified": "2026-04-20"
     },
     {
@@ -12483,7 +12483,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 7734,
+      "wordCount": 7991,
       "modified": "2026-04-24"
     },
     {
@@ -12844,7 +12844,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 12324,
-      "modified": "2026-05-10"
+      "modified": "2026-05-22"
     },
     {
       "id": "isaac-sim-3dgs-vla-synthetic-data-2026-04-en",
@@ -12866,7 +12866,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 20146,
-      "modified": "2026-04-29"
+      "modified": "2026-05-22"
     },
     {
       "id": "claude-creative-work-connectors-ko",

--- a/blog/dc-story-produce-pipeline-meta/en/index.html
+++ b/blog/dc-story-produce-pipeline-meta/en/index.html
@@ -232,7 +232,7 @@
                         <p class="themeable-text leading-relaxed mt-4">
                             This article dissects that process.
                             Which agent did what, where the time went, and when a human stepped in.
-                            It is the execution log of a multi-agent content pipeline, laid bare.
+                            It is the execution log of a multi-agent content pipeline, laid bare. This piece is the pipeline-meta chapter of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series &mdash; how a diagnostic becomes a story.
                         </p>
                     </div>
 
@@ -589,6 +589,14 @@
 
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 DataClinic Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series curated by Pebblous &mdash; diagnosing and prescribing for AI training data, holding our own datasets and public benchmarks to the same standard.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/blog/dc-story-produce-pipeline-meta/ko/index.html
+++ b/blog/dc-story-produce-pipeline-meta/ko/index.html
@@ -232,7 +232,7 @@
                         <p class="themeable-text leading-relaxed mt-4">
                             이 글은 그 과정 자체를 해부합니다.
                             어떤 에이전트가 무엇을 했고, 시간은 어디에 쓰였으며, 사람은 언제 개입했는지.
-                            멀티 에이전트 콘텐츠 파이프라인의 실제 실행 기록입니다.
+                            멀티 에이전트 콘텐츠 파이프라인의 실제 실행 기록입니다. 이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a> 시리즈의 파이프라인 메타 편으로, 진단이 어떻게 콘텐츠로 잇는지를 보는 자리입니다.
                         </p>
                     </div>
 
@@ -590,6 +590,14 @@
 
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 데이터클리닉 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a>에서 큐레이션하는 시리즈의 일부입니다. AI 학습 데이터를 진단하고 처방하는 자리 — 자사 데이터부터 공개 벤치마크까지 같은 잣대로 본다.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/project/DataClinic/en/index.html
+++ b/project/DataClinic/en/index.html
@@ -113,6 +113,18 @@
                     <a href="/project/DataClinic/pbls-patent-portfolio-2025/en/" class="text-lg font-semibold" style="color: #F86825;">Pebblous IP Portfolio & Technology Competitiveness In-Depth Analysis</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">Comprehensive survey of US, Korea, Japan, and PCT patent portfolios. Global IP strategy and Physical AI market competitiveness analysis covering Data Imaging, Manifold Learning, and Synthetic Data generation.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/dataclinic-report-102-whitestarmnist-story-pb/en/" class="text-lg font-semibold" style="color: #F86825;">Star-MNIST Data Quality Diagnostic — 10-Class Synthetic Geometry Dataset Analysis</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">Pebblous DAL diagnoses its own Star-MNIST dataset with its own DataClinic — score 54, rated "Poor." The mean images of all 10 classes converge to the same gray circle, a trap of pixel-space averaging. Honest self-diagnosis.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/dataclinic-report-126-places365-story-pb/en/" class="text-lg font-semibold" style="color: #F86825;">Places365 Data Quality Diagnostic — 1.8M Scene Recognition Dataset Analysis</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">MIT CSAIL's Places365: 1.8M images, 365 classes — looks like the most balanced dataset on the surface. DataClinic finds 61 classes overlapping in feature space. The visual identity gap hiding beneath the veneer of "uniform distribution."</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/blog/dc-story-produce-pipeline-meta/en/" class="text-lg font-semibold" style="color: #F86825;">Multi-Agent Content Automation — How 7 AI Agents Write a Blog Post in 9 Steps</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">First full end-to-end run of the dc-story-produce pipeline. 7 AI agents, 141 tool calls across 9 stages, ~2 hours, producing two blog posts (KO + EN). How a diagnostic becomes a story.</p>
+                </div>
             </div>
         </div>
 
@@ -144,7 +156,10 @@
                 'ISO5259/5259-pbls-dataclinic-02',
                 'AADS/regulation-governance-qa-dataset',
                 'AADS/safety-qa-dataset',
-                'DataClinic/pbls-patent-us-01'
+                'DataClinic/pbls-patent-us-01',
+                'story/dataclinic-report-102-whitestarmnist-story-pb',
+                'story/dataclinic-report-126-places365-story-pb',
+                'blog/dc-story-produce-pipeline-meta'
             ],
             language: 'en'
         });

--- a/project/DataClinic/ko/index.html
+++ b/project/DataClinic/ko/index.html
@@ -116,6 +116,18 @@
                     <a href="/project/DataClinic/pbls-patent-us-01/ko/" class="text-lg font-semibold" style="color: #F86825;">페블러스 미국 특허 (US 12,481,720 B2) 기술 및 비즈니스 가치 분석</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">데이터 이미징과 임베딩 공간 분석을 통해 AI 데이터 품질을 진단하고 개선하는 독점 기술. ISO/IEC 5259-2 표준의 유사성, 대표성, 다양성을 정량적으로 측정하는 DataClinic의 핵심 특허입니다.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/dataclinic-report-102-whitestarmnist-story-pb/ko/" class="text-lg font-semibold" style="color: #F86825;">Star-MNIST 데이터 품질 진단 — 합성 기하 도형 10 클래스 60,000장 분석</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">페블러스 DAL이 만든 Star-MNIST를 자사 DataClinic으로 진단한 결과 54점, "나쁨" 등급. 10개 클래스의 평균 이미지가 모두 같은 회색 원이 되는 픽셀 공간의 함정. 자가진단의 정직성.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/dataclinic-report-126-places365-story-pb/ko/" class="text-lg font-semibold" style="color: #F86825;">Places365 데이터 품질 진단 — AI 씬 인식 데이터셋 180만 장 분석</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">MIT CSAIL Places365 180만 장, 365개 클래스. 표면적으로는 가장 균형 잡힌 데이터셋이지만 DataClinic은 61개 클래스가 피처 공간에서 중첩됨을 발견. 균형이라는 외피 아래 숨은 시각적 정체성의 격차.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/blog/dc-story-produce-pipeline-meta/ko/" class="text-lg font-semibold" style="color: #F86825;">멀티 에이전트 콘텐츠 자동화 — AI 7개가 블로그 1편을 만드는 9단계</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">dc-story-produce 파이프라인 첫 전 단계 실행 기록. AI 에이전트 7개가 9단계에 걸쳐 141회 tool call, 약 2시간 만에 한국어+영어 블로그 포스트 2편을 생성. 진단이 어떻게 콘텐츠로 잇는가.</p>
+                </div>
             </div>
         </div>
 
@@ -149,7 +161,10 @@
                 'AADS/robot-qa-dataset/',
                 'AADS/robot-qa-dataset-2',
                 'AADS/safety-qa-dataset',
-                'DataClinic/pbls-patent-us-01'
+                'DataClinic/pbls-patent-us-01',
+                'story/dataclinic-report-102-whitestarmnist-story-pb',
+                'story/dataclinic-report-126-places365-story-pb',
+                'blog/dc-story-produce-pipeline-meta'
             ],
             language: 'ko'
         });

--- a/story/dataclinic-report-102-whitestarmnist-story-pb/en/index.html
+++ b/story/dataclinic-report-102-whitestarmnist-story-pb/en/index.html
@@ -159,7 +159,7 @@
                             Here is the key finding. The mean images of all ten classes are the same gray circle. A 4-pointed star and an 8-pointed star are clearly different shapes, yet averaging them cancels out the vertices and both converge into the same circular blob. In pixel space, the classes are indistinguishable. In feature space (L2/L3), high-density duplicates concentrate in Class 11 (star patterns), while Classes 3, 4, and 5 show wider dispersion, forming a clear two-group split.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Dimensionality optimization (from 1,280 down to 155 dimensions) amplified this gap threefold. It preserved the structure while enhancing class separability, but did not solve the fundamental lack of data diversity. Two prescriptions follow: a Data Diet to remove duplicate data from Class 11, and a Data Bulk-Up to add variations to Classes 3, 4, and 5. Diagnosing your own data with your own tool and refusing to hide a score of 54 out of 100 — that is honest self-assessment of data quality.
+                            Dimensionality optimization (from 1,280 down to 155 dimensions) amplified this gap threefold. It preserved the structure while enhancing class separability, but did not solve the fundamental lack of data diversity. Two prescriptions follow: a Data Diet to remove duplicate data from Class 11, and a Data Bulk-Up to add variations to Classes 3, 4, and 5. Diagnosing your own data with your own tool and refusing to hide a score of 54 out of 100 — that is honest self-assessment of data quality. This piece is the self-diagnosis chapter of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series &mdash; where the makers run their own data through their own tool first.
                         </p>
                     </div>
 
@@ -898,6 +898,14 @@
                         </li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 DataClinic Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series curated by Pebblous &mdash; diagnosing and prescribing for AI training data, holding our own datasets and public benchmarks to the same standard.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/story/dataclinic-report-102-whitestarmnist-story-pb/ko/index.html
+++ b/story/dataclinic-report-102-whitestarmnist-story-pb/ko/index.html
@@ -159,7 +159,7 @@
                             핵심 발견은 이것이다. 10개 클래스의 평균 이미지가 모두 같은 회색 원이다. 4꼭짓점 별과 8꼭짓점 별은 분명히 다른 도형이지만, 평균을 내면 꼭짓점이 상쇄되어 같은 원형 블롭으로 수렴한다. 픽셀 공간에서는 클래스를 구별할 수 없다. 특징 공간(L2/L3)에서는 클래스 11(별 패턴)에 고밀도 중복이 집중되고, 클래스 3, 4, 5는 상대적으로 분산이 넓어 뚜렷한 2그룹으로 분리된다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            차원 최적화(1,280차원에서 155차원)는 이 격차를 3배로 증폭시켰다. 구조를 보존하면서 클래스 구별력을 강화했지만, 근본적인 데이터 다양성 부족은 해결하지 못했다. 처방은 두 가지다. 클래스 11의 중복 데이터를 걷어내는 Data Diet, 클래스 3, 4, 5에 변형을 추가하는 Data Bulk-Up. 자사 데이터를 자사 도구로 진단하고, 54점이라는 결과를 숨기지 않는 것. 데이터 품질에 대한 정직한 자기 검증이다.
+                            차원 최적화(1,280차원에서 155차원)는 이 격차를 3배로 증폭시켰다. 구조를 보존하면서 클래스 구별력을 강화했지만, 근본적인 데이터 다양성 부족은 해결하지 못했다. 처방은 두 가지다. 클래스 11의 중복 데이터를 걷어내는 Data Diet, 클래스 3, 4, 5에 변형을 추가하는 Data Bulk-Up. 자사 데이터를 자사 도구로 진단하고, 54점이라는 결과를 숨기지 않는 것. 데이터 품질에 대한 정직한 자기 검증이다. 이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a> 시리즈의 자가진단 편으로, 만든 사람이 자기 데이터를 가장 먼저 의심하는 자리다.
                         </p>
                     </div>
 
@@ -898,6 +898,14 @@
                         </li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 데이터클리닉 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a>에서 큐레이션하는 시리즈의 일부입니다. AI 학습 데이터를 진단하고 처방하는 자리 — 자사 데이터부터 공개 벤치마크까지 같은 잣대로 본다.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/story/dataclinic-report-126-places365-story-pb/en/index.html
+++ b/story/dataclinic-report-126-places365-story-pb/en/index.html
@@ -165,7 +165,7 @@
                             The DataClinic diagnostic reveals structural problems hiding beneath that balance. At least 61 classes overlap in the feature space, including 16 types of food-and-beverage venues and 8 types of residential spaces. An amusement_arcade image turns out to be a hockey arena scoreboard. A mosque-outdoor sample is the Taj Mahal. The labels are tidy, but the images tell a different story.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            The place AI is most confident about is the Japanese zen garden, with a density of 0.660. The place it struggles with most is the lecture room, at 0.032. A 20x gap. Beneath the veneer of "uniform distribution," the visual identities of 365 places are drastically uneven. More data does not always mean better data.
+                            The place AI is most confident about is the Japanese zen garden, with a density of 0.660. The place it struggles with most is the lecture room, at 0.032. A 20x gap. Beneath the veneer of "uniform distribution," the visual identities of 365 places are drastically uneven. More data does not always mean better data. This piece is the false-balance chapter of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series &mdash; showing the visual unevenness that hides behind matching class counts.
                         </p>
                     </div>
 
@@ -739,6 +739,14 @@
                         </li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 DataClinic Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/DataClinic/en/" class="text-orange-500 hover:text-orange-400 font-semibold">DataClinic</a> series curated by Pebblous &mdash; diagnosing and prescribing for AI training data, holding our own datasets and public benchmarks to the same standard.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/story/dataclinic-report-126-places365-story-pb/ko/index.html
+++ b/story/dataclinic-report-126-places365-story-pb/ko/index.html
@@ -165,7 +165,7 @@
                             DataClinic 진단은 균형 아래 숨은 구조적 문제를 드러낸다. 16종의 식음료 공간, 8종의 거주 공간 등 최소 61개 클래스가 피처 공간에서 중첩된다. amusement_arcade에는 하키 전광판이, mosque-outdoor에는 타지마할이 섞여 있다. 라벨은 정돈되어 있지만, 이미지가 말하는 장소는 라벨과 다르다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            AI가 가장 확신하는 장소는 일본식 젠 가든이다. 밀도 0.660. AI가 가장 헤매는 장소는 강의실이다. 밀도 0.032. 격차 20배. "균일한 분포"라는 외피 아래에서, 365개 장소의 시각적 정체성은 극심하게 불균등하다. 가장 풍부한 데이터가 반드시 좋은 데이터는 아니다.
+                            AI가 가장 확신하는 장소는 일본식 젠 가든이다. 밀도 0.660. AI가 가장 헤매는 장소는 강의실이다. 밀도 0.032. 격차 20배. "균일한 분포"라는 외피 아래에서, 365개 장소의 시각적 정체성은 극심하게 불균등하다. 가장 풍부한 데이터가 반드시 좋은 데이터는 아니다. 이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a> 시리즈의 균형의 함정 편으로, 클래스 수가 같다는 사실 뒤에 숨은 시각적 불균등을 드러낸다.
                         </p>
                     </div>
 
@@ -739,6 +739,14 @@
                         </li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 데이터클리닉 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/DataClinic/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터클리닉</a>에서 큐레이션하는 시리즈의 일부입니다. AI 학습 데이터를 진단하고 처방하는 자리 — 자사 데이터부터 공개 벤치마크까지 같은 잣대로 본다.
+                    </p>
+                </div>
 
             </main>
         </div>


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 2차 해결 (PR #171 후속)
- 영향 페이지 54개 중 6개(3쌍 KO+EN) 처리
- DataClinic hub와 시리즈 글 사이 양방향 reverse-link 정착

## 누적 진척

| Phase | PR | 처리 페이지 | 누적 |
|---|---|---|---|
| Phase 1 (PhysicalAI) | #171 (merged) | 8 | 8/54 |
| **Phase 2 (DataClinic)** | **(this PR)** | **6** | **14/54 (26%)** |

## 처리한 글 (3쌍)

| 글 | DataClinic 시리즈 내 포지셔닝 |
|---|---|
| `story/dataclinic-report-102-whitestarmnist-story-pb` | 자가진단 편 — 자사 데이터를 자사 도구로 |
| `story/dataclinic-report-126-places365-story-pb` | 균형의 함정 편 — 표면 균형 아래 클래스 혼동 |
| `blog/dc-story-produce-pipeline-meta` | 파이프라인 메타 편 — 진단이 콘텐츠로 잇는 자동화 |

## 적용 패턴 — `docs/hub-reverse-link.md` 그대로

- **(A) Executive Summary 마지막 `<p>` 끝**: inline 백링크 한 문장 (글마다 포지셔닝 차별화)
- **(B) `</main>` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 양방향 완성

`project/DataClinic/{ko,en}/index.html`:
- "시리즈 가이드" 섹션에 3개 정적 카드 추가 (SEO용 forward-link)
- `extraPaths`에 3개 추가 (동적 카드 그리드 자동 등록)

## 후속 작업

Semrush 영향 페이지 54개 중 이번 PR로 누적 14개 해결. 나머지 **40개는 별도 PR로 단계적 진행 예정**:
- AnthropicClaude hub 신설 (claude-harness/mythos/nanoclaw 등 6쌍)
- BizReport hub 확장 (circle 시리즈 등)
- 단발 글 cross-link (yann-lecun-jepa, frontend-vibe-coders, artemis 등)

## Test Plan

- [ ] 빌드 후 `curl` 로 정적 HTML에 `/project/DataClinic/{lang}/` 링크 2개씩 들어가 있는지 확인
- [ ] DataClinic hub에서 신규 3개 카드가 시리즈 가이드 + 동적 그리드 둘 다 보이는지 시각 확인
- [ ] Semrush 다음 크롤 후 영향 페이지 수 추적 (46 → 40 기대)