### PR TITLE
chore(codeowners): 자산 2/3 경로 보호 — 진본/사본 모델 안전장치

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS — pebblous/pebblous.github.io (사본)
+#
+# 진본/사본 모델: 자산 2/3은 진본(joohaeng-pbls/blog-service)이 source of truth.
+# 사본의 자산 2/3 경로 변경 PR은 본인(@joohaeng-pbls) 리뷰 필수.
+#
+# 목적: reverse-divergence 사전 차단.
+# - 다른 세션이 사본 자산 2/3을 직접 수정하는 패턴(PR #188, commit 62fded3d 등)을 방지
+# - 정상 흐름: 진본 PR → 자동 sync → 사본 auto-sync PR → 머지 (auto-sync 봇은 본 규칙 영향 받지 않음, 본인이 리뷰)
+#
+# 참고:
+# - 자산 분류 정책: CLAUDE.md "🌐 진본/사본 모델" 섹션
+# - 자동 sync 워크플로우: docs/blog-service/sync.md
+# - 우선순위는 위에서 아래로 — 마지막 매칭 규칙이 적용됨
+#
+# 강제 차단을 원하면 Settings → Branches → main → Branch protection rule에서
+# "Require review from Code Owners" 활성화 필요.
+
+# 자산 2 — 메서드론·정책·문서 (진본 source of truth)
+/.claude/skills/                @joohaeng-pbls
+/.claude/agents/                @joohaeng-pbls
+/CLAUDE.md                      @joohaeng-pbls
+/docs/                          @joohaeng-pbls
+
+# 자산 3 — 빌드/배포 도구 (진본 source of truth)
+/tools/                         @joohaeng-pbls
+
+# 자동 sync 워크플로우 (진본에서 정의, 본 레포의 .github/는 사본 측 정책 영역이라 미적용)
+# .github/workflows/sync-to-sabon.yml은 진본 측 워크플로우라 본 레포에 없음.
+# 본 레포의 .github/workflows/는 사본 정책(update-sitemap, scan-html-files 등) — owner 별도 지정 안 함.


### PR DESCRIPTION
## Summary

진본/사본 모델의 **첫 번째 안전장치**. 사본의 자산 2/3 경로(`tools/`, `.claude/skills/`, `.claude/agents/`, `CLAUDE.md`, `docs/`) 변경 PR에 본인(`@joohaeng-pbls`) 리뷰를 자동 요구.

## 배경

이번 세션에서 reverse-divergence가 **두 번** 발생 (사본 PR #188, commit 62fded3d → 진본 PR #6, #9로 reverse-sync). CLAUDE.md 정책만으론 부족 — PR 단계에서 신호·차단 필요.

## 변경

`.github/CODEOWNERS` 생성 (29 lines). 자산 2/3 경로별 owner = `@joohaeng-pbls`.

## 효과

**기본 (본 PR 머지만으로)**: 자산 2/3 변경 PR에 본인 reviewer 자동 추가 + 알림.

**강제 차단 (추가 설정)**: Settings → Branches → main → Branch protection rule → "Require review from Code Owners" 활성화 시 본인 승인 없으면 머지 불가.

## 정상 흐름 영향 없음

- 진본 → 자동 sync → 사본 auto-sync PR: 본인 검토 후 머지 그대로
- 콘텐츠 PR (자산 1): 영향 없음

## 관련

- CLAUDE.md "🌐 진본/사본 모델" (PR #211)
- docs/blog-service/sync.md
- 진본 PR #10 (decision-log B+C단계 완료 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)