### PR TITLE
fix(hub): DataEconomy hub 추가 흡수 — Upstage 소버린 AI (Semrush 진단 6차)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -256,7 +256,7 @@
         "Korean LLM"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 26410,
+      "wordCount": 26699,
       "modified": "2026-05-10"
     },
     {
@@ -281,7 +281,7 @@
         "한국어 LLM"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 13861,
+      "wordCount": 13991,
       "modified": "2026-05-10"
     },
     {
@@ -309,7 +309,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 7867,
-      "modified": "2026-05-03"
+      "modified": "2026-05-22"
     },
     {
       "id": "yann-lecun-jepa-world-models-en",
@@ -336,7 +336,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 15488,
-      "modified": "2026-05-05"
+      "modified": "2026-05-22"
     },
     {
       "id": "multiagent-industrial-data-operations-ko",
@@ -12183,7 +12183,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 5821,
-      "modified": "2026-04-16"
+      "modified": "2026-05-22"
     },
     {
       "id": "artemis-lunar-operations-en",
@@ -12206,7 +12206,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 12903,
-      "modified": "2026-04-16"
+      "modified": "2026-05-22"
     },
     {
       "id": "data-quality-mathematics-ko",

--- a/project/DataEconomy/en/index.html
+++ b/project/DataEconomy/en/index.html
@@ -106,6 +106,11 @@
                     <p class="themeable-text text-sm mt-1 leading-relaxed">12 business domains, 11.13 million users, and a KRW 87.2 trillion market — the institutional foundation of Korea's digital asset framework.</p>
                     <p class="text-xs themeable-muted mt-2">2026.05.06 · Deep Research Report</p>
                 </a>
+                <a href="/report/upstage-national-fund-2026-05/en/" class="ir-hover-card block themeable-card-bg rounded-lg p-5 border-2 no-underline" style="border-color: #F86825;">
+                    <p class="ir-hover-title text-lg font-bold themeable-heading">Upstage's $400M Sovereign AI Funding — The Korean Data Question</p>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">Korea's National Growth Fund places its first-ever software direct equity check on Upstage. Model capital arrived; the 0.823% Korean-corpus gap shows where data autonomy still has not.</p>
+                    <p class="text-xs themeable-muted mt-2">2026.05.11 · Deep Research Report</p>
+                </a>
             </div>
         </div>
 
@@ -174,6 +179,7 @@
                 'report/hermes-agent-data-quality-risk/en/',
                 'report/kronos-financial-foundation-model/en/',
                 'report/korea-digital-asset-basic-law-2026/en/',
+                'report/upstage-national-fund-2026-05/en/',
                 'project/DataClinic/data-quality/en/',
                 'project/DataClinic/data-quality-guide-book-01/en/',
                 'project/SyntheticData/en/',

--- a/project/DataEconomy/ko/index.html
+++ b/project/DataEconomy/ko/index.html
@@ -106,6 +106,11 @@
                     <p class="themeable-text text-sm mt-1 leading-relaxed">디지털자산기본법 12개 사업 영역, 1,113만 이용자, 87.2조 원 시장의 제도적 기반.</p>
                     <p class="text-xs themeable-muted mt-2">2026.05.06 · 심층조사 보고서</p>
                 </a>
+                <a href="/report/upstage-national-fund-2026-05/ko/" class="ir-hover-card block themeable-card-bg rounded-lg p-5 border-2 no-underline" style="border-color: #F86825;">
+                    <p class="ir-hover-title text-lg font-bold themeable-heading">업스테이지 5,600억 투자 — 소버린 AI와 한국어 데이터 자립의 진짜 변수</p>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">국민성장펀드의 SW 첫 직접투자 5,600억 원. 모델 자본은 도착했지만 한국어 0.823% 격차가 남긴 데이터 자립의 진짜 변수를 본다.</p>
+                    <p class="text-xs themeable-muted mt-2">2026.05.11 · 심층조사 보고서</p>
+                </a>
             </div>
         </div>
 
@@ -174,6 +179,7 @@
                 'report/hermes-agent-data-quality-risk/ko/',
                 'report/kronos-financial-foundation-model/ko/',
                 'report/korea-digital-asset-basic-law-2026/ko/',
+                'report/upstage-national-fund-2026-05/ko/',
                 'project/DataClinic/data-quality/ko/',
                 'project/DataClinic/data-quality-guide-book-01/ko/',
                 'project/SyntheticData/ko/',

--- a/report/upstage-national-fund-2026-05/en/index.html
+++ b/report/upstage-national-fund-2026-05/en/index.html
@@ -283,7 +283,7 @@
                             But the question this report asks is different. <strong>Model capital has arrived in Korea. Data sovereignty has not.</strong> Upstage's own <em>Solar Open Technical Report</em> (arXiv:2601.07022, January 2026) names the gap explicitly: <em>"Korean represents only about 0.8% of indexed web content and ranks 17th by bytes in FineWeb 2 — a reasonably severe data scarcity."</em> Common Crawl's CC-MAIN-2026-17 confirms it: Korean at 0.823%, English at 41.02% — a <strong>50× gap</strong>. The 2024–2025 academic consensus from DataComp-LM, FineWeb, Phi-3, and NVIDIA's Nemotron-4 converges on a single point: <strong>data quality matters more than model size</strong>. DCLM-7B saved 40% of compute at the same accuracy. Nemotron-4 340B's alignment data is 98% synthetic. Korean-language quality filtering can't be substituted by English filters — Naver's HyperCLOVA X THINK had to train a Korean-specific quality regression model from scratch.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Seven sections answer seven questions. (1) What's the policy mechanism behind the $400M? (2) Why did the government pick Upstage? (3) Where does Korea sit on the global sovereign-AI map? (4) Is $400M enough? (5) What's the actual state of the Korean corpus? (6) What does the next funding round look like? (7) What does this mean for policymakers, executives, and ML practitioners? The conclusion is one line — <strong>the binding variable in sovereign AI is data quality</strong>.
+                            Seven sections answer seven questions. (1) What's the policy mechanism behind the $400M? (2) Why did the government pick Upstage? (3) Where does Korea sit on the global sovereign-AI map? (4) Is $400M enough? (5) What's the actual state of the Korean corpus? (6) What does the next funding round look like? (7) What does this mean for policymakers, executives, and ML practitioners? The conclusion is one line — <strong>the binding variable in sovereign AI is data quality</strong>. This piece is the sovereign-AI chapter of the <a href="/project/DataEconomy/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Data Economy</a> series &mdash; where model capital arrived but data autonomy did not.
                         </p>
                     </div>
 
@@ -1004,6 +1004,14 @@
                         <li>Pebblous internal report (HAI 2026 Part 2) — <a href="https://blog.pebblous.ai/report/hai-ai-index-2026-part2/en/" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-600 transition-colors">blog.pebblous.ai</a></li>
                     </ol>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Data Economy Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/DataEconomy/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Data Economy</a> series curated by Pebblous &mdash; reading the market structure that turns data into assets, across the four axes of sovereignty, quality, synthesis, and value proof.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/upstage-national-fund-2026-05/ko/index.html
+++ b/report/upstage-national-fund-2026-05/ko/index.html
@@ -283,7 +283,7 @@
                             그러나 이 보고서가 던지는 질문은 다릅니다. <strong>모델 자본은 도착했지만, 데이터 자립은 도착하지 않았습니다.</strong> 업스테이지 자신이 2026년 1월 발표한 <em>Solar Open Technical Report</em>(arXiv:2601.07022)는 "한국어는 인덱싱된 웹 콘텐츠의 0.8%, FineWeb 2 바이트 기준 17위, 상당히 심각한 데이터 부족"이라고 명시했습니다. Common Crawl 공식 통계(CC-MAIN-2026-17)도 한국어 0.823% 대 영어 41.02% — <strong>약 50배 격차</strong>입니다. DataComp-LM·FineWeb·Phi-3·Nemotron-4 등 2024~2025년 학계 합의는 하나로 모입니다. <strong>데이터 품질이 모델 크기보다 중요하다</strong>는 것입니다. DCLM-7B는 컴퓨트의 40%를 절감했고, Nemotron-4 340B 정렬 데이터의 98%는 합성이며, 한국어용 품질 회귀 모델은 영어 필터로 대체할 수 없다는 사실이 HyperCLOVA X THINK에서 다시 확인됩니다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            그래서 우리는 일곱 개의 질문을 차례로 따라갑니다. 5,600억의 정책 메커니즘은 어떻게 설계되었는지, 왜 다른 후보가 아닌 업스테이지였는지, 글로벌 소버린 AI 지도 위에서 한국은 어디에 서 있는지, 4억 달러는 정말로 충분한 자본인지, 한국어 corpus의 진실은 무엇이며 다음 라운드는 어디로 향하는지, 그리고 이 흐름이 정책·기업·엔지니어에게 무엇을 요구하는지. 일곱 갈래의 답은 결국 한 줄로 모입니다 — <strong>소버린 AI의 진짜 변수는 데이터 품질입니다.</strong>
+                            그래서 우리는 일곱 개의 질문을 차례로 따라갑니다. 5,600억의 정책 메커니즘은 어떻게 설계되었는지, 왜 다른 후보가 아닌 업스테이지였는지, 글로벌 소버린 AI 지도 위에서 한국은 어디에 서 있는지, 4억 달러는 정말로 충분한 자본인지, 한국어 corpus의 진실은 무엇이며 다음 라운드는 어디로 향하는지, 그리고 이 흐름이 정책·기업·엔지니어에게 무엇을 요구하는지. 일곱 갈래의 답은 결국 한 줄로 모입니다 — <strong>소버린 AI의 진짜 변수는 데이터 품질입니다.</strong> 이 글은 <a href="/project/DataEconomy/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터 이코노미</a> 시리즈의 소버린 AI 편으로, 모델 자본이 도착했지만 데이터 자립이 도착하지 않은 자리를 본다.
                         </p>
                     </div>
 
@@ -1005,6 +1005,14 @@
                         <li>페블러스 자체 보고서 (HAI 2026 Part 2) — <a href="https://blog.pebblous.ai/report/hai-ai-index-2026-part2/en/" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-600 transition-colors">blog.pebblous.ai</a></li>
                     </ol>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 데이터 이코노미 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/DataEconomy/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">데이터 이코노미</a>에서 큐레이션하는 시리즈의 일부입니다. 데이터가 자산이 되는 시장의 구조를 — 주권, 품질, 합성, 가치 증명의 네 축으로 — 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 6차 해결
- 영향 페이지 54개 중 2개(1쌍 KO+EN) 처리
- DataEconomy hub로 Upstage 소버린 AI 글 흡수

## 누적 진척

| Phase | PR | 처리 페이지 | 누적 |
|---|---|---|---|
| Phase 1-5a | #171,172,181,182,183 (merged) | 32 | 32/54 |
| **Phase 5b (DataEconomy / Upstage)** | **(this PR)** | **2** | **34/54 (63%)** |

## 처리한 글 (1쌍)

| 글 | 포지셔닝 |
|---|---|
| \`report/upstage-national-fund-2026-05\` | 소버린 AI 편 — 모델 자본은 도착했지만 데이터 자립은 도착하지 않은 자리 |

업스테이지 5,600억 정책 투자가 데이터 이코노미 시리즈의 "데이터 주권과 가치" 축에 정확히 들어맞으나 이전에 글에 reverse-link가 빠져있었음.

## 적용 패턴 — \`docs/hub-reverse-link.md\` 그대로

- **(A) Executive Summary 마지막 \`<p>\` 끝**: inline 백링크 한 문장
- **(B) \`</main>\` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 업데이트

- "데이터 주권과 가치" 시리즈 가이드 섹션에 upstage 카드 신규 추가 (KO+EN)
- \`extraPaths\`에 \`report/upstage-national-fund-2026-05\` 등록

## 후속 작업

남은 20개:
- 단발 cross-link 후보: kronos (금융 AI), nvidia-vcc (바이오 AI), frontend-vibe-coders, ngogo (행동 시뮬레이션)
- 메타 페이지 (특수 처리): IR Press Room, blog-2026-feb (메인 인덱스 링크), DataEconomy/IR hub 자체

## Test Plan

- [ ] 머지 후 \`curl https://blog.pebblous.ai/report/upstage-national-fund-2026-05/ko/\`에서 DataEconomy hub 링크 2개 확인
- [ ] DataEconomy hub의 "데이터 주권과 가치" 섹션에 upstage 카드 노출 확인