### PR TITLE
fix(hub): 단발 4쌍을 3개 hub로 분산 흡수 (Semrush 진단 7차)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -154,7 +154,7 @@
         "Digital Cell Twin"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 15776,
+      "wordCount": 15924,
       "modified": "2026-05-14"
     },
     {
@@ -181,7 +181,7 @@
         "Digital Cell Twin"
       ],
       "publisher": "Pebblous Inc. Data Communications Team",
-      "wordCount": 25118,
+      "wordCount": 25402,
       "modified": "2026-05-14"
     },
     {
@@ -257,7 +257,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 26699,
-      "modified": "2026-05-10"
+      "modified": "2026-05-22"
     },
     {
       "id": "upstage-national-fund-2026-05-ko",
@@ -282,7 +282,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 13991,
-      "modified": "2026-05-10"
+      "modified": "2026-05-22"
     },
     {
       "id": "yann-lecun-jepa-world-models-ko",
@@ -912,7 +912,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 11604,
+      "wordCount": 11724,
       "modified": "2026-04-14"
     },
     {
@@ -937,7 +937,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 23134,
+      "wordCount": 23412,
       "modified": "2026-05-02"
     },
     {
@@ -1423,7 +1423,7 @@
         "Science 2026"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 5925,
+      "wordCount": 6067,
       "modified": "2026-04-12"
     },
     {
@@ -1450,7 +1450,7 @@
         "Science 2026"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 11897,
+      "wordCount": 12199,
       "modified": "2026-04-12"
     },
     {
@@ -12739,7 +12739,7 @@
       "published": true,
       "featured": false,
       "language": "ko",
-      "wordCount": 4878,
+      "wordCount": 5054,
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "tags": [
         "바이브코딩",
@@ -12763,7 +12763,7 @@
       "published": true,
       "featured": false,
       "language": "en",
-      "wordCount": 9213,
+      "wordCount": 9563,
       "publisher": "Pebblous Data Communication Team",
       "tags": [
         "vibe coding",
@@ -12935,7 +12935,7 @@
       ],
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "modified": "2026-05-10"
+      "modified": "2026-05-22"
     },
     {
       "id": "data-economy-hub-en",
@@ -12958,7 +12958,7 @@
       ],
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
-      "modified": "2026-05-10"
+      "modified": "2026-05-22"
     },
     {
       "id": "neuro-symbolic-ontology-hub-ko",

--- a/project/AnthropicClaude/en/index.html
+++ b/project/AnthropicClaude/en/index.html
@@ -150,7 +150,8 @@
                 'report/karpathy-coding-skills-2026-04',
                 'report/karpathy-llm-wiki',
                 'blog/dc-story-produce-pipeline-meta',
-                'report/ai-psychosis-agentic-governance-2026-05'
+                'report/ai-psychosis-agentic-governance-2026-05',
+                'report/frontend-vibe-coders'
             ],
             language: 'en'
         });

--- a/project/AnthropicClaude/ko/index.html
+++ b/project/AnthropicClaude/ko/index.html
@@ -150,7 +150,8 @@
                 'report/karpathy-coding-skills-2026-04',
                 'report/karpathy-llm-wiki',
                 'blog/dc-story-produce-pipeline-meta',
-                'report/ai-psychosis-agentic-governance-2026-05'
+                'report/ai-psychosis-agentic-governance-2026-05',
+                'report/frontend-vibe-coders'
             ],
             language: 'ko'
         });

--- a/project/BizReport/en/index.html
+++ b/project/BizReport/en/index.html
@@ -131,6 +131,12 @@
                     </a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">A field record of Allaire's April 2026 Seoul declaration. The counterpart to the Circle financial analysis — B2A, KYA, X402, CPN, and Circle's strategy for entering the Korean market and powering AI agent payments.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/kronos-financial-foundation-model/en/" class="text-lg font-semibold" style="color: #F86825;">
+                        Kronos Explained: Why Finance-Specific Time-Series AI Outperforms General Models
+                    </a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">Tsinghua's Kronos at AAAI 2026 beat general TSFMs by RankIC +93%. BSQ tokenization on a 12B+ K-line corpus shows where domain data — not model scale — decides the outcome of a domain-specific foundation model.</p>
+                </div>
             </div>
         </div>
 
@@ -157,7 +163,8 @@
             pathFilter: 'BizReport/',
             extraPaths: [
                 'BizReport/palantir-analysis-2026',
-                'story/circle-seoul-jeremy-allaire-pb'
+                'story/circle-seoul-jeremy-allaire-pb',
+                'report/kronos-financial-foundation-model'
             ],
             language: 'en'
         });

--- a/project/BizReport/ko/index.html
+++ b/project/BizReport/ko/index.html
@@ -137,6 +137,12 @@
                     </a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">2026년 4월 서울에서 알레어가 던진 선언의 현장 기록. Circle 재무 분석의 짝글 — B2A, KYA, X402, CPN 개념과 한국 시장 진입 전략, AI 에이전트 결제 인프라를 풀어낸다.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/report/kronos-financial-foundation-model/ko/" class="text-lg font-semibold" style="color: #F86825;">
+                        Kronos 금융 시계열 파운데이션 모델: 도메인 특화 AI와 데이터 품질의 새로운 공식
+                    </a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">청화대학교 Kronos가 AAAI 2026에서 RankIC +93%로 범용 TSFM을 압도. BSQ 토큰화·12B+ K-line 코퍼스가 만든 도메인 특화 FM의 승부 — 모델보다 도메인 데이터가 결정짓는다.</p>
+                </div>
             </div>
         </div>
 
@@ -162,7 +168,8 @@
             containerId: 'bizreport-cards',
             pathFilter: 'BizReport/',
             extraPaths: [
-                'story/circle-seoul-jeremy-allaire-pb'
+                'story/circle-seoul-jeremy-allaire-pb',
+                'report/kronos-financial-foundation-model'
             ],
             language: 'ko'
         });

--- a/project/PhysicalAI/en/index.html
+++ b/project/PhysicalAI/en/index.html
@@ -176,7 +176,9 @@
                 'report/vla-architecture-comparison',
                 'report/physical-ai-industry-landscape',
                 'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',
-                'report/multiagent-industrial-data-operations'
+                'report/multiagent-industrial-data-operations',
+                'report/nvidia-virtual-cell-challenge-2026-05',
+                'story/ngogo-chimp-network-ai-pb'
             ],
             language: 'en'
         });

--- a/project/PhysicalAI/ko/index.html
+++ b/project/PhysicalAI/ko/index.html
@@ -176,7 +176,9 @@
                 'report/vla-architecture-comparison',
                 'report/physical-ai-industry-landscape',
                 'report/isaac-sim-3dgs-vla-synthetic-data-2026-04',
-                'report/multiagent-industrial-data-operations'
+                'report/multiagent-industrial-data-operations',
+                'report/nvidia-virtual-cell-challenge-2026-05',
+                'story/ngogo-chimp-network-ai-pb'
             ],
             language: 'ko'
         });

--- a/report/frontend-vibe-coders/en/index.html
+++ b/report/frontend-vibe-coders/en/index.html
@@ -103,7 +103,7 @@
                             Frontend history isn't a long timeline — it's three pivotal shifts. From documents to apps, from jQuery to state management, from MPA to choosing a rendering strategy. Each shift had a reason, and those reasons live on as patterns in AI-generated code today.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            This report doesn't teach frontend from scratch. It covers the five core concepts that matter when a vibe coder actually gets stuck — the context that lets you have a more precise conversation with AI.
+                            This report doesn't teach frontend from scratch. It covers the five core concepts that matter when a vibe coder actually gets stuck — the context that lets you have a more precise conversation with AI. This piece is the vibe-coder chapter of the <a href="/project/AnthropicClaude/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Claude Watch</a> series &mdash; the context you need to make precise requests to Claude in Karpathy-style coding environments.
                         </p>
                     </div>
                 </section>
@@ -476,6 +476,14 @@
             
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Claude Watch Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/AnthropicClaude/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Claude Watch</a> series curated by Pebblous &mdash; tracking Anthropic's Claude across the politics of model release, the harness microstructure, AI alignment, agent architecture, and coding behavior correction.
+                    </p>
+                </div>
 
 </main>
         </div>

--- a/report/frontend-vibe-coders/ko/index.html
+++ b/report/frontend-vibe-coders/ko/index.html
@@ -103,7 +103,7 @@
                             프론트엔드 역사는 긴 연대기가 아니다. 세 번의 결정적 전환이 있었다. 문서에서 앱으로, jQuery에서 상태 관리로, MPA에서 렌더링 전략의 선택으로. 각 전환에는 이유가 있었고, 그 이유들이 지금 AI 생성 코드의 패턴으로 남아 있다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            이 글은 프론트엔드를 처음부터 가르치지 않는다. 바이브코더가 실제로 막히는 순간에 필요한 맥락, AI에게 더 정확한 요청을 할 수 있게 해주는 다섯 가지 핵심 개념을 정리한다.
+                            이 글은 프론트엔드를 처음부터 가르치지 않는다. 바이브코더가 실제로 막히는 순간에 필요한 맥락, AI에게 더 정확한 요청을 할 수 있게 해주는 다섯 가지 핵심 개념을 정리한다. 이 글은 <a href="/project/AnthropicClaude/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">Claude 워치</a> 시리즈의 바이브 코더 편으로, Claude·Karpathy 코딩 환경에서 AI에게 더 정확하게 요청하기 위한 맥락을 본다.
                         </p>
                     </div>
                 </section>
@@ -476,6 +476,14 @@
             
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card"></section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Claude 워치 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/AnthropicClaude/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">Claude 워치</a>에서 큐레이션하는 시리즈의 일부입니다. Anthropic이 만든 Claude를 페블러스 관점에서 추적하는 자리 — 모델 공개의 정치학부터 하네스, 정렬, 에이전트 아키텍처, 코딩 행동 교정까지.
+                    </p>
+                </div>
 
 </main>
         </div>

--- a/report/kronos-financial-foundation-model/en/index.html
+++ b/report/kronos-financial-foundation-model/en/index.html
@@ -140,7 +140,7 @@
                             The deeper significance of this achievement goes beyond model performance. It empirically proves that machines can learn the native "language" of a domain like financial time series — and that the quality of that learning depends entirely on the quality of the training data. While TimesFM (500M parameters), a general-purpose TSFM, recorded R² = -2.80% on financial data, Kronos outperformed all 25 baseline models on the same tasks. This is the clearest evidence that "domain-appropriate representation" — not "bigger and more general models" — is what decides the outcome.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Pebblous intersects this paradigm shift at three points. First, the fact that Kronos's BSQ codebook (2^20 vocabulary) directly reflects training data distribution means that DataClinic's time-series outlier detection, missing value imputation, and distribution diagnostics determine FM performance at the upstream level. Second, Kronos's synthetic K-line generation (+22% fidelity) serves as prior validation for the synthetic sensor time-series generation that DataGreenhouse aims to deliver in the manufacturing domain. Third, the positioning that "in the era of domain-specific FMs, data quality is a constituent element of the model itself" becomes the central argument for the AI-Ready Data strategy. Gartner has already warned: "Through 2026, organizations will abandon 60% of AI projects unsupported by AI-ready data."
+                            Pebblous intersects this paradigm shift at three points. First, the fact that Kronos's BSQ codebook (2^20 vocabulary) directly reflects training data distribution means that DataClinic's time-series outlier detection, missing value imputation, and distribution diagnostics determine FM performance at the upstream level. Second, Kronos's synthetic K-line generation (+22% fidelity) serves as prior validation for the synthetic sensor time-series generation that DataGreenhouse aims to deliver in the manufacturing domain. Third, the positioning that "in the era of domain-specific FMs, data quality is a constituent element of the model itself" becomes the central argument for the AI-Ready Data strategy. Gartner has already warned: "Through 2026, organizations will abandon 60% of AI projects unsupported by AI-ready data." This piece is the domain-specific FM chapter of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series &mdash; where domain data, not model scale, decides the outcome.
                         </p>
                     </div>
                     <div class="mt-6 text-xs themeable-muted leading-relaxed" style="border-top: 1px solid var(--border-color); padding-top: 0.75rem;">
@@ -662,6 +662,14 @@
                         </p>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Biz Insight Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/BizReport/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Biz Insight</a> series curated by Pebblous &mdash; reading the financials, products, and market strategies of global companies through a data infrastructure lens.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/kronos-financial-foundation-model/ko/index.html
+++ b/report/kronos-financial-foundation-model/ko/index.html
@@ -140,7 +140,7 @@
                             이 성과의 본질적 의미는 단순한 모델 성능 개선이 아니다. 금융 시계열이라는 도메인 고유의 "언어"를 기계가 배울 수 있다는 것, 그리고 그 학습의 질은 전적으로 학습 데이터의 품질에 달려 있다는 것을 실증적으로 증명했다. 범용 TSFM인 TimesFM(500M 파라미터)이 금융 데이터에서 R² = -2.80%를 기록한 반면, 금융 도메인에 특화된 Kronos는 동일한 과제에서 25개 베이스라인 모델을 모두 압도했다. "더 크고 범용적인 모델"이 아니라 "도메인에 맞는 표현 구조"가 승부를 결정짓는 시대가 왔음을 보여주는 가장 선명한 증거다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            페블러스는 이 전환에서 세 가지 접점을 갖는다. 첫째, Kronos의 BSQ codebook(2^20 어휘)이 학습 데이터 분포를 직접 반영하는 구조는 DataClinic의 시계열 이상치 탐지·결측값 처리·분포 진단 역량이 FM 성능을 업스트림에서 결정하는 근거가 된다. 둘째, Kronos의 합성 K-line 생성(+22% fidelity)은 DataGreenhouse가 제조 도메인에서 수행하려는 합성 센서 시계열 생성의 선행 증명이다. 셋째, "도메인 특화 FM 시대에 데이터 품질은 모델 자체의 구성 요소"라는 포지셔닝이 AI-Ready Data 전략의 핵심 논거가 된다. Gartner는 이미 경고했다 — "Through 2026, organizations will abandon 60% of AI projects unsupported by AI-ready data."
+                            페블러스는 이 전환에서 세 가지 접점을 갖는다. 첫째, Kronos의 BSQ codebook(2^20 어휘)이 학습 데이터 분포를 직접 반영하는 구조는 DataClinic의 시계열 이상치 탐지·결측값 처리·분포 진단 역량이 FM 성능을 업스트림에서 결정하는 근거가 된다. 둘째, Kronos의 합성 K-line 생성(+22% fidelity)은 DataGreenhouse가 제조 도메인에서 수행하려는 합성 센서 시계열 생성의 선행 증명이다. 셋째, "도메인 특화 FM 시대에 데이터 품질은 모델 자체의 구성 요소"라는 포지셔닝이 AI-Ready Data 전략의 핵심 논거가 된다. Gartner는 이미 경고했다 — "Through 2026, organizations will abandon 60% of AI projects unsupported by AI-ready data." 이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a> 시리즈의 도메인 특화 FM 편으로, 모델보다 도메인 데이터가 승부를 결정하는 자리다.
                         </p>
                     </div>
                     <div class="mt-6 text-xs themeable-muted leading-relaxed" style="border-top: 1px solid var(--border-color); padding-top: 0.75rem;">
@@ -662,6 +662,14 @@
                         </p>
                     </div>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 비즈 인사이트 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/BizReport/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">비즈 인사이트</a>에서 큐레이션하는 시리즈의 일부입니다. 데이터 인프라 관점에서 글로벌 기업의 재무·제품·시장 전략을 페블러스가 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/nvidia-virtual-cell-challenge-2026-05/en/index.html
+++ b/report/nvidia-virtual-cell-challenge-2026-05/en/index.html
@@ -210,7 +210,7 @@
                             But the most consequential finding wasn't who won — it was <em>how</em> they won. Arc Institute's Hani Goodarzi stated bluntly at the wrap-up: <em>"Pure end-to-end neural networks have yet to outperform hybrid models."</em> The most-discussed solution, <strong>TransPert</strong> from the joint University of Chicago–Dartmouth–HKU "Outlier" team, reached the top of the PDS leaderboard not with a giant model but with classical statistics — pseudo-bulk summary stats and Wilcoxon-style tests. Even the BioMap winners publicly noted that <em>"purely AI-based approaches did not consistently outperform statistical baselines."</em> In the same window, Ahlmann-Eltze et al. (<em>Nature Methods</em>, 2025) showed that five major single-cell foundation models — scGPT, scFoundation, GEARS and others — failed to consistently beat simple linear baselines. Arc Institute's wet-lab-curated 300K-cell dataset, Vevo Therapeutics's Tahoe-100M (50× larger than all prior public drug-perturbation data), the CZI Billion Cells Project, and the January 2026 Arc–Tahoe–Biohub 120M-cell pledge all point in the same direction: capital and attention are migrating <strong>below</strong> the model layer to data.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Pebblous's read fits on one line. <strong>"There's enough GPU. There's enough model. What's scarce is trustworthy training data and the domain inductive bias to use it."</strong> The thesis we have argued for years in industrial AI — that data quality decides outcomes more than model architecture — was re-validated in a completely different domain by an objective contest. This report unpacks the event for global readers and traces what it implies for drug discovery, public bio-data infrastructure, and bio-AI startups outside the U.S. and China.
+                            Pebblous's read fits on one line. <strong>"There's enough GPU. There's enough model. What's scarce is trustworthy training data and the domain inductive bias to use it."</strong> The thesis we have argued for years in industrial AI — that data quality decides outcomes more than model architecture — was re-validated in a completely different domain by an objective contest. This report unpacks the event for global readers and traces what it implies for drug discovery, public bio-data infrastructure, and bio-AI startups outside the U.S. and China. This piece is the bio-AI chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; where NVIDIA's ecosystem meets synthetic data and domain inductive bias.
                         </p>
                     </div>
 
@@ -757,6 +757,14 @@
                         <li><span class="ref-num">27.</span><span class="ref-body">Korean Ministry of Health / Science and ICT. "Training 1,000+ AI diagnostic, predictive, and drug-discovery talents over 5 years." Aug 2025.</span></li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/report/nvidia-virtual-cell-challenge-2026-05/ko/index.html
+++ b/report/nvidia-virtual-cell-challenge-2026-05/ko/index.html
@@ -210,7 +210,7 @@
                             그러나 챌린지의 가장 중요한 결과는 누가 1등을 했느냐가 아니라 "어떻게" 그 순위가 만들어졌느냐다. Arc Institute의 핵심 연구자 Hani Goodarzi는 결과 발표에서 <em>"순수 end-to-end 신경망은 아직 하이브리드 모델을 능가하지 못했다"</em>고 명시했다. 가장 회자된 솔루션 <strong>TransPert</strong>(시카고대·다트머스·홍콩대 합동팀 "Outlier")는 거대 모델이 아닌 pseudo-bulk 요약 통계와 Wilcoxon test 같은 고전 통계 framework로 PDS 최상위권에 들었다. 1위 BioMap 팀조차 공식 코멘트로 "순수 AI 접근은 통계 베이스라인을 일관되게 넘지 못했다"는 사실을 공유했다. 동시기 <em>Nature Methods</em>에 게재된 Ahlmann-Eltze et al.(2025)은 scGPT·scFoundation·GEARS 등 거대 single-cell foundation model 다섯 개가 단순 선형 베이스라인을 일관되게 이기지 못함을 보였다. Arc Institute가 wet lab에서 직접 큐레이션한 30만 셀 데이터셋, Vevo Therapeutics가 공개한 Tahoe-100M(기존 공개 약물 perturbation 데이터의 50배), CZI Billion Cells Project, 2026-01 Arc–Tahoe–Biohub의 120M cell 신규 약속은 모두 "모델 위가 아니라 그 아래 데이터 레이어"로 자본·관심이 이동하고 있음을 보여준다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            페블러스 관점의 발견은 단 한 줄로 요약된다. <strong>"GPU도 모델도 충분하다. 부족한 것은 신뢰할 수 있는 학습 데이터와 도메인 inductive bias다."</strong> 페블러스가 산업 AI에서 일관되게 주장해온 "모델보다 데이터 품질이 결과를 결정한다"는 명제가, 바이오라는 전혀 다른 도메인의 객관적 챌린지에서 재입증된 사건이다. 본 보고서는 이 사건을 한국 독자에게 풀어 설명하고, K-바이오 AI·정부 빅데이터 사업·국내 제약 R&D에 시사하는 바를 짚는다.
+                            페블러스 관점의 발견은 단 한 줄로 요약된다. <strong>"GPU도 모델도 충분하다. 부족한 것은 신뢰할 수 있는 학습 데이터와 도메인 inductive bias다."</strong> 페블러스가 산업 AI에서 일관되게 주장해온 "모델보다 데이터 품질이 결과를 결정한다"는 명제가, 바이오라는 전혀 다른 도메인의 객관적 챌린지에서 재입증된 사건이다. 본 보고서는 이 사건을 한국 독자에게 풀어 설명하고, K-바이오 AI·정부 빅데이터 사업·국내 제약 R&D에 시사하는 바를 짚는다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 바이오 AI 편으로, NVIDIA 생태계와 합성데이터·도메인 inductive bias의 인접 지점을 본다.
                         </p>
                     </div>
 
@@ -760,6 +760,14 @@
                         <li><span class="ref-num">27.</span><span class="ref-body">보건복지부 / 과기정통부. "AI 진단·예측·신약 인재 5년 1,000+ 명 양성." 2025-08.</span></li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
         </div>

--- a/story/ngogo-chimp-network-ai-pb/en/index.html
+++ b/story/ngogo-chimp-network-ai-pb/en/index.html
@@ -245,7 +245,7 @@
                             In April 2026, a <a href="https://www.science.org/doi/10.1126/science.adz4944" target="_blank" rel="noopener" class="text-orange-500 hover:underline">30-year study</a> was published in the journal <em>Science</em>. The world's largest wild chimpanzee community — the Ngogo group in Uganda — split into two factions, waged civil war, and 14 infants in one group were largely killed. The cause was not territory or food. <strong>In a community with no language, ideology, ethnicity, or religion, civil war emerged purely from changes in the structure of social networks.</strong>
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            Pebblous pays attention to this research not out of humanistic curiosity. It is because the collapse mechanism of this community is structurally identical to large-scale AI agent systems and the data ecosystems we build. This article is a work of data journalism that bridges data science and network biology — directly visualizing 24 years of real network data from Zenodo to derive system design principles for the Agentic AI era.
+                            Pebblous pays attention to this research not out of humanistic curiosity. It is because the collapse mechanism of this community is structurally identical to large-scale AI agent systems and the data ecosystems we build. This article is a work of data journalism that bridges data science and network biology — directly visualizing 24 years of real network data from Zenodo to derive system design principles for the Agentic AI era. This piece is the multi-agent behavior chapter of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series &mdash; what natural community collapse asks of industrial multi-agent system design.
                         </p>
                     </div>
                 </section>
@@ -510,6 +510,14 @@ Sandel's words summarize this lesson: <strong>"The new group identities are over
                         <li>NPR: <a href="https://www.npr.org/2026/04/09/nx-s1-5775783/what-a-chimpanzee-civil-war-can-teach-us-about-how-societies-fall-apart" target="_blank" rel="noopener" class="text-orange-500 hover:underline">What a chimpanzee civil war can teach us about how societies fall apart</a></li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 Physical AI Series</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        This article is part of the <a href="/project/PhysicalAI/en/" class="text-orange-500 hover:text-orange-400 font-semibold">Physical AI</a> series curated by Pebblous &mdash; how robots come to see, understand, and act, read together across data, simulation, models, and industry landscape.
+                    </p>
+                </div>
 
             </main>
 

--- a/story/ngogo-chimp-network-ai-pb/ko/index.html
+++ b/story/ngogo-chimp-network-ai-pb/ko/index.html
@@ -245,7 +245,7 @@
                             2026년 4월, 과학저널 <em>Science</em>에 <a href="https://www.science.org/doi/10.1126/science.adz4944" target="_blank" rel="noopener" class="text-orange-500 hover:underline">30년짜리 연구 결과</a>가 실렸다. 세계 최대 야생 침팬지 집단인 우간다 Ngogo 군집이 두 파로 갈라져 내전을 벌이고, 한 쪽 집단의 새끼 14마리가 대부분 살해됐다는 내용이다. 분열의 원인은 영토나 먹이가 아니었다. <strong>언어도, 이념도, 민족도 없는 집단에서 순수하게 '관계망 구조의 변화'만으로 내전이 발생했다.</strong>
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            페블러스가 이 연구에 주목하는 이유는 인문학적 흥미 때문이 아니다. 이 집단의 붕괴 메커니즘이 대규모 AI 에이전트 시스템, 그리고 우리가 구축하는 데이터 생태계와 구조적으로 동일하기 때문이다. 이 글은 데이터 사이언스와 네트워크 생물학을 접목하여, Zenodo에 공개된 24년간의 실제 네트워크 데이터를 직접 시각화하고, Agentic AI 시대의 시스템 설계 원칙을 도출하는 데이터 저널리즘이다.
+                            페블러스가 이 연구에 주목하는 이유는 인문학적 흥미 때문이 아니다. 이 집단의 붕괴 메커니즘이 대규모 AI 에이전트 시스템, 그리고 우리가 구축하는 데이터 생태계와 구조적으로 동일하기 때문이다. 이 글은 데이터 사이언스와 네트워크 생물학을 접목하여, Zenodo에 공개된 24년간의 실제 네트워크 데이터를 직접 시각화하고, Agentic AI 시대의 시스템 설계 원칙을 도출하는 데이터 저널리즘이다. 이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a> 시리즈의 멀티에이전트 행동 편으로, 자연계의 군집 붕괴가 산업 멀티에이전트 시스템 설계에 던지는 질문을 본다.
                         </p>
                     </div>
                 </section>
@@ -519,6 +519,14 @@ Sandel의 말이 이 교훈을 요약한다. <strong>"새로운 집단 정체성
                         <li>NPR: <a href="https://www.npr.org/2026/04/09/nx-s1-5775783/what-a-chimpanzee-civil-war-can-teach-us-about-how-societies-fall-apart" target="_blank" rel="noopener" class="text-orange-500 hover:underline">What a chimpanzee civil war can teach us about how societies fall apart</a></li>
                     </ul>
                 </section>
+
+                <!-- Hub Series Notice -->
+                <div class="themeable-card rounded-xl p-6 mt-8 mb-8" style="border-left: 4px solid #F86825;">
+                    <p class="text-sm font-bold themeable-heading mb-2">📚 피지컬 AI 시리즈</p>
+                    <p class="text-sm themeable-text leading-relaxed">
+                        이 글은 <a href="/project/PhysicalAI/ko/" class="text-orange-500 hover:text-orange-400 font-semibold">피지컬 AI</a>에서 큐레이션하는 시리즈의 일부입니다. 로봇이 환경을 보고, 이해하고, 행동하기까지 — 데이터·시뮬레이션·모델·산업 지형을 한자리에서 묶어 읽는 자리.
+                    </p>
+                </div>
 
             </main>
 


### PR DESCRIPTION
## Summary

- Semrush 사이트 진단(2026-05-16) "내부 링크가 1개뿐인 페이지" 이슈 7차 해결
- 영향 페이지 54개 중 8개(4쌍 KO+EN) 처리
- 단발 4쌍을 도메인에 맞는 3개 hub로 분산 흡수

## 누적 진척

| Phase | PR | 처리 페이지 | 누적 |
|---|---|---|---|
| Phase 1-5b | #171~#184 (merged) | 34 | 34/54 |
| **Phase 5c (단발 4쌍 분산)** | **(this PR)** | **8** | **42/54 (78%)** |

## 처리한 글 (4쌍)

| 글 | 흡수 hub | 포지셔닝 |
|---|---|---|
| \`report/kronos-financial-foundation-model\` | **BizReport** | 도메인 특화 FM 편 |
| \`report/nvidia-virtual-cell-challenge-2026-05\` | **PhysicalAI** | 바이오 AI 편 |
| \`report/frontend-vibe-coders\` | **AnthropicClaude (Claude 워치)** | 바이브 코더 편 |
| \`story/ngogo-chimp-network-ai-pb\` | **PhysicalAI** | 멀티에이전트 행동 편 |

각 글의 도메인이 다르지만 페블러스의 기존 hub 구조 안에서 자연스럽게 위치 가능했음.

## 적용 패턴 — \`docs/hub-reverse-link.md\` 그대로

- **(A) Executive Summary 마지막 \`<p>\` 끝**: inline 백링크 한 문장
- **(B) \`</main>\` 직전**: Series Notice 카드 (📚 헤더 + 오렌지 좌측 보더)
- KO + EN 양쪽 동시 적용

## Hub 업데이트

- **BizReport** (KO+EN): kronos 카드 + \`extraPaths\` 등록
- **PhysicalAI** (KO+EN): nvidia-vcc + ngogo \`extraPaths\` 등록
- **AnthropicClaude** (KO+EN): frontend-vibe-coders \`extraPaths\` 등록

## 후속 작업

남은 12개:
- 메타 페이지: IR Press Room (KO+EN, 4페이지, 인증 페이지 — 특수 처리)
- 자기 결산: \`report/blog-2026-feb\` (KO+EN, 2페이지 — 메인 인덱스만)
- Hub 자체: \`project/DataEconomy/{ko,en}/\` (2페이지 — type:hub 자체)
- 잔여 그래프RAG/openmetadata (이미 NeuroSymbolicOntology hub 흡수됨, 더블 확인 필요)

## Test Plan

- [ ] 머지 후 \`curl https://blog.pebblous.ai/report/kronos-financial-foundation-model/ko/\`에서 BizReport hub 링크 2개 확인
- [ ] 각 4글의 동적 카드가 해당 hub 그리드에 노출되는지 확인