### PR TITLE
fix(hub): BizReport hub reverse-link — Circle 시리즈 2쌍 (Semrush 진단 4차)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -524,7 +524,7 @@
       "language": "en",
       "publisher": "Pebblous Research Team",
       "wordCount": 13982,
-      "modified": "2026-04-29"
+      "modified": "2026-05-22"
     },
     {
       "id": "karpathy-coding-skills-2026-04-ko",
@@ -550,7 +550,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 리서치팀",
       "wordCount": 7961,
-      "modified": "2026-04-29"
+      "modified": "2026-05-22"
     },
     {
       "id": "openmetadata-ai-ready-data-2026-04-en",
@@ -963,7 +963,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 5354,
-      "modified": "2026-04-12"
+      "modified": "2026-05-22"
     },
     {
       "id": "claude-mythos-preview-en",
@@ -988,7 +988,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 9991,
-      "modified": "2026-04-12"
+      "modified": "2026-05-22"
     },
     {
       "id": "ai-agent-benchmark-trust-ko",
@@ -1211,7 +1211,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 8405,
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "bernie-vs-claude-pb-en",
@@ -1235,7 +1235,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 17673,
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "circle-seoul-jeremy-allaire-pb-ko",
@@ -1266,7 +1266,7 @@
         "페블러스"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 7880,
+      "wordCount": 8004,
       "modified": "2026-04-14"
     },
     {
@@ -1296,7 +1296,7 @@
         "Arc"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 16799,
+      "wordCount": 17089,
       "modified": "2026-04-24"
     },
     {
@@ -12133,7 +12133,7 @@
       ],
       "image": "",
       "publisher": "(주)페블러스 경영지원실",
-      "wordCount": 10582,
+      "wordCount": 10706,
       "modified": "2026-04-14"
     },
     {
@@ -12159,7 +12159,7 @@
       ],
       "image": "",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 19329,
+      "wordCount": 19627,
       "modified": "2026-04-14"
     },
     {
@@ -12609,7 +12609,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 6975,
-      "modified": "2026-05-16"
+      "modified": "2026-05-22"
     },
     {
       "id": "nanoclaw-architecture-deep-dive-en",
@@ -12632,7 +12632,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 12992,
-      "modified": "2026-05-16"
+      "modified": "2026-05-22"
     },
     {
       "id": "claude-harness-postmortem-ko",
@@ -12656,7 +12656,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 2196,
-      "modified": "2026-04-24"
+      "modified": "2026-05-22"
     },
     {
       "id": "claude-harness-postmortem-en",
@@ -12680,7 +12680,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 4718,
-      "modified": "2026-04-24"
+      "modified": "2026-05-22"
     },
     {
       "id": "palantir-technological-republic-ko",
@@ -13142,7 +13142,8 @@
         "Karpathy",
         "페블러스"
       ],
-      "publisher": "(주)페블러스 데이터 커뮤니케이션팀"
+      "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
+      "modified": "2026-05-22"
     },
     {
       "id": "anthropicclaude-hub-en",
@@ -13168,7 +13169,8 @@
         "Karpathy",
         "Pebblous"
       ],
-      "publisher": "Pebblous Data Communication Team"
+      "publisher": "Pebblous Data Communication Team",
+      "modified": "2026-05-22"
     }
   ]
 }

--- a/project/BizReport/circle-analysis-01/en/index.html
+++ b/project/BizReport/circle-analysis-01/en/index.html
@@ -219,7 +219,7 @@
             </p>
 
             <p class="themeable-text leading-relaxed mb-8">
-                But Circle is no longer just a stablecoin issuer. With Arc (a purpose-built L1 blockchain), CCTP V2 (sub-second cross-chain transfers), and the x402 protocol (micropayments for AI agents), Circle is building the financial plumbing for a world where autonomous software agents transact billions of times per day. From Pebblous's perspective, this creates a massive opportunity: as payment infrastructure scales, so does the need for data quality middleware to ensure transaction integrity, regulatory compliance, and cross-chain data reconciliation.
+                But Circle is no longer just a stablecoin issuer. With Arc (a purpose-built L1 blockchain), CCTP V2 (sub-second cross-chain transfers), and the x402 protocol (micropayments for AI agents), Circle is building the financial plumbing for a world where autonomous software agents transact billions of times per day. From Pebblous's perspective, this creates a massive opportunity: as payment infrastructure scales, so does the need for data quality middleware to ensure transaction integrity, regulatory compliance, and cross-chain data reconciliation. This piece is the Circle financial analysis chapter of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series &mdash; how Pebblous reads global companies through a data infrastructure lens.
             </p>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
@@ -947,6 +947,14 @@
                 <li><span class="font-semibold accent-text">[10]</span> Pebblous Business Analysis Framework (2026) — 6-Step Company Analysis Model</li>
             </ol>
         </section>
+
+        <!-- Hub Series Notice -->
+        <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+            <p class="text-sm font-bold themeable-heading mb-2">📚 Biz Insight Series</p>
+            <p class="text-sm themeable-text leading-relaxed">
+                This article is part of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series curated by Pebblous &mdash; reading the financials, products, and market strategies of global companies through a data infrastructure lens.
+            </p>
+        </div>
 
         </main>
         </div>

--- a/project/BizReport/circle-analysis-01/ko/index.html
+++ b/project/BizReport/circle-analysis-01/ko/index.html
@@ -206,7 +206,7 @@
             </div>
 
             <p class="themeable-text leading-relaxed mb-8">
-                Circle Internet Financial은 스테이블코인 시장에서 "규제 준수 = 경쟁 우위"라는 공식을 증명하고 있습니다. USDT가 시가총액에서 2.4배 앞서지만, USDC는 2025년 유통량 성장률 73%로 Tether(36%)를 2배 앞지르며, 거래량 기준으로는 전체 스테이블코인의 64%를 차지합니다. IPO를 통해 $1.05B를 확보한 Circle은 Arc L1 블록체인과 AI 에이전트 결제 인프라(x402)로 "인터넷 네이티브 달러" 비전을 실행 중입니다. 아래 세 가지 핵심 수치는 Circle의 규모와 성장 속도를 집약합니다.
+                Circle Internet Financial은 스테이블코인 시장에서 "규제 준수 = 경쟁 우위"라는 공식을 증명하고 있습니다. USDT가 시가총액에서 2.4배 앞서지만, USDC는 2025년 유통량 성장률 73%로 Tether(36%)를 2배 앞지르며, 거래량 기준으로는 전체 스테이블코인의 64%를 차지합니다. IPO를 통해 $1.05B를 확보한 Circle은 Arc L1 블록체인과 AI 에이전트 결제 인프라(x402)로 "인터넷 네이티브 달러" 비전을 실행 중입니다. 아래 세 가지 핵심 수치는 Circle의 규모와 성장 속도를 집약합니다. 이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a> 시리즈의 Circle 재무 분석 편으로, 페블러스가 데이터 인프라 관점에서 보는 자리입니다.
             </p>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
@@ -853,6 +853,14 @@
                 <li><span class="font-semibold accent-text">[10]</span> 페블러스 비즈니스 분석 프레임워크 (2026) — 6단계 기업 분석 모델</li>
             </ol>
         </section>
+
+        <!-- Hub Series Notice -->
+        <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+            <p class="text-sm font-bold themeable-heading mb-2">📚 비즈 인사이트 시리즈</p>
+            <p class="text-sm themeable-text leading-relaxed">
+                이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a>에서 큐레이션하는 시리즈의 일부입니다. 데이터 인프라 관점에서 글로벌 기업의 재무·제품·시장 전략을 페블러스가 읽는 자리.
+            </p>
+        </div>
 
         </main>
         </div>

--- a/project/BizReport/en/index.html
+++ b/project/BizReport/en/index.html
@@ -119,6 +119,18 @@
                     </a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">Why Shelf.io's $60.7M from Tiger Global hasn't translated into $50M ARR. Category clarification — Shelf.io is KM, not data quality — and what the horizontal platform dilemma teaches Pebblous.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/project/BizReport/circle-analysis-01/en/" class="text-lg font-semibold" style="color: #F86825;">
+                        Biz Insight: Circle — Architect of the USDC Empire
+                    </a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">NYSE:CRCL, $78.8B USDC stablecoin infrastructure giant. Regulation-first strategy, AI agent payments (x402), the Arc blockchain, and where Pebblous data quality fits in.</p>
+                </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/circle-seoul-jeremy-allaire-pb/en/" class="text-lg font-semibold" style="color: #F86825;">
+                        Stablecoins Are Not Crypto — Circle CEO Jeremy Allaire's Seoul Declaration
+                    </a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">A field record of Allaire's April 2026 Seoul declaration. The counterpart to the Circle financial analysis — B2A, KYA, X402, CPN, and Circle's strategy for entering the Korean market and powering AI agent payments.</p>
+                </div>
             </div>
         </div>
 
@@ -143,7 +155,10 @@
         PebblousHubCards.init({
             containerId: 'bizreport-cards',
             pathFilter: 'BizReport/',
-            extraPaths: ['BizReport/palantir-analysis-2026'],
+            extraPaths: [
+                'BizReport/palantir-analysis-2026',
+                'story/circle-seoul-jeremy-allaire-pb'
+            ],
             language: 'en'
         });
 

--- a/project/BizReport/ko/index.html
+++ b/project/BizReport/ko/index.html
@@ -131,6 +131,12 @@
                     </a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">총 펀딩 $944만(약 140억원)으로 CME Group 최초 온체인 데이터 공급업체가 된 한국 스타트업. Terra-Luna/FTX 사전 경고, 150+ 기관 고객, 온체인 데이터 품질 인증 협력 시나리오.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/story/circle-seoul-jeremy-allaire-pb/ko/" class="text-lg font-semibold" style="color: #F86825;">
+                        스테이블코인은 암호화폐가 아니다 — Circle CEO 제레미 알레어의 서울 선언
+                    </a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">2026년 4월 서울에서 알레어가 던진 선언의 현장 기록. Circle 재무 분석의 짝글 — B2A, KYA, X402, CPN 개념과 한국 시장 진입 전략, AI 에이전트 결제 인프라를 풀어낸다.</p>
+                </div>
             </div>
         </div>
 
@@ -155,7 +161,9 @@
         PebblousHubCards.init({
             containerId: 'bizreport-cards',
             pathFilter: 'BizReport/',
-            extraPaths: [],
+            extraPaths: [
+                'story/circle-seoul-jeremy-allaire-pb'
+            ],
             language: 'ko'
         });
 

--- a/story/circle-seoul-jeremy-allaire-pb/en/index.html
+++ b/story/circle-seoul-jeremy-allaire-pb/en/index.html
@@ -131,7 +131,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         Allaire's core message was blunt. Stablecoins are no longer crypto trading instruments; they are <strong>global payment infrastructure</strong>. Stripe and Shopify already offer USDC payments natively. AI agents are transacting with each other in USDC right now. The longer Korea delays regulation, the further behind it falls.
                     </p>
                     <p class="themeable-text leading-relaxed">
-                        This article presents the full transcript alongside analysis of each key statement. <strong>B2A (Business to Agent), KYA (Know Your Agent), <a href="/blog/x402-protocol-ai-payment-2026/en/" class="text-orange-500 hover:underline">X402</a>, CPN</strong> -- once you understand the concepts Allaire introduced, the shape of the next five years of financial infrastructure comes into focus.
+                        This article presents the full transcript alongside analysis of each key statement. <strong>B2A (Business to Agent), KYA (Know Your Agent), <a href="/blog/x402-protocol-ai-payment-2026/en/" class="text-orange-500 hover:underline">X402</a>, CPN</strong> -- once you understand the concepts Allaire introduced, the shape of the next five years of financial infrastructure comes into focus. This piece is the Circle Seoul declaration chapter of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series &mdash; the field-record counterpart to the <a href="/project/BizReport/circle-analysis-01/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Circle financial analysis</a>.
                     </p>
                 </div>
             </section>
@@ -506,6 +506,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
             <!-- FAQ placeholder -->
             <section id="faq" class="mb-16 fade-in-card"></section>
+
+            <!-- Hub Series Notice -->
+            <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                <p class="text-sm font-bold themeable-heading mb-2">📚 Biz Insight Series</p>
+                <p class="text-sm themeable-text leading-relaxed">
+                    This article is part of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series curated by Pebblous &mdash; reading the financials, products, and market strategies of global companies through a data infrastructure lens.
+                </p>
+            </div>
 
         </main>
     </div>

--- a/story/circle-seoul-jeremy-allaire-pb/ko/index.html
+++ b/story/circle-seoul-jeremy-allaire-pb/ko/index.html
@@ -130,7 +130,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         알레어의 핵심 메시지는 간결했다. 스테이블코인은 더 이상 암호화폐 거래 도구가 아니라 <strong>글로벌 결제 인프라</strong>다. Stripe·Shopify는 이미 USDC 결제를 기본 제공한다. AI 에이전트는 지금 이 순간 USDC로 서로 결제하고 있다. 한국이 규제를 늦출수록 뒤처진다.
                     </p>
                     <p class="themeable-text leading-relaxed">
-                        이 글은 대담 전문과 함께, 각 발언이 담고 있는 의미를 용어 해설과 함께 풀어낸다. <strong>B2A(Business to Agent), KYA(Know Your Agent), <a href="/blog/x402-protocol-ai-payment-2026/ko/" class="text-orange-500 hover:underline">X402</a>, CPN</strong> — 알레어가 꺼낸 개념들이 왜 중요한지를 파악하면, 다음 5년간의 금융 인프라 지형이 보인다.
+                        이 글은 대담 전문과 함께, 각 발언이 담고 있는 의미를 용어 해설과 함께 풀어낸다. <strong>B2A(Business to Agent), KYA(Know Your Agent), <a href="/blog/x402-protocol-ai-payment-2026/ko/" class="text-orange-500 hover:underline">X402</a>, CPN</strong> — 알레어가 꺼낸 개념들이 왜 중요한지를 파악하면, 다음 5년간의 금융 인프라 지형이 보인다. 이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a> 시리즈의 Circle 서울 선언 편으로, <a href="/project/BizReport/circle-analysis-01/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">Circle 재무 분석</a>과 짝을 이루는 현장 기록이다.
                     </p>
                 </div>
             </section>
@@ -505,6 +505,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
             <!-- FAQ placeholder -->
             <section id="faq" class="mb-16 fade-in-card"></section>
+
+            <!-- Hub Series Notice -->
+            <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                <p class="text-sm font-bold themeable-heading mb-2">📚 비즈 인사이트 시리즈</p>
+                <p class="text-sm themeable-text leading-relaxed">
+                    이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a>에서 큐레이션하는 시리즈의 일부입니다. 데이터 인프라 관점에서 글로벌 기업의 재무·제품·시장 전략을 페블러스가 읽는 자리.
+                </p>
+            </div>
 
         </main>
     </div>


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 4차 해결
- 영향 페이지 54개 중 4개(2쌍 KO+EN) 처리
- BizReport hub와 Circle 시리즈 글 사이 양방향 reverse-link 정착

## 누적 진척

| Phase | PR | 처리 페이지 | 누적 |
|---|---|---|---|
| Phase 1 (PhysicalAI) | #171 (merged) | 8 | 8/54 |
| Phase 2 (DataClinic) | #172 (merged) | 6 | 14/54 |
| Phase 3 (Claude 워치) | #181 (merged) | 10 | 24/54 |
| **Phase 4 (BizReport / Circle)** | **(this PR)** | **4** | **28/54 (52%)** |

## 처리한 글 (2쌍 — Circle 짝글)

| 글 | 포지셔닝 |
|---|---|
| \`project/BizReport/circle-analysis-01\` | Circle 재무 분석 편 |
| \`story/circle-seoul-jeremy-allaire-pb\` | Circle 서울 선언 편 (재무 분석의 짝글) |

두 글은 같은 회사(Circle)를 다른 각도로 보는 짝 — 재무 분석 vs 현장 기록. circle-seoul의 inline 백링크에서 circle-analysis와의 짝 관계도 명시했음.

## 적용 패턴 — \`docs/hub-reverse-link.md\` 그대로

- **(A) Executive Summary 마지막 \`<p>\` 끝**: inline 백링크 한 문장
- **(B) \`</main>\` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 양방향 완성

- KO hub: circle-seoul 카드 추가 + extraPaths 등록
- EN hub: **Circle, circle-seoul 2개 카드 신규 추가** (KO 대비 누락 보완)
- 두 hub 모두 \`extraPaths\`에 circle-seoul 등록

## 후속 작업

Semrush 영향 페이지 54개 중 이번 PR로 누적 28개 해결. 나머지 **26개**:
- PhysicalAI hub 추가 흡수: yann-lecun-jepa, artemis (이미 extraPaths에 있음 — 글에 reverse-link만 추가)
- DataEconomy hub forward-link: upstage 흡수
- 단발 cross-link: frontend-vibe-coders, kronos, nvidia-vcc, ngogo 등

## Test Plan

- [ ] 머지 후 \`curl https://blog.pebblous.ai/project/BizReport/circle-analysis-01/ko/\`에서 BizReport hub 링크 카운트 확인
- [ ] BizReport hub에서 Circle 짝글 2개 카드가 시리즈 가이드와 동적 그리드 모두에 보이는지 확인