### PR TITLE
test(e2e): Blog Service 진본 환경 end-to-end 검증 placeholder (DO NOT MERGE)

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -23,6 +23,23 @@
   },
   "articles": [
     {
+      "id": "blog-service-e2e-test-ko",
+      "title": "Blog Service E2E 검증 placeholder",
+      "path": "pebblopedia/blog-service-e2e-test/",
+      "date": "2026-05-24",
+      "category": "tech",
+      "published": false,
+      "description": "진본/사본 모델 end-to-end 검증용 placeholder.",
+      "language": "ko",
+      "tags": [
+        "test",
+        "blog-service",
+        "e2e"
+      ],
+      "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
+      "wordCount": 46
+    },
+    {
       "id": "iclr-2026-ai-peer-review-crisis-ko",
       "title": "AI가 AI를 심사한다 — ICLR 2026, 리뷰 76,139편의 21%가 AI였다",
       "path": "report/iclr-2026-ai-peer-review-crisis/ko/",
@@ -43,7 +60,7 @@
         "학술 출판"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 15333,
+      "wordCount": 15290,
       "modified": "2026-05-24"
     },
     {
@@ -67,7 +84,7 @@
         "academic publishing"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 5529,
+      "wordCount": 32538,
       "modified": "2026-05-24"
     },
     {
@@ -92,7 +109,7 @@
         "DataClinic"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 7200,
+      "wordCount": 18950,
       "modified": "2026-05-24"
     },
     {
@@ -117,7 +134,7 @@
         "DataClinic"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 8400,
+      "wordCount": 10779,
       "modified": "2026-05-24"
     },
     {
@@ -139,7 +156,7 @@
         "유타 HB 276"
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
-      "wordCount": 17881,
+      "wordCount": 14350,
       "modified": "2026-05-23"
     },
     {
@@ -161,7 +178,7 @@
         "Utah HB 276"
       ],
       "publisher": "Pebblous Data Communication Team",
-      "wordCount": 6020,
+      "wordCount": 33477,
       "modified": "2026-05-23"
     },
     {
@@ -297,7 +314,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 15924,
-      "modified": "2026-05-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "nvidia-virtual-cell-challenge-2026-05-en",
@@ -324,7 +341,7 @@
       ],
       "publisher": "Pebblous Inc. Data Communications Team",
       "wordCount": 25402,
-      "modified": "2026-05-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "korea-digital-asset-basic-law-2026-ko",
@@ -1055,7 +1072,7 @@
       "language": "ko",
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 11724,
-      "modified": "2026-04-14"
+      "modified": "2026-05-22"
     },
     {
       "id": "kronos-financial-foundation-model-en",
@@ -1080,7 +1097,7 @@
       "language": "en",
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 23412,
-      "modified": "2026-05-02"
+      "modified": "2026-05-22"
     },
     {
       "id": "claude-mythos-preview-ko",
@@ -1566,7 +1583,7 @@
       ],
       "publisher": "(주)페블러스 데이터 커뮤니케이션팀",
       "wordCount": 6067,
-      "modified": "2026-04-12"
+      "modified": "2026-05-22"
     },
     {
       "id": "ngogo-chimp-network-ai-pb-en",
@@ -1593,7 +1610,7 @@
       ],
       "publisher": "Pebblous Data Communication Team",
       "wordCount": 12199,
-      "modified": "2026-04-12"
+      "modified": "2026-05-22"
     },
     {
       "id": "data-value-proof-ko",
@@ -12892,7 +12909,7 @@
         "Vite",
         "TypeScript"
       ],
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "frontend-vibe-coders-en",
@@ -12916,7 +12933,7 @@
         "Vite",
         "TypeScript"
       ],
-      "modified": "2026-04-26"
+      "modified": "2026-05-22"
     },
     {
       "id": "nemotron-personas-korea-ko",

--- a/pebblopedia/blog-service-e2e-test/index.html
+++ b/pebblopedia/blog-service-e2e-test/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>E2E 검증 placeholder | 페블러스</title>
+    <meta name="description" content="진본/사본 모델 end-to-end 검증용 placeholder 페이지. 머지 안 됨.">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://blog.pebblous.ai/pebblopedia/blog-service-e2e-test/">
+    <link rel="stylesheet" href="/css/theme-variables.css?v=20260524">
+    <link rel="stylesheet" href="/styles/tailwind-build.css?v=20260524">
+    <link rel="stylesheet" href="/styles/common-styles.css?v=20260524">
+</head>
+<body class="antialiased themeable-bg">
+    <header id="header"></header>
+    <main class="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8">
+        <section class="fade-in-card mb-16">
+            <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
+            <p class="themeable-text">진본/사본 모델 end-to-end 검증용 placeholder. 이 페이지는 머지되지 않습니다.</p>
+        </section>
+    </main>
+    <footer id="footer"></footer>
+    <script src="/scripts/common-utils.js?v=20260524" defer></script>
+    <script>
+        PebblousPage.init({
+            mainTitle: "Blog Service E2E 검증",
+            subtitle: "진본/사본 모델 placeholder",
+            pageTitle: "E2E 검증 placeholder | 페블러스",
+            category: "tech",
+            publishDate: "2026-05-24",
+            publisher: "(주)페블러스 데이터 커뮤니케이션팀",
+            defaultTheme: "light",
+            articlePath: "pebblopedia/blog-service-e2e-test/index.html",
+            tags: ["test", "blog-service", "e2e"],
+            faqs: []
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## ⚠️ 검증 목적 — 머지하지 마세요

decision-log B단계 1차 마일스톤의 **진짜 검증** PR. 진본(`joohaeng-pbls/blog-service`) 환경에서 외부 콘텐츠(BLOG_CONTENT_REPO=사본 clone) 가리키며 도구 시퀀스 실행 + 사본 PR 흐름까지 정상 작동하는지 확인.

## 검증 시나리오 통과 결과

| 단계 | 도구 | 결과 |
|---|---|---|
| 1 | `validate-articles.py` (외부) | placeholder 정상 인식 |
| 2 | `scan-articles-meta.py` (외부) | 15 articles 갱신 (460 total) |
| 3 | `scan-files-index.py` (외부) | 정상 HTML 스캔 |
| 4 | `generate-rss.js` (외부) | 445 items |
| 5 | `generate-sitemap.js` (외부) | 444 published |
| 6 | `generate-llms-txt.py` (외부) | 14,856 bytes / 117 lines |
| 7 | git push to sabon | ✅ 성공 |
| 8 | gh pr create | ✅ 본 PR |

## 검증되는 것

- 자산 2/3 코드(진본)가 BLOG_CONTENT_REPO로 외부 콘텐츠 디렉토리(사본)를 정확히 가리키며 동작
- 새 글 작성 시 사본의 정확한 경로에 파일 생성 (`pebblopedia/blog-service-e2e-test/`)
- `articles.json` 등록 + metadata 자동 추출 정상
- 인덱스 파일(`rss.xml`, `sitemap.xml`, `llms.txt`, `files-index.json`) 정상 생성
- 사본 워크플로우와 호환 (PR 생성됨)

## 안전 장치 (혹시 잘못 머지돼도)

- `published: false` → init.js published 필터로 사이트 인덱스에 표시 안 됨
- `<meta name="robots" content="noindex, nofollow">` → 검색엔진 차단

## 처리 흐름

1. CI 결과 확인 (사본의 scan-html-files, validate-articles 등)
2. diff 검토
3. **PR close** (머지 안 함)
4. cleanup (~/Downloads/pebblous-verify-skill 삭제)

본 검증으로 decision-log B단계 1차 마일스톤 "blog-service 환경에서 새 글 작성 PR이 정상 동작" **완전 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)