### PR TITLE
tools: BLOG_CONTENT_REPO 환경변수 지원 (진본 동기화) — fix sitemap workflow

### DIFF
--- a/tools/generate-llms-txt.py
+++ b/tools/generate-llms-txt.py
@@ -15,10 +15,14 @@ Usage:
 
 import argparse
 import json
+import os
 from pathlib import Path
 from datetime import datetime, timezone
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+# Asset 1 (content repo) location.
+# Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
+ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(os.environ.get("BLOG_CONTENT_REPO", str(ROOT)))
 ARTICLES_JSON = REPO_ROOT / "articles.json"
 DEFAULT_OUTPUT = REPO_ROOT / "llms.txt"
 BASE_URL = "https://blog.pebblous.ai"

--- a/tools/generate-rss.js
+++ b/tools/generate-rss.js
@@ -11,8 +11,13 @@ const fs = require('fs');
 const path = require('path');
 
 const SITE_URL = 'https://blog.pebblous.ai';
-const RSS_PATH = path.join(__dirname, 'rss.xml');
-const ARTICLES_PATH = path.join(__dirname, 'articles.json');
+
+// Asset 1 (content repo) location.
+// Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
+const ROOT = path.resolve(__dirname, '..');
+const BLOG_CONTENT_REPO = process.env.BLOG_CONTENT_REPO || ROOT;
+const RSS_PATH = path.join(BLOG_CONTENT_REPO, 'rss.xml');
+const ARTICLES_PATH = path.join(BLOG_CONTENT_REPO, 'articles.json');
 
 function escapeXml(unsafe) {
     return unsafe

--- a/tools/generate-sitemap.js
+++ b/tools/generate-sitemap.js
@@ -16,8 +16,13 @@ const path = require('path');
 
 // Configuration
 const SITE_URL = 'https://blog.pebblous.ai';
-const ARTICLES_FILE = path.join(__dirname, 'articles.json');
-const SITEMAP_FILE = path.join(__dirname, 'sitemap.xml');
+
+// Asset 1 (content repo) location.
+// Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
+const ROOT = path.resolve(__dirname, '..');
+const BLOG_CONTENT_REPO = process.env.BLOG_CONTENT_REPO || ROOT;
+const ARTICLES_FILE = path.join(BLOG_CONTENT_REPO, 'articles.json');
+const SITEMAP_FILE = path.join(BLOG_CONTENT_REPO, 'sitemap.xml');
 
 // Read articles.json
 const articlesData = JSON.parse(fs.readFileSync(ARTICLES_FILE, 'utf8'));

--- a/tools/scan-articles-meta.py
+++ b/tools/scan-articles-meta.py
@@ -23,7 +23,9 @@ import sys
 from pathlib import Path
 from html.parser import HTMLParser
 
-ROOT = Path(__file__).resolve().parent.parent
+# Asset 1 (content repo) location.
+# Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
+ROOT = Path(os.environ.get("BLOG_CONTENT_REPO", str(Path(__file__).resolve().parent.parent)))
 ARTICLES_JSON = ROOT / "articles.json"
 
 # ========================================

--- a/tools/scan-files-index.py
+++ b/tools/scan-files-index.py
@@ -12,8 +12,10 @@ import os
 from pathlib import Path
 from datetime import datetime
 
-# Configuration
-ROOT_DIR = Path(__file__).parent
+# Asset 1 (content repo) location.
+# Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
+ROOT = Path(__file__).resolve().parent.parent
+ROOT_DIR = Path(os.environ.get("BLOG_CONTENT_REPO", str(ROOT)))
 OUTPUT_FILE = ROOT_DIR / 'files-index.json'
 ARTICLES_FILE = ROOT_DIR / 'articles.json'
 


### PR DESCRIPTION
## Summary

진본 [`joohaeng-pbls/blog-service#2`](https://github.com/joohaeng-pbls/blog-service/pull/2) 동기화. **사본 워크플로우 결함 fix**.

## 배경

PR #189(`fix/notify-applescript-syntax`) 머지 시 진본의 tools/ 이동(진본 PR #1) 변경이 함께 끌려 들어왔으나, BLOG_CONTENT_REPO 환경변수 지원(진본 PR #2)이 누락된 채 머지됨.

**결과**: 사본의 `Update Sitemap & RSS & llms.txt` 워크플로우가 **PR #189 머지 직후 실패** (run 26328366873).

원인:
- `tools/generate-rss.js`, `tools/generate-sitemap.js`가 `__dirname/articles.json` (즉 `tools/articles.json`)을 찾음 → 없음
- `tools/scan-files-index.py`는 `ROOT_DIR = __file__.parent` (즉 `tools/`)에서 HTML 스캔 → 0개

본 PR로 5개 도구가 새 위치(`tools/`)에서 정상 동작하도록 path 가정을 일반화.

## 변경

```python
# Asset 1 (content repo) location.
# Priority: BLOG_CONTENT_REPO env var → ROOT (parent of tools/, i.e. repo root)
ROOT = Path(__file__).resolve().parent.parent
REPO_ROOT = Path(os.environ.get("BLOG_CONTENT_REPO", str(ROOT)))
```

JS는 같은 패턴 (`path.resolve(__dirname, '..')`).

`validate-articles.py`가 이미 쓰던 패턴과 100% 일관.

## 검증

사본 working tree에서 **BLOG_CONTENT_REPO 없이 default ROOT만으로** 실행:

- ✅ `tools/generate-rss.js`: 439 items
- ✅ `tools/generate-sitemap.js`: 439 URLs (438 published)
- ✅ `tools/generate-llms-txt.py`: 14,678 bytes, 117 lines
- ✅ `tools/scan-files-index.py`: 정상 HTML 인덱싱
- ✅ `tools/scan-articles-meta.py --dry-run`: 453 articles loaded, 8 updated

## Test plan

머지 후:
- [ ] `update-sitemap.yml` workflow_dispatch 트리거 — 정상 실행 + sitemap/rss/llms.txt 정상 생성
- [ ] `scan-html-files.yml` workflow_dispatch 트리거 — tools/scan-files-index.py 정상 동작
- [ ] 다음 push에서 자동 트리거되는 워크플로우 success 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)