### PR TITLE
fix(hub): PhysicalAI hub 추가 흡수 — JEPA/Artemis 2쌍 (Semrush 진단 5차)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -308,7 +308,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 7738,
+      "wordCount": 7867,
       "modified": "2026-05-03"
     },
     {
@@ -335,7 +335,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 15214,
+      "wordCount": 15488,
       "modified": "2026-05-05"
     },
     {
@@ -1267,7 +1267,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 8004,
-      "modified": "2026-04-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "circle-seoul-jeremy-allaire-pb-en",
@@ -1297,7 +1297,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 17089,
-      "modified": "2026-04-24"
+      "modified": "2026-05-22"
     },
     {
       "id": "bernie-sanders-ai-moratorium-pb-en",
@@ -1880,7 +1880,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "modified": "2026-04-22"
+      "modified": "2026-05-22"
     },
     {
       "id": "bizreport-hub-en",
@@ -1912,7 +1912,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "modified": "2026-04-22"
+      "modified": "2026-05-22"
     },
     {
       "id": "mlflow-mlops-standard-ko",
@@ -12134,7 +12134,7 @@
       "image": "",
       "publisher": "(주)페블러스 경영지원실",
       "wordCount": 10706,
-      "modified": "2026-04-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "circle-analysis-01-en",
@@ -12160,7 +12160,7 @@
       "image": "",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 19627,
-      "modified": "2026-04-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "artemis-lunar-operations-ko",
@@ -12182,7 +12182,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 5684,
+      "wordCount": 5821,
       "modified": "2026-04-16"
     },
     {
@@ -12205,7 +12205,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 12619,
+      "wordCount": 12903,
       "modified": "2026-04-16"
     },
     {

--- a/blog/yann-lecun-jepa-world-models/en/index.html
+++ b/blog/yann-lecun-jepa-world-models/en/index.html
@@ -163,7 +163,7 @@
                             This idea is already delivering concrete results. V-JEPA 2 achieved an 80% success rate in zero-shot robot control (versus 15% for Octo), adapting to new environments with just 62 hours of unlabeled video. Meta continues to invest billions in this direction.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            What JEPA aims to prove is clear: the foundation of a good AI model is a good representation space. This shifts the definition of "good data" from quantity or label accuracy to whether data can produce meaningful representations.
+                            What JEPA aims to prove is clear: the foundation of a good AI model is a good representation space. This shifts the definition of "good data" from quantity or label accuracy to whether data can produce meaningful representations. This piece is the world-model chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; a different path from VLA intuition for how robots learn.
                         </p>
                     </div>
                 </section>
@@ -634,6 +634,14 @@
                         <span class="themeable-muted text-sm">May 3, 2026</span>
                     </p>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/blog/yann-lecun-jepa-world-models/ko/index.html
+++ b/blog/yann-lecun-jepa-world-models/ko/index.html
@@ -163,7 +163,7 @@
                             이 아이디어는 이미 구체적 성과로 이어지고 있다. V-JEPA 2는 로봇 제로샷 제어에서 80%의 성공률을 기록했고(기존 Octo 모델 15%), 62시간의 라벨 없는 영상만으로 새로운 환경에 적응했다. Meta는 이 방향에 수십억 달러 규모의 투자를 지속하고 있다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            JEPA가 증명하려는 것은 명확하다. "좋은 AI 모델"의 전제가 "좋은 표현 공간"이라는 것이다. 이는 곧 "좋은 데이터"의 정의가 양이나 라벨 정확도가 아니라 "의미 있는 표현 공간을 만드는 데이터"로 이동하고 있음을 뜻한다.
+                            JEPA가 증명하려는 것은 명확하다. "좋은 AI 모델"의 전제가 "좋은 표현 공간"이라는 것이다. 이는 곧 "좋은 데이터"의 정의가 양이나 라벨 정확도가 아니라 "의미 있는 표현 공간을 만드는 데이터"로 이동하고 있음을 뜻한다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 월드 모델 편으로, VLA의 직관과 다른 길에서 로봇 학습을 보는 자리다.
                         </p>
                     </div>
                 </section>
@@ -634,6 +634,14 @@
                         <span class="themeable-muted text-sm">2026년 5월 3일</span>
                     </p>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/project/PhysicalAI/en/index.html
+++ b/project/PhysicalAI/en/index.html
@@ -172,6 +172,7 @@
                 'blog/john-deere-right-to-repair-2026',
                 'blog/neural-computers-meta',
                 'report/artemis-lunar-operations',
+                'blog/yann-lecun-jepa-world-models',
                 'report/vla-architecture-comparison',
                 'report/physical-ai-industry-landscape',
                 'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',

--- a/project/PhysicalAI/ko/index.html
+++ b/project/PhysicalAI/ko/index.html
@@ -172,6 +172,7 @@
                 'blog/john-deere-right-to-repair-2026',
                 'blog/neural-computers-meta',
                 'report/artemis-lunar-operations',
+                'blog/yann-lecun-jepa-world-models',
                 'report/vla-architecture-comparison',
                 'report/physical-ai-industry-landscape',
                 'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',

--- a/report/artemis-lunar-operations/en/index.html
+++ b/report/artemis-lunar-operations/en/index.html
@@ -105,7 +105,7 @@
                             That same month, NASA cancelled the Lunar Gateway space station and redirected $20 billion toward building a permanent surface base. Not in orbit — on the ground, permanently. The new battleground has four layers: communications infrastructure (LunaNet), positioning and navigation, energy supply, and resource extraction. The US has rallied 60+ nations under the Artemis Accords; China is building its own coalition through the International Lunar Research Station (ILRS).
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Korea has signed the Artemis Accords and its space agency (KASA) has announced a lunar relay satellite for 2029. But while Japan secured a lunar rover role and Canada locked in the Canadarm3 robotic arm, Korea has yet to define a concrete contribution. This report analyzes the technical, geopolitical, and business structure of the lunar operations race — and identifies the strategic positions still available to Korea.
+                            Korea has signed the Artemis Accords and its space agency (KASA) has announced a lunar relay satellite for 2029. But while Japan secured a lunar rover role and Canada locked in the Canadarm3 robotic arm, Korea has yet to define a concrete contribution. This report analyzes the technical, geopolitical, and business structure of the lunar operations race — and identifies the strategic positions still available to Korea. This piece is the space-infrastructure chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; how robots and data infrastructure operate beyond Earth.
                         </p>
                     </div>
                 </section>
@@ -442,6 +442,14 @@
                         <li class="themeable-muted text-sm leading-relaxed">Tero Karppi (2026). Extraoperable networks: Delay and power in the rise of LunaNet. Sage Journals.</li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/artemis-lunar-operations/ko/index.html
+++ b/report/artemis-lunar-operations/ko/index.html
@@ -105,7 +105,7 @@
                             같은 달, NASA는 Gateway 달 우주정거장 계획을 전면 취소하고 $20B을 달 표면 기지 건설에 재배분했다. 궤도가 아닌 표면에 항구적으로 존재하겠다는 선언이다. 통신 인프라(루나넷), 위치·항법 시스템, 에너지 공급망, 자원 채굴—이 4개 레이어가 달의 새로운 전장이 됐다. 미국은 Artemis Accords로 60개국을 결집했고, 중국은 ILRS(국제 달 연구 기지)로 자체 진영을 구축했다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            한국은 아르테미스 협정 가입국이고, 우주항공청은 2029년 달 통신 궤도선 발사를 선언했다. 그러나 일본(월면차), 캐나다(로봇 팔)처럼 구체적인 역할을 확보한 파트너와 달리, 한국의 포지션은 아직 공백이다. 이 보고서는 달 운영 체계 경쟁의 기술·지정학·비즈니스 구조를 분석하고, 한국이 찾아야 할 전략적 위치를 제안한다.
+                            한국은 아르테미스 협정 가입국이고, 우주항공청은 2029년 달 통신 궤도선 발사를 선언했다. 그러나 일본(월면차), 캐나다(로봇 팔)처럼 구체적인 역할을 확보한 파트너와 달리, 한국의 포지션은 아직 공백이다. 이 보고서는 달 운영 체계 경쟁의 기술·지정학·비즈니스 구조를 분석하고, 한국이 찾아야 할 전략적 위치를 제안한다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 우주 인프라 편으로, 로봇과 데이터 인프라가 지구 밖에서 어떻게 운영되는지를 보는 자리다.
                         </p>
                     </div>
                 </section>
@@ -442,6 +442,14 @@
                         <li class="themeable-muted text-sm leading-relaxed">Tero Karppi (2026). Extraoperable networks: Delay and power in the rise of LunaNet. Sage Journals.</li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 5차 해결
- 영향 페이지 54개 중 4개(2쌍 KO+EN) 처리
- PhysicalAI hub로 \`yann-lecun-jepa\`와 \`artemis\` 추가 흡수

## 누적 진척

| Phase | PR | 처리 페이지 | 누적 |
|---|---|---|---|
| Phase 1 (PhysicalAI) | #171 (merged) | 8 | 8/54 |
| Phase 2 (DataClinic) | #172 (merged) | 6 | 14/54 |
| Phase 3 (Claude 워치) | #181 (merged) | 10 | 24/54 |
| Phase 4 (BizReport / Circle) | #182 (merged) | 4 | 28/54 |
| **Phase 5a (PhysicalAI / JEPA·Artemis)** | **(this PR)** | **4** | **32/54 (59%)** |

## 처리한 글 (2쌍)

| 글 | 포지셔닝 |
|---|---|
| \`blog/yann-lecun-jepa-world-models\` | 월드 모델 편 (VLA의 직관과 다른 길) |
| \`report/artemis-lunar-operations\` | 우주 인프라 편 (지구 밖 데이터 인프라) |

두 글 모두 PhysicalAI hub의 컨셉(로봇/데이터/시뮬레이션)과 결이 맞으나 이전에 글에 reverse-link가 빠져있었음. artemis는 이미 hub의 \`extraPaths\`에 등록돼 있었고, yann-lecun-jepa는 이번 PR로 신규 등록.

## 적용 패턴 — \`docs/hub-reverse-link.md\` 그대로

- **(A) Executive Summary 마지막 \`<p>\` 끝**: inline 백링크 한 문장
- **(B) \`</main>\` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 업데이트

\`project/PhysicalAI/{ko,en}/index.html\` \`extraPaths\`에 \`blog/yann-lecun-jepa-world-models\` 신규 등록 (artemis는 기등록).

## 후속 작업

남은 22개:
- DataEconomy hub forward-link (upstage 흡수, IR 메타 처리)
- 단발 cross-link 또는 새 hub: kronos (금융 AI), nvidia-vcc (바이오 AI), frontend-vibe-coders, ngogo (행동 시뮬레이션), blog-2026-feb (메타)

## Test Plan

- [ ] 머지 후 \`curl https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/ko/\`에서 PhysicalAI hub 링크 2개 확인
- [ ] PhysicalAI hub 동적 그리드에 두 글 카드 노출 확인