### PR TITLE
fix(bilingual): Hero 하드코딩 + EN copyright 누락 (closes #118)

### DIFF
--- a/.claude/skills/bilingual/SKILL.md
+++ b/.claude/skills/bilingual/SKILL.md
@@ -47,13 +47,11 @@ mkdir -p blog/ko blog/en
    - All remaining old `.html` URLs in JSON-LD schemas → new `/ko/` URL (use `replace_all`)
    - `articlePath` in PebblousPage.init config → new path with `/ko/`
    - Internal relative links to same-directory assets (PDFs, images) → adjust depth (e.g., `./file.pdf` → `../../file.pdf`)
-   - **Replace hero meta info** with 2-line compact format (below subtitle, centered):
-     ```html
-     <!-- Korean -->
-     <p class="text-sm themeable-muted">YYYY.MM · (주)페블러스 데이터 커뮤니케이션팀</p>
-     <p class="text-sm themeable-muted mt-1">읽는 시간: ~N분 · <a href="../en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
-     ```
-     Line 1: `date · team` / Line 2: `reading time · language link`. Remove any old `<div class="flex ...">` publication info block.
+   - **⛔ Hero meta info — DO NOT hardcode (Issue #118)**:
+     `PebblousPage.init()` auto-generates the meta line (`날짜 | 팀명 | ~N분 | English | [공유아이콘]`) from `config.publishDate`, `config.publisher`, `config.wordCount`. See `CLAUDE.md` "Hero meta info — 동적 생성" rule.
+     - Keep the hero `<header>` minimal — just an empty `<h1 id="page-h1-title">`.
+     - Remove any existing hardcoded `<p class="text-sm themeable-muted">` meta lines, `<div id="share-buttons-placeholder">`, or `<div class="flex ...">` publication info block.
+     - Language switcher is rendered by `common-utils.js` (it checks `fetch HEAD` for the alternate-language sibling page).
    - Fix any existing HTML issues (e.g., broken tags)
 
 ### 4. Create `blog/en/index.html` — English translation
@@ -70,6 +68,7 @@ The English version MUST be created by **copying the completed KO file** and the
 - `<html lang="ko">` → `<html lang="en">`
 - `<meta name="language" content="Korean">` → `English`
 - `<meta http-equiv="content-language" content="ko">` → `en`
+- `<meta name="copyright" content="...">` → `© 2026 Pebblous. All rights reserved.` (Issue #118 — KO `(주)페블러스 데이터 커뮤니케이션` 그대로 복사 금지)
 - `canonical`, `og:url`, `twitter:url` → change `/ko/` to `/en/`
 - `og:locale` → `en_US`
 - `articlePath` → change `/ko/` to `/en/`


### PR DESCRIPTION
## Summary

\`bilingual\` 스킬의 두 가지 구조적 버그 수정. 이 버그가 있는 한 bilingual 변환된 모든 EN 글이 비표준으로 생성되는 상태였음.

## Bug 1 — Hero 메타 하드코딩 지시 (Step 3, line 50-56)

**기존**: 스킬이 \`<p class=\"text-sm themeable-muted\">YYYY.MM · (주)페블러스 데이터 커뮤니케이션팀</p>\` 같은 하드코딩 패턴을 hero에 삽입하도록 지시.

**문제**: \`PebblousPage.init()\`이 \`publishDate\`, \`publisher\`, \`wordCount\`에서 같은 정보를 자동 생성함. CLAUDE.md \"Hero meta info — 동적 생성\" 규칙 위반.

**수정**: 하드코딩 템플릿 삭제 + \"기존 하드코딩 제거\" 지시로 교체. empty \`<h1 id=\"page-h1-title\">\`만 두는 main 표준 회복.

## Bug 2 — EN copyright 메타 한국어 유지 (Step 4)

**기존**: \`<meta name=\"copyright\">\` 변환이 Step 4 \"URL/language changes\" 목록에 없어서, KO의 \`(주)페블러스 데이터 커뮤니케이션\`이 EN에 그대로 복사됨.

**수정**: Step 4 변환 목록에 추가:
\`\`\`
<meta name=\"copyright\"> → \"© 2026 Pebblous. All rights reserved.\"
\`\`\`

## 영향

- ✅ 향후 \`bilingual\` 변환 시 EN HTML이 main 표준 구조로 생성됨
- ⚠ 기존에 잘못 변환된 글들은 별도 일괄 수정 PR 필요 (#118 후속, scope 분리)

## 발견 경위

PR #117 리뷰, JH 지적.

## Test Plan

- [ ] 다음 \`bilingual\` 실행 시 EN hero에 hardcoded \`<p>\` 없음 확인
- [ ] 다음 \`bilingual\` 실행 시 EN \`<meta name=\"copyright\">\` 영어 확인