### PR TITLE
chore(skill): report-produce에 bibliography 단계 정식 편입 + 5-B/5-C/5-D skip 정책 강화

### DIFF
--- a/.claude/skills/report-produce-express/skill.md
+++ b/.claude/skills/report-produce-express/skill.md
@@ -94,6 +94,19 @@ python3 tools/report-produce-logger.py note \
   --content "Phase 4.5 자동 진행 — JH 리뷰 생략 (express)"
 ```
 
+### Phase 5 분기 — Skip 정책 강화 (express에서 특히 중요)
+
+JH가 없는 무인 모드이므로 5-B/5-C/5-D를 자의적 판단으로 skip하는 사고가 자주 났다 (예: ICLR run에서 "본문 충분히 풍부함"으로 5-B/5-C 둘 다 skip → image-reinforce/bibliography 누락). 베이스 스킬의 객관 skip 기준을 그대로 따르되 express에서는 다음을 추가:
+
+| 서브단계 | express에서의 호출 의무 |
+|---------|-----------------------|
+| 5-A | 항상 |
+| 5-B text-reinforce | 항상 호출. "충분히 풍부하다"는 표현 금지 — 호출 결과가 0개 보강이어도 호출은 한다 |
+| 5-C image-reinforce | 항상 호출 + 주제 매칭 우선 모드. 본문 이미지 < 4 이면 무조건 보강. 단순 추상 다이어그램으로만 채우면 미완료 |
+| 5-D bibliography | references ≥ 4면 무조건. references.json SSOT 생성 + BibTeX/RIS 버튼 + Scholar 메타 (KO+EN 양쪽). express의 거의 모든 보고서가 학술 인용 4개 이상이므로 사실상 항상 호출 |
+
+→ logger note에 skip 사유를 적을 때 "충분히 풍부하다 / 이미 잘 돼있다" 같은 주관어 사용 금지. 객관 조건 (`references<4`, `images>=4 with topic match`) 만 인용.
+
 ### Phase 8 — PR까지만
 
 표준 스킬의 blog-publisher가 push + PR 생성까지 한다. `gh pr merge` 호출 **금지**.

--- a/.claude/skills/report-produce/skill.md
+++ b/.claude/skills/report-produce/skill.md
@@ -116,6 +116,7 @@ python3 tools/report-produce-logger.py finalize \
         5-A: content + style review (자기검토, 위반 즉시 수정)
         5-B: text-reinforce (차트/표 앞 설명 문단 보강)
         5-C: image-reinforce (맥락 이미지 추가)
+        5-D: bibliography (references.json SSOT + BibTeX/RIS + Scholar 메타)
         ↓
 [Phase 6] 영문화 (단순 번역 금지, 영미권 문화 고려 재작성)
         → report/[slug]/en/index.html
@@ -435,7 +436,17 @@ python3 tools/report-produce-logger.py end --slug [slug] --phase 4 --agent repor
 
 ### Phase 5: 품질 검증 + 보강
 
-Phase 4.5 승인 후, 퍼블리싱 전에 반드시 아래 3단계를 실행한다. 각 서브단계별로 logger start/end를 호출 (5-A는 self-review, 5-B/C는 스킬).
+Phase 4.5 승인 후, 퍼블리싱 전에 반드시 아래 **4단계(5-A ~ 5-D)** 를 실행한다. 각 서브단계별로 logger start/end를 호출.
+
+⛔ **Skip 정책 (객관 기준 — 주관 판단 금지)**:
+| 서브단계 | 무조건 호출 | Skip 가능 조건 |
+|---------|-----------|---------------|
+| 5-A 자기검토 | ✅ 항상 | (skip 불가) |
+| 5-B text-reinforce | 항상 호출 | 결과적으로 보강할 곳이 0개여도 호출은 한다 |
+| 5-C image-reinforce | 항상 호출 | 본문 이미지가 4개 이상이고 핵심 주제 시각 자료가 포함된 경우만 skip 가능 — 그 외 일반론 / 본문 이미지 < 4 / 주제 매칭 부족 시 반드시 호출 |
+| 5-D bibliography | references 4개 이상이면 항상 호출 | references < 4면 skip 가능 |
+
+→ "본문이 충분히 풍부하니까", "이미 충분히 길어서" 같은 주관 판단으로 skip하지 말 것. 객관 조건만 사용.
 
 ```bash
 python3 tools/report-produce-logger.py start --slug [slug] --phase 5-A --agent self-review --model sonnet
@@ -446,7 +457,10 @@ python3 tools/report-produce-logger.py start --slug [slug] --phase 5-B --agent t
 python3 tools/report-produce-logger.py end --slug [slug] --phase 5-B --agent text-reinforce --status ok --notes "[보강 문단 수]"
 
 python3 tools/report-produce-logger.py start --slug [slug] --phase 5-C --agent image-reinforce --model haiku
-python3 tools/report-produce-logger.py end --slug [slug] --phase 5-C --agent image-reinforce --status ok --notes "[삽입 이미지 수]"
+python3 tools/report-produce-logger.py end --slug [slug] --phase 5-C --agent image-reinforce --status ok --notes "[삽입 이미지 수, 주제 매칭 여부]"
+
+python3 tools/report-produce-logger.py start --slug [slug] --phase 5-D --agent bibliography --model haiku
+python3 tools/report-produce-logger.py end --slug [slug] --phase 5-D --agent bibliography --status ok --notes "[references.json 항목 수]"
 ```
 
 #### 5-A: Content + Style Review (자기검토)
@@ -474,6 +488,38 @@ python3 tools/report-produce-logger.py end --slug [slug] --phase 5-C --agent ima
 # 스킬: .claude/skills/image-reinforce/SKILL.md
 # 본문 맥락에 맞는 이미지를 찾아 삽입 (CC 라이선스 또는 자체 생성)
 ```
+
+⛔ **주제 매칭 우선 모드**: 단순 추상 다이어그램(피드백 루프, 일반 아키텍처)만 채우지 말 것. 주제 고유 시각 자료를 우선 탐색:
+- 게임/제품 주제 → 실제 게임/제품 스크린샷 (CC, Wikimedia, 공식 press kit)
+- 학술 논문 인용 주제 → 원 논문의 figure (fair use 인용)
+- 인물 주제 → 공식 프로필 사진 (CC 또는 자체 촬영)
+- 사례/데이터 주제 → 해당 기관 공식 차트
+일반 추상 이미지로만 채우면 5-C 실행했어도 본 단계 미완료로 간주.
+
+#### 5-D: bibliography (신규 정식 편입 — 2026-05-24)
+
+```python
+# 스킬: .claude/skills/bibliography/SKILL.md
+# (1) references.json 생성 (CSL-JSON, SSOT) — report/[slug]/references.json
+# (2) HTML 참고문헌 섹션을 .reference-list 표준으로 렌더링
+#     - <span class="ref-num">N.</span><span class="ref-body">...</span>
+#     - 카테고리 분류 (학술 / 정책·통계 / 페블러스 인접) — 4건 이상이면 필수
+# (3) Download Citation 버튼 (BibTeX / RIS)
+#     - <button onclick="PebblousCitation.download('bibtex', '../references.json')">BibTeX</button>
+#     - <button onclick="PebblousCitation.download('ris', '../references.json')">RIS</button>
+# (4) </body> 직전: <script src="/scripts/citation-download.js?v=YYYYMMDD" defer></script>
+# (5) Google Scholar citation_* 메타 태그 (head)
+#     - citation_title, citation_author, citation_publication_date,
+#       citation_online_date, citation_journal_title, citation_language
+```
+
+⛔ **무조건 호출 조건**: Phase 2 리서치에서 학술 논문·정책 문서·보고서 인용이 4개 이상이면 무조건 5-D 호출. Phase 4 writer가 본문에 inline `<a href>`만 박은 상태라도 5-D에서 references.json SSOT를 만들고 다운로드 인프라를 추가해야 함.
+
+검증 grep (Phase 5-D 종료 직전):
+- `python3 -c "import json; print(len(json.load(open('report/[slug]/references.json'))))"` ≥ 4
+- `grep -c "PebblousCitation.download" report/[slug]/{ko,en}/index.html` → 각 2 (BibTeX + RIS)
+- `grep -c "citation-download.js" report/[slug]/{ko,en}/index.html` → 각 1
+- `grep -c 'name="citation_title"' report/[slug]/{ko,en}/index.html` → 각 1
 
 ---
 


### PR DESCRIPTION
## Summary

### 문제 (실제 발생)
- `report-produce/skill.md`에 **bibliography 호출 절차가 누락**된 상태 → ICLR/Voyager 두 보고서 모두 references.json 없이 머지됨 (BibTeX/RIS 다운로드 불가, Scholar 메타 부재). PR #201로 ICLR retroactive 적용은 완료, Voyager는 다음 PR 예정.
- `report-produce-express` 무인 모드에서 \"본문 충분히 풍부하다\"는 주관 판단으로 5-B/5-C를 임의 skip하는 사고 반복.
- image-reinforce는 호출돼도 주제 매칭 부족(Voyager: Minecraft인데 추상 다이어그램 4장).

### 수정
1. **report-produce/skill.md**
   - Phase 5에 **5-D bibliography 정식 편입**
   - 5-B/5-C/5-D **Skip 정책 표** 신설 (객관 조건만)
   - 5-C **주제 매칭 우선 모드** 명문화
   - 5-D 절차 명시: references.json / .reference-list / BibTeX·RIS / citation-download.js / Scholar 메타 + 사후 grep 검증
   - Data flow diagram 갱신

2. **report-produce-express/skill.md**
   - Phase 5 분기 절 신설: 무인 모드에서 자의적 skip 방지
   - 호출 의무 표: 5-B/5-C 항상, 5-D는 references>=4일 때 무조건
   - logger note 주관어 사용 금지

## Test plan
- [x] 두 skill md compile (markdown valid)
- [x] 변경 라인: report-produce +50/-2, express +13/-0
- [ ] 다음 express run에서 5-D bibliography 자동 호출 확인 (다음 새 보고서 작성 때 검증)
- [ ] Voyager retroactive bibliography PR (별도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)