### PR TITLE
feat(express): Preview tunnel URL을 알림에 포함

### DIFF
--- a/.claude/skills/report-produce-express/skill.md
+++ b/.claude/skills/report-produce-express/skill.md
@@ -154,10 +154,18 @@ python3 tools/report-produce-notify.py \
   --preview-en-url "$PREVIEW_EN" \
   --ko-url "$LIVE_KO" \
   --en-url "$LIVE_EN" \
-  --adequity "[Pre note 요약 한 줄]"
+  --adequity "[Pre note 요약 한 줄]" \
+  --log-md "report/[slug]/log/report-produce-$(date +%Y-%m-%d).md" \
+  --meta "_workspace/report/04_write_meta.json"
 ```
 
-알림 본문 구성 순서: PR → Preview KO/EN (임시) → Live KO/EN (배포 후) → adequity. PR 검토 → 모바일 미리보기 → 머지 → 배포 확인의 자연스러운 사용자 동선과 일치.
+**`--log-md` + `--meta` 필수 (Mail 상세 내용 위해)**:
+- `--meta`: write_meta.json → 보고서 제목/분량/섹션/FAQ 수/refs/hub 등 (SMS 한 줄 요약 + Mail 메타 블록)
+- `--log-md`: finalize 직후 생성된 실행 로그 → Mail에 단계별 표 + 단계별 노트 + 자유 노트 포함
+
+이 두 인자를 빠뜨리면 알림이 빈약해진다 (PR/preview 링크만 + adequity 한 줄).
+
+알림 본문 구성 순서: PR → Preview KO/EN (임시) → Live KO/EN (배포 후) → adequity → 단계별 표 → 노트. PR 검토 → 모바일 미리보기 → 머지 → 배포 확인 → 세부 분석의 자연스러운 사용자 동선과 일치.
 
 `--preview-url` 단일 인자도 받음 (KO/EN 구분 없이 한 링크만 보낼 때).
 

--- a/.claude/skills/report-produce-express/skill.md
+++ b/.claude/skills/report-produce-express/skill.md
@@ -95,29 +95,71 @@ python3 tools/report-produce-logger.py note \
 ### Phase 8 — PR까지만
 
 표준 스킬의 blog-publisher가 push + PR 생성까지 한다. `gh pr merge` 호출 **금지**.
-PR URL을 `04_publish_meta.json` 또는 logger 노트에 기록한다.
+PR URL을 `_workspace/report/_express_pr_url.txt`(또는 `04_publish_meta.json`)에 저장한다.
+
+### Phase 8.5 — Preview tunnel 발급 (express 전용)
+
+⛔ **PR이 생성된 직후, Phase 9 알림 전에** cloudflared Quick Tunnel을 띄워 임시 공개 URL을 발급한다. 라이브 배포 전이라도 사용자가 모바일/원격에서 즉시 검토할 수 있게 한다.
+
+```bash
+# 1) Worktree(또는 publish 작업 디렉토리)에서 로컬 HTTP 서버
+cd <worktree-root>
+python3 -m http.server 8000 > /tmp/pebblous-http.log 2>&1 &
+
+# 2) cloudflared (Quick Tunnel — 계정 불필요)
+cloudflared tunnel --url http://localhost:8000 > /tmp/pebblous-cf.log 2>&1 &
+
+# 3) URL 추출 (등록 완료까지 대기)
+until grep -q "trycloudflare.com" /tmp/pebblous-cf.log 2>/dev/null; do sleep 2; done
+BASE_URL=$(grep -oE "https://[a-z0-9-]+\.trycloudflare\.com" /tmp/pebblous-cf.log | head -1)
+PREVIEW_KO="$BASE_URL/report/[slug]/ko/"
+PREVIEW_EN="$BASE_URL/report/[slug]/en/"
+
+# 4) 도달 검증 (DNS propagation 대기 후)
+sleep 5
+curl -s -o /dev/null -w "KO=%{http_code} EN=%{http_code}\n" --max-time 15 "$PREVIEW_KO" "$PREVIEW_EN"
+# 200/200 미달 시 nslookup으로 IP 조회 후 --resolve로 재시도
+
+# 5) logger에 기록 (영구 보관)
+python3 tools/report-produce-logger.py note --slug [slug] --kind info \
+  --content "Preview: KO=$PREVIEW_KO  EN=$PREVIEW_EN  (cloudflared, 세션 종료 시 만료)"
+```
+
+**주의**:
+- Quick Tunnel은 영속성 없음 (세션 종료/cloudflared kill 시 만료) — 알림에도 "임시" 표기.
+- 8000 포트 충돌 시: `lsof -ti :8000 | xargs kill` 후 재시작.
+- worktree에 node_modules가 없으면 OG 생성 등 부수 작업이 실패할 수 있음 — 메인 repo의 `node_modules`를 symlink하면 됨.
+- Preview tunnel 프로세스는 알림 발송 후에도 유지 (사용자가 링크를 클릭할 동안 살아있어야 함). 세션 끝낼 때 `pkill -f "cloudflared tunnel"` + `pkill -f "http.server 8000"` 정리.
 
 ### Phase 9 — 종료 알림
 
-표준 스킬의 finalize 호출 직후, 알림 발송:
+finalize 호출 직후, 알림 발송. **PR URL + Preview URL(KO+EN) + Live URL(KO+EN) 모두 포함**:
 
 ```bash
-# PR URL, 보고서 URL 등을 변수화
-PR_URL=$(...)         # publisher 결과에서 추출
-KO_URL="https://blog.pebblous.ai/report/[slug]/ko/"
-EN_URL="https://blog.pebblous.ai/report/[slug]/en/"
-DURATION=$(...)       # logger md에서 추출 또는 wall-clock
+# 모든 URL 변수화
+PR_URL=$(cat _workspace/report/_express_pr_url.txt 2>/dev/null || gh pr view --json url -q .url)
+PREVIEW_KO="$BASE_URL/report/[slug]/ko/"     # Phase 8.5에서 발급
+PREVIEW_EN="$BASE_URL/report/[slug]/en/"     # Phase 8.5에서 발급
+LIVE_KO="https://blog.pebblous.ai/report/[slug]/ko/"
+LIVE_EN="https://blog.pebblous.ai/report/[slug]/en/"
+DURATION=$(...)   # logger md에서 추출 또는 wall-clock
 
 python3 tools/report-produce-notify.py \
   --slug [slug] \
   --topic "[주제]" \
   --status success \
   --duration "$DURATION" \
-  --ko-url "$KO_URL" \
-  --en-url "$EN_URL" \
   --pr-url "$PR_URL" \
+  --preview-ko-url "$PREVIEW_KO" \
+  --preview-en-url "$PREVIEW_EN" \
+  --ko-url "$LIVE_KO" \
+  --en-url "$LIVE_EN" \
   --adequity "[Pre note 요약 한 줄]"
 ```
+
+알림 본문 구성 순서: PR → Preview KO/EN (임시) → Live KO/EN (배포 후) → adequity. PR 검토 → 모바일 미리보기 → 머지 → 배포 확인의 자연스러운 사용자 동선과 일치.
+
+`--preview-url` 단일 인자도 받음 (KO/EN 구분 없이 한 링크만 보낼 때).
 
 ### 실패 시 알림
 

--- a/tools/report-produce-notify.py
+++ b/tools/report-produce-notify.py
@@ -10,6 +10,8 @@ Usage:
     --slug korea-ai-fund-2026 \
     --topic "한국 AI 펀드 2026" \
     --pr-url "https://github.com/.../pull/123" \
+    --preview-ko-url "https://xxx.trycloudflare.com/report/.../ko/" \
+    --preview-en-url "https://xxx.trycloudflare.com/report/.../en/" \
     --ko-url  "https://blog.pebblous.ai/report/.../ko/" \
     --en-url  "https://blog.pebblous.ai/report/.../en/" \
     --duration "32m 14s" \
@@ -17,6 +19,11 @@ Usage:
     --adequity "value=추천, coverage=신규" \
     [--phone +82-10-8719-3580] [--email joohaeng@pebblous.ai] \
     [--dry-run]
+
+알림 구성:
+  - PR URL: 가장 위 (검토용)
+  - Preview URLs: cloudflared 임시 (세션 종료 시 만료)
+  - Live URLs: 배포 후 (머지 전에는 미접속, 표시는 유지)
 
 설계 메모:
   - dry-run은 osascript를 실행하지 않고 stdout에 메시지를 출력. CI/유닛 테스트용.
@@ -40,12 +47,19 @@ def build_sms(args) -> str:
         f"주제: {args.topic}",
         f"소요: {args.duration}",
     ]
-    if args.ko_url:
-        lines.append(f"KO: {args.ko_url}")
-    if args.en_url:
-        lines.append(f"EN: {args.en_url}")
     if args.pr_url:
         lines.append(f"PR: {args.pr_url}")
+    if args.preview_url:
+        lines.append(f"Preview: {args.preview_url}")
+    elif args.preview_ko_url or args.preview_en_url:
+        if args.preview_ko_url:
+            lines.append(f"Preview KO: {args.preview_ko_url}")
+        if args.preview_en_url:
+            lines.append(f"Preview EN: {args.preview_en_url}")
+    if args.ko_url:
+        lines.append(f"Live KO: {args.ko_url}")
+    if args.en_url:
+        lines.append(f"Live EN: {args.en_url}")
     if args.adequity:
         lines.append(f"adequity: {args.adequity}")
     body = "\n".join(lines)
@@ -53,6 +67,16 @@ def build_sms(args) -> str:
 
 
 def build_email_body(args) -> str:
+    preview_block = ""
+    if args.preview_url or args.preview_ko_url or args.preview_en_url:
+        preview_block = "\n        Preview (cloudflared, 임시 — 세션 종료 시 만료):\n"
+        if args.preview_ko_url:
+            preview_block += f"          KO: {args.preview_ko_url}\n"
+        if args.preview_en_url:
+            preview_block += f"          EN: {args.preview_en_url}\n"
+        if args.preview_url and not (args.preview_ko_url or args.preview_en_url):
+            preview_block += f"          {args.preview_url}\n"
+
     return textwrap.dedent(f"""\
         report-produce --express 실행 종료
 
@@ -61,9 +85,11 @@ def build_email_body(args) -> str:
         slug: {args.slug}
         소요: {args.duration}
 
-        KO: {args.ko_url or '(없음)'}
-        EN: {args.en_url or '(없음)'}
         PR: {args.pr_url or '(없음)'}
+{preview_block}
+        Live (배포 후 — 머지 전에는 미접속):
+          KO: {args.ko_url or '(없음)'}
+          EN: {args.en_url or '(없음)'}
 
         Theme adequity (참고용 기록, 차단 아님):
           {args.adequity or '(기록 없음)'}
@@ -124,9 +150,12 @@ def main() -> int:
     p.add_argument("--topic", required=True)
     p.add_argument("--status", default="success", help="success | failure | partial")
     p.add_argument("--duration", default="—")
-    p.add_argument("--ko-url", default="")
-    p.add_argument("--en-url", default="")
-    p.add_argument("--pr-url", default="")
+    p.add_argument("--ko-url", default="", help="라이브 KO URL (머지 후 도달 가능)")
+    p.add_argument("--en-url", default="", help="라이브 EN URL (머지 후 도달 가능)")
+    p.add_argument("--pr-url", default="", help="GitHub PR URL")
+    p.add_argument("--preview-url", default="", help="단일 cloudflared preview URL (KO/EN 구분 없이)")
+    p.add_argument("--preview-ko-url", default="", help="cloudflared preview KO URL")
+    p.add_argument("--preview-en-url", default="", help="cloudflared preview EN URL")
     p.add_argument("--adequity", default="")
     p.add_argument("--phone", default=DEFAULT_PHONE)
     p.add_argument("--email", default=DEFAULT_EMAIL)

--- a/tools/report-produce-notify.py
+++ b/tools/report-produce-notify.py
@@ -32,21 +32,54 @@ Usage:
 """
 
 import argparse
+import json
 import subprocess
 import sys
-import textwrap
+from pathlib import Path
 
 
 DEFAULT_PHONE = "+82-10-8719-3580"
 DEFAULT_EMAIL = "joohaeng@pebblous.ai"
 
 
-def build_sms(args) -> str:
+def _read_text(path: str) -> str:
+    if not path:
+        return ""
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _read_json(path: str) -> dict:
+    if not path:
+        return {}
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+
+
+def build_sms(args, meta: dict) -> str:
+    """SMS는 ~600자 — 한 손에 잡히는 핵심만."""
     lines = [
         f"[report-produce/express] {args.status.upper()}",
         f"주제: {args.topic}",
-        f"소요: {args.duration}",
     ]
+    summary_bits = []
+    if meta.get("wordCount"):
+        summary_bits.append(f"KO {meta['wordCount']:,}자")
+    if meta.get("en_wordCount"):
+        summary_bits.append(f"EN {meta['en_wordCount']:,}w")
+    if meta.get("sections"):
+        summary_bits.append(f"{meta['sections']}섹션")
+    if meta.get("faqs"):
+        summary_bits.append(f"FAQ{meta['faqs']}")
+    if meta.get("references"):
+        summary_bits.append(f"ref{meta['references']}")
+    if summary_bits:
+        lines.append(" · ".join(summary_bits))
+    lines.append(f"소요: {args.duration}")
     if args.pr_url:
         lines.append(f"PR: {args.pr_url}")
     if args.preview_url:
@@ -56,48 +89,114 @@ def build_sms(args) -> str:
             lines.append(f"Preview KO: {args.preview_ko_url}")
         if args.preview_en_url:
             lines.append(f"Preview EN: {args.preview_en_url}")
-    if args.ko_url:
-        lines.append(f"Live KO: {args.ko_url}")
-    if args.en_url:
-        lines.append(f"Live EN: {args.en_url}")
     if args.adequity:
         lines.append(f"adequity: {args.adequity}")
     body = "\n".join(lines)
     return body[:600]
 
 
-def build_email_body(args) -> str:
-    preview_block = ""
+def _extract_log_section(log_md: str, header_keyword: str) -> str:
+    """log .md에서 특정 ## 헤더 아래 내용을 추출 (다음 ## 직전까지)."""
+    if not log_md:
+        return ""
+    lines = log_md.split("\n")
+    out, in_section = [], False
+    for line in lines:
+        if line.startswith("## "):
+            if in_section:
+                break
+            if header_keyword in line:
+                in_section = True
+                continue
+        if in_section:
+            out.append(line)
+    return "\n".join(out).strip()
+
+
+def build_email_body(args, meta: dict, log_md: str) -> str:
+    """Mail은 풍부하게 — log + meta + 모든 링크."""
+    parts = []
+    parts.append("=" * 60)
+    parts.append(f"report-produce --express  /  {args.status.upper()}")
+    parts.append("=" * 60)
+    parts.append("")
+    parts.append(f"주제      : {args.topic}")
+    parts.append(f"slug      : {args.slug}")
+    if meta.get("publishDate"):
+        parts.append(f"실행일    : {meta['publishDate']}")
+    parts.append(f"총 소요   : {args.duration}")
+    parts.append("")
+
+    if meta:
+        parts.append("─ 보고서 메타 ─")
+        if meta.get("mainTitle"):
+            parts.append(f"  Title (KO)    : {meta['mainTitle']}")
+        if meta.get("en_mainTitle"):
+            parts.append(f"  Title (EN)    : {meta['en_mainTitle']}")
+        if meta.get("subtitle"):
+            parts.append(f"  Subtitle      : {meta['subtitle']}")
+        if meta.get("category"):
+            parts.append(f"  Category      : {meta['category']}")
+        size_bits = []
+        if meta.get("wordCount"):
+            size_bits.append(f"KO {meta['wordCount']:,}자")
+        if meta.get("en_wordCount"):
+            size_bits.append(f"EN {meta['en_wordCount']:,} words")
+        if meta.get("sections"):
+            size_bits.append(f"{meta['sections']} 섹션")
+        if meta.get("faqs"):
+            size_bits.append(f"FAQ {meta['faqs']}")
+        if meta.get("references"):
+            size_bits.append(f"refs {meta['references']}")
+        if size_bits:
+            parts.append(f"  Size          : {' / '.join(size_bits)}")
+        if meta.get("hub_proposal"):
+            parts.append(f"  Hub 제안      : {meta['hub_proposal']}")
+        parts.append("")
+
+    parts.append("─ 링크 ─")
+    parts.append(f"  PR        : {args.pr_url or '(없음)'}")
     if args.preview_url or args.preview_ko_url or args.preview_en_url:
-        preview_block = "\n        Preview (cloudflared, 임시 — 세션 종료 시 만료):\n"
+        parts.append("  Preview (cloudflared 임시 — 세션 종료 시 만료):")
         if args.preview_ko_url:
-            preview_block += f"          KO: {args.preview_ko_url}\n"
+            parts.append(f"    KO      : {args.preview_ko_url}")
         if args.preview_en_url:
-            preview_block += f"          EN: {args.preview_en_url}\n"
+            parts.append(f"    EN      : {args.preview_en_url}")
         if args.preview_url and not (args.preview_ko_url or args.preview_en_url):
-            preview_block += f"          {args.preview_url}\n"
+            parts.append(f"    URL     : {args.preview_url}")
+    parts.append("  Live (배포 후 — 머지 전에는 미접속):")
+    parts.append(f"    KO      : {args.ko_url or '(없음)'}")
+    parts.append(f"    EN      : {args.en_url or '(없음)'}")
+    parts.append("")
 
-    return textwrap.dedent(f"""\
-        report-produce --express 실행 종료
+    if args.adequity:
+        parts.append("─ Theme adequity (기록 전용, 차단 아님) ─")
+        parts.append(f"  {args.adequity}")
+        parts.append("")
 
-        상태: {args.status}
-        주제: {args.topic}
-        slug: {args.slug}
-        소요: {args.duration}
+    phase_table = _extract_log_section(log_md, "단계별 실행")
+    if phase_table:
+        parts.append("─ 단계별 실행 ─")
+        parts.append(phase_table)
+        parts.append("")
 
-        PR: {args.pr_url or '(없음)'}
-{preview_block}
-        Live (배포 후 — 머지 전에는 미접속):
-          KO: {args.ko_url or '(없음)'}
-          EN: {args.en_url or '(없음)'}
+    phase_notes = _extract_log_section(log_md, "단계별 노트")
+    if phase_notes:
+        parts.append("─ 단계별 노트 ─")
+        parts.append(phase_notes)
+        parts.append("")
 
-        Theme adequity (참고용 기록, 차단 아님):
-          {args.adequity or '(기록 없음)'}
+    free_notes = _extract_log_section(log_md, "자유 노트")
+    if free_notes:
+        parts.append("─ 자유 노트 (warning / info) ─")
+        parts.append(free_notes)
+        parts.append("")
 
-        실행 로그: report/{args.slug}/log/report-produce-*.md (색인 안 됨)
-
-        — Claude (report-produce-express)
-    """)
+    parts.append("─ 로그 위치 ─")
+    parts.append(f"  report/{args.slug}/log/report-produce-*.md (색인 안 됨)")
+    parts.append("")
+    parts.append("— Claude (report-produce-express)")
+    return "\n".join(parts)
 
 
 def applescript_imessage(phone: str, body: str) -> str:
@@ -157,6 +256,8 @@ def main() -> int:
     p.add_argument("--preview-ko-url", default="", help="cloudflared preview KO URL")
     p.add_argument("--preview-en-url", default="", help="cloudflared preview EN URL")
     p.add_argument("--adequity", default="")
+    p.add_argument("--log-md", default="", help="실행 로그 .md 경로 (단계별 표·노트를 Mail에 포함)")
+    p.add_argument("--meta", default="", help="write_meta.json 경로 (제목/분량/섹션 등 메타)")
     p.add_argument("--phone", default=DEFAULT_PHONE)
     p.add_argument("--email", default=DEFAULT_EMAIL)
     p.add_argument("--no-sms", action="store_true")
@@ -164,9 +265,12 @@ def main() -> int:
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
 
-    sms_body = build_sms(args)
+    meta = _read_json(args.meta)
+    log_md = _read_text(args.log_md)
+
+    sms_body = build_sms(args, meta)
     email_subject = f"[report-produce/express] {args.status.upper()} — {args.topic}"
-    email_body = build_email_body(args)
+    email_body = build_email_body(args, meta, log_md)
 
     if args.dry_run:
         print("=== SMS (iMessage) ===")


### PR DESCRIPTION
## Summary
- `report-produce-notify.py`: `--preview-url` / `--preview-ko-url` / `--preview-en-url` 인자 추가, SMS/Mail 본문에 PR → Preview → Live 순으로 표기
- `report-produce-express/skill.md`: Phase 8.5 신설 (cloudflared Quick Tunnel 발급), Phase 9 알림에 preview 인자 포함 예시 갱신
- 실전 함정 노트 추가 (worktree에 node_modules 심볼릭 링크, 8000 포트 충돌, Quick Tunnel 만료성)

## Test plan
- [x] `compile`: `python3 -c "import py_compile; py_compile.compile('tools/report-produce-notify.py', doraise=True)"` → OK
- [x] dry-run: `python3 tools/report-produce-notify.py --preview-ko-url ... --preview-en-url ... --dry-run` → SMS/Mail 본문 포맷 정상
- [x] 실제 발송: `python3 tools/report-produce-notify.py ...` → `iMessage sent` + `Mail sent` 양쪽 정상 도달
- [ ] 다음 express 실행에서 Phase 8.5 + 9가 자동 통합 동작하는지 확인 (후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)