### PR TITLE
auto-sync: 진본 blog-service@a1a0cf3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,48 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Pebblous Blog (`blog.pebblous.ai`) — a static site on GitHub Pages for Pebblous Inc., covering AI-Ready Data, Physical AI, and Data Quality topics. Built with vanilla JavaScript + TailwindCSS (build, not CDN).
 
+## 🌐 진본/사본 모델 — 자산 2/3은 진본 우선
+
+본 레포(`joohaeng-pbls/blog-service`)는 자산 2(메서드론)·자산 3(도구)의 **진본(source of truth)**. 사본(`pebblous/pebblous.github.io`)은 GitHub Pages가 호스팅하는 라이브 사이트 + 자산 2/3 미러.
+
+### 자산 분류
+
+| 자산 | 내용 | 진본 | 사본 |
+|---|---|---|---|
+| 1 | 콘텐츠 (HTML 글, 이미지, articles.json 등) | (없음) | source of truth — GitHub Pages 호스팅 |
+| 2 | 메서드론 (`.claude/skills/`, `.claude/agents/`, `CLAUDE.md`, `docs/`) | **source of truth** | 자동 미러 |
+| 3 | 도구 (`tools/` — 빌드/배포 스크립트, OG 생성, RSS·sitemap·인덱싱) | **source of truth** | 자동 미러 |
+
+### ⛔ 정책 — 자산 2/3은 진본에서만 수정
+
+**사본의 `tools/`, `.claude/skills/`, `.claude/agents/`, `CLAUDE.md`, `docs/` 파일을 직접 수정 금지.**
+
+이유: 사본에서 직접 수정하면 **reverse-divergence** 발생. 다음 자동 sync 시:
+- 진본 버전이 사본을 덮어쓰면 → 사본 변경 손실
+- 손실 막으려면 명시적 reverse-sync PR 작성 → 매번 수동 정리 부담
+
+예외: 콘텐츠 작업(자산 1: 블로그 글, articles.json, image 등)은 사본에서 직접 — 진본엔 콘텐츠 없음.
+
+### 자동 동기화
+
+진본 main에 자산 2/3 변경 push → [`sync-to-sabon.yml`](.github/workflows/sync-to-sabon.yml) 자동 트리거 → 사본에 `auto-sync: 진본 blog-service@<sha>` PR 자동 생성 → 사람이 검토 후 머지.
+
+상세: [`docs/blog-service/sync.md`](docs/blog-service/sync.md)
+
+### Reverse-divergence 발생 시 (이미 사본에서 수정된 변경이 있다면)
+
+1. 자동 sync PR이 그 변경을 덮어쓰려 함 (보수적 모드라 삭제는 안 하지만 덮어쓰기는 함)
+2. 그런 PR은 머지 보류
+3. 사본의 변경을 명시적으로 진본에 reverse-sync (PR로 — 사본 → 진본 수동)
+4. 그 후 자동 sync 재트리거 → 깨끗한 새 PR → 머지
+5. (사례: 2026-05-24 PR #6 — 사본 PR #188의 `report-produce/skill.md` 변경을 진본에 reverse-sync)
+
+### 관련 문서
+
+- [`docs/blog-service/decision-log.md`](docs/blog-service/decision-log.md) — 진본/사본 분리 결정 (2026-05-22)
+- [`docs/blog-service/architecture.md`](docs/blog-service/architecture.md) — 3-자산 분리 비전
+- [`docs/blog-service/sync.md`](docs/blog-service/sync.md) — 자동 동기화 워크플로우 + 트러블슈팅
+
 ## ⛔ Branch Policy — 새 작업 시작 시 반드시 확인
 
 여러 Claude 창이 병렬로 작업 중인 환경이다. 위험을 피하려면:

--- a/docs/blog-service/openapi.yaml
+++ b/docs/blog-service/openapi.yaml
@@ -2,16 +2,42 @@ openapi: 3.1.0
 
 info:
   title: Pebblous Blog Service API
-  version: 0.1.0-draft
+  version: 0.2.0-draft
   description: |
-    HTTP API for executing the Pebblous blog repo's content pipelines (blog/report/dc-story)
-    and managing pipeline runs with async approval gates.
+    HTTP API for executing Pebblous blog content pipelines with async approval gates.
+    Shares the same underlying Pipeline Engine with the MCP server (`mcp-tools.md`).
 
-    This API and the MCP server (`mcp-tools.md`) share the same underlying Pipeline Engine.
-    See `architecture.md` for the system design and `decision-log.md` for major decisions.
+    ## Architecture (진본/사본 모델)
 
-    **Status:** Draft — derived from `docs/nanoclaw/blog-mcp-stdio.ts` (the existing MCP implementation
-    inside NanoClaw). The 9 MCP tools map 1:1 to REST endpoints below.
+    - **자산 1 (콘텐츠)**: `pebblous/pebblous.github.io` (사본) — live site `blog.pebblous.ai`
+    - **자산 2/3 (메서드론 + 도구)**: `joohaeng-pbls/blog-service` (진본) — source of truth
+      - 자산 2: skills (`.claude/skills/`), agents (`.claude/agents/`), policies, docs
+      - 자산 3: Pipeline Engine + this HTTP API + MCP server
+
+    See:
+    - `architecture.md` — 3-asset separation vision
+    - `decision-log.md` — major decisions (B/C/Phase 1+)
+    - `sync.md` — 진본↔사본 auto-sync workflow
+
+    ## Current State (2026-05-24)
+
+    - 9 endpoints below 1:1-map to MCP tools in `docs/nanoclaw/blog-mcp-stdio.ts`
+    - Pipeline Engine 위치: 현재 NanoClaw 컨테이너 내부 (stdio MCP만 노출)
+    - **Phase 1 작업**: Engine을 NanoClaw에서 추출 → 진본 자산 3로 이전 → HTTP transport 추가 (본 스펙 구현)
+    - Pipeline type 6종 (스펙) — 그중 3종이 NanoClaw에 구현됨 (blog/report/dc-story)
+
+    ## Pipeline Types (6종)
+
+    각 type은 진본 `.claude/skills/` 의 같은 이름 스킬에 매핑:
+
+    | API type | 진본 스킬 | NanoClaw 구현 |
+    |---|---|---|
+    | `blog` | `blog-produce` | ✅ |
+    | `report` | `report-produce` | ✅ |
+    | `dc-story` | `dc-story-produce` | ✅ |
+    | `pebblopedia` | `pebblopedia-produce` | ⏳ Phase 1 추가 |
+    | `pb-story` | `pb-story-produce` | ⏳ Phase 1 추가 |
+    | `biz-report` | `biz-produce` | ⏳ Phase 1 추가 |
 
   contact:
     name: Pebblous
@@ -458,10 +484,21 @@ components:
 
     PipelineType:
       type: string
-      enum: [blog, report, dc-story]
+      enum: [blog, report, dc-story, pebblopedia, pb-story, biz-report]
       description: |
-        Pipeline templates defined in `blog-mcp-stdio.ts` PIPELINES constant.
-        `pebblopedia` is reserved for future use.
+        Pipeline templates. 각 type은 진본 `.claude/skills/`의 같은 이름 스킬에 매핑:
+
+        | type | 진본 스킬 | NanoClaw 구현 |
+        |---|---|---|
+        | `blog` | `blog-produce` | ✅ |
+        | `report` | `report-produce` | ✅ |
+        | `dc-story` | `dc-story-produce` | ✅ |
+        | `pebblopedia` | `pebblopedia-produce` | ⏳ Phase 1 추가 |
+        | `pb-story` | `pb-story-produce` | ⏳ Phase 1 추가 |
+        | `biz-report` | `biz-produce` | ⏳ Phase 1 추가 |
+
+        현재 `blog-mcp-stdio.ts` PIPELINES에는 blog/report/dc-story 3종 구현.
+        나머지 3종은 자산 3 분리 시 Engine을 일반화해서 6종 모두 지원 예정.
 
     Model:
       type: string


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@a1a0cf3

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
