### PR TITLE
fix(report): §9 attribution, Vatican URLs, internal links — pope-magnifica-humanitas

### DIFF
--- a/report/pope-magnifica-humanitas/en/index.html
+++ b/report/pope-magnifica-humanitas/en/index.html
@@ -208,8 +208,8 @@
                                     <div class="text-xs font-semibold mb-4 tracking-wider" style="color: #1E50B4;">MAGNIFICA HUMANITAS · 2026 · LEO XIV</div>
                                     <div class="text-sm themeable-text leading-relaxed space-y-5">
                                         <div>
-                                            <p class="text-xs themeable-muted font-medium mb-1">§6 — Technology Is Never Neutral</p>
-                                            <p class="italic">"Technology is never neutral — it reflects the character of those who design it, finance it, regulate it, and use it. Artificial intelligence, like every other technological advance, is not exempt from this reality."</p>
+                                            <p class="text-xs themeable-muted font-medium mb-1">§9 — Technology Is Never Neutral</p>
+                                            <p class="italic">"In practice, however, technology is never neutral, because it takes on the characteristics of those who devise, finance, regulate and use it." <span class="not-italic text-xs themeable-muted">(§9)</span></p>
                                         </div>
                                         <div>
                                             <p class="text-xs themeable-muted font-medium mb-1">§67 — Universal Destination of Data</p>
@@ -237,9 +237,9 @@
                         Distilled into concrete demands the tech industry cannot ignore, the encyclical's 245 paragraphs compress into five core declarations. Each challenges a foundational premise of the AI industry.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">Declaration 1: "Technology Is Never Neutral" (§6)</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">Declaration 1: "Technology Is Never Neutral" (§9)</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Section 6 states clearly: <strong>"Technology is never neutral — it reflects the character of those who design, fund, regulate, and use it."</strong> This is a direct refutation of the industry's standard line that "AI is just a tool; users are responsible." The 362 AI safety incidents of 2025 (+55.4% year over year, Stanford HAI AI Index 2026) serve as empirical grounding for this declaration.
+                        Paragraph 9 states directly: <strong>"In practice, however, technology is never neutral, because it takes on the characteristics of those who devise, finance, regulate and use it."</strong> This is a direct refutation of the industry's standard line that "AI is just a tool; users are responsible." The 362 AI safety incidents of 2025 (+55.4% year over year, Stanford HAI AI Index 2026) serve as empirical grounding for this declaration.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4">Declaration 2: Solidarity Elevated to "Principle and Virtue" (§73)</h3>
@@ -410,6 +410,33 @@
                     </div>
                 </section>
 
+                <!-- Related Content -->
+                <section class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">More from Pebblous</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <a href="/report/ai-psychosis-agentic-governance-2026-05/en/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">Report · AI Governance</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">When AI Is Wrong and No One Speaks Up</div>
+                            <div class="text-xs themeable-muted mt-2">The agentic AI governance gap — and who bears responsibility</div>
+                        </a>
+                        <a href="/story/palantir-technological-republic/en/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">Story · Technology &amp; Neutrality</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">Technology Is Never Neutral — Palantir's Technological Republic</div>
+                            <div class="text-xs themeable-muted mt-2">Read alongside §9 — two declarations on the same question</div>
+                        </a>
+                        <a href="/report/claude-creative-work-connectors/en/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">Report · Anthropic</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">When the Agent Works, Someone Else Harvests the Data</div>
+                            <div class="text-xs themeable-muted mt-2">Claude's creative work connectors and the question of data attribution</div>
+                        </a>
+                        <a href="/story/dataclinic-stories/en/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">DataClinic Diagnostic Stories</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">The Stories Behind AI Datasets</div>
+                            <div class="text-xs themeable-muted mt-2">Browse the full DataClinic diagnostic series</div>
+                        </a>
+                    </div>
+                </section>
+
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Frequently Asked Questions</h2>
@@ -422,10 +449,10 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4">Primary Sources (Papal Documents and Official Statements)</h3>
                     <ol class="space-y-3 mb-8 themeable-text leading-relaxed" style="list-style:decimal;margin-left:1.5rem;">
-                        <li>Pope Leo XIV (2026). <em>Magnifica Humanitas: On Safeguarding the Human Person in the Time of Artificial Intelligence</em>. Vatican.</li>
+                        <li>Pope Leo XIV (2026). <a href="https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Magnifica Humanitas: On Safeguarding the Human Person in the Time of Artificial Intelligence</em></a>. Vatican, 15 May 2026.</li>
                         <li>Pontifical Academy for Life (2020). <a href="https://www.romecall.org/" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400">Rome Call for AI Ethics</a>. Vatican.</li>
-                        <li>Pope Francis (2015). <em>Laudato Si': On Care for Our Common Home</em>. Vatican.</li>
-                        <li>Pope Leo XIII (1891). <em>Rerum Novarum: On Capital and Labor</em>. Vatican.</li>
+                        <li>Pope Francis (2015). <a href="https://www.vatican.va/content/francesco/en/encyclicals/documents/papa-francesco_20150524_enciclica-laudato-si.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Laudato Si': On Care for Our Common Home</em></a>. Vatican.</li>
+                        <li>Pope Leo XIII (1891). <a href="https://www.vatican.va/content/leo-xiii/en/encyclicals/documents/hf_l-xiii_enc_15051891_rerum-novarum.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Rerum Novarum: On Capital and Labor</em></a>. Vatican, 15 May 1891.</li>
                         <li>Dicastery for the Doctrine of the Faith &amp; Dicastery for Culture and Education (2025). <em>Antiqua et Nova</em>. Vatican.</li>
                         <li>Vatican News (2026-05). <a href="https://www.vaticannews.va/en/pope/news/2026-05/pope-leo-interdicasterial-artificial-intelligence-commission.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400">Establishment of the Pontifical AI Commission</a>.</li>
                     </ol>

--- a/report/pope-magnifica-humanitas/ko/index.html
+++ b/report/pope-magnifica-humanitas/ko/index.html
@@ -232,8 +232,8 @@
                                     <div class="text-xs font-semibold mb-4 tracking-wider" style="color: #1E50B4;">MAGNIFICA HUMANITAS · 2026 · LEO XIV</div>
                                     <div class="text-sm themeable-text leading-relaxed space-y-5">
                                         <div>
-                                            <p class="text-xs themeable-muted font-medium mb-1">§6 — 기술은 중립적이지 않다</p>
-                                            <p class="italic">"Technology is never neutral — it reflects the character of those who design it, finance it, regulate it, and use it. Artificial intelligence, like every other technological advance, is not exempt from this reality."</p>
+                                            <p class="text-xs themeable-muted font-medium mb-1">§9 — 기술은 중립적이지 않다</p>
+                                            <p class="italic">"In practice, however, technology is never neutral, because it takes on the characteristics of those who devise, finance, regulate and use it." <span class="not-italic text-xs themeable-muted">(§9)</span></p>
                                         </div>
                                         <div>
                                             <p class="text-xs themeable-muted font-medium mb-1">§67 — 데이터의 보편적 목적</p>
@@ -273,9 +273,9 @@
                         </figcaption>
                     </figure>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">선언 1. "기술은 결코 중립적이지 않다" (SS6)</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">선언 1. "기술은 결코 중립적이지 않다" (§9)</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        회칙 &sect;6은 명확하게 선언한다. <strong>"기술은 결코 중립적이지 않다 &mdash; 설계, 자금, 규제, 사용에 관여한 자의 특성을 반영한다."</strong> 이는 "AI는 도구이며, 사용자가 책임진다"는 기존 기업 논리에 대한 직접 반박이다. 2025년 AI 안전 사고 362건(전년 대비 +55.4%, Stanford HAI AI Index 2026)이 이 선언의 실증적 근거가 된다.
+                        회칙 &sect;9는 선언한다. <strong>"실제로 기술은 결코 중립적이지 않다. 기술은 그것을 고안하고, 자금을 대고, 규제하고, 사용하는 자들의 특성을 취하기 때문이다(In practice, however, technology is never neutral, because it takes on the characteristics of those who devise, finance, regulate and use it)."</strong> 이는 "AI는 도구이며, 사용자가 책임진다"는 기존 기업 논리에 대한 직접 반박이다. 2025년 AI 안전 사고 362건(전년 대비 +55.4%, Stanford HAI AI Index 2026)이 이 선언의 실증적 근거가 된다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4">선언 2. 연대를 "원칙이자 덕목"으로 격상 (SS73)</h3>
@@ -458,6 +458,33 @@
                     </div>
                 </section>
 
+                <!-- 관련 콘텐츠 -->
+                <section class="mb-16 fade-in-card">
+                    <h2 class="text-3xl font-bold themeable-heading mb-8">페블러스에서 더 읽기</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <a href="/report/ai-psychosis-agentic-governance-2026-05/ko/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">보고서 · AI 거버넌스</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">AI가 틀렸는데 아무도 말하지 않는다</div>
+                            <div class="text-xs themeable-muted mt-2">에이전틱 AI 거버넌스 공백 — 책임은 누구에게</div>
+                        </a>
+                        <a href="/story/palantir-technological-republic/ko/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">스토리 · 기술 중립성</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">기술은 중립이 아니다 — 팔란티어 기술 공화국</div>
+                            <div class="text-xs themeable-muted mt-2">22조 선언 원문과 해설 — §9의 선언과 나란히 읽기</div>
+                        </a>
+                        <a href="/report/claude-creative-work-connectors/ko/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">보고서 · Anthropic</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">에이전트가 일할 때, 누군가는 데이터를 거둬간다</div>
+                            <div class="text-xs themeable-muted mt-2">Claude 크리에이티브 작업 커넥터와 데이터 귀속</div>
+                        </a>
+                        <a href="/story/dataclinic-stories/ko/" class="block p-5 rounded-xl border themeable-border hover:border-orange-400 transition-colors group">
+                            <div class="text-xs themeable-muted mb-2">DataClinic 진단 스토리</div>
+                            <div class="font-semibold themeable-heading text-sm leading-snug group-hover:text-orange-500 transition-colors">AI 데이터셋, 숫자 뒤에 숨은 이야기</div>
+                            <div class="text-xs themeable-muted mt-2">DataClinic 진단 시리즈 전체 보기</div>
+                        </a>
+                    </div>
+                </section>
+
                 <!-- FAQ -->
                 <section id="faq" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-8">자주 묻는 질문</h2>
@@ -470,10 +497,10 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4">1차 소스 (교황 문서 및 공식 발표)</h3>
                     <ol class="space-y-3 mb-8 themeable-text leading-relaxed" style="list-style:decimal;margin-left:1.5rem;">
-                        <li>Pope Leo XIV (2026). <em>Magnifica Humanitas: On Safeguarding the Human Person in the Time of Artificial Intelligence</em>. Vatican.</li>
+                        <li>Pope Leo XIV (2026). <a href="https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Magnifica Humanitas: On Safeguarding the Human Person in the Time of Artificial Intelligence</em></a>. Vatican, 15 May 2026. [영어 원문]</li>
                         <li>Pontifical Academy for Life (2020). <a href="https://www.romecall.org/" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400">Rome Call for AI Ethics</a>. Vatican.</li>
-                        <li>Pope Francis (2015). <em>Laudato Si': On Care for Our Common Home</em>. Vatican.</li>
-                        <li>Pope Leo XIII (1891). <em>Rerum Novarum: On Capital and Labor</em>. Vatican.</li>
+                        <li>Pope Francis (2015). <a href="https://www.vatican.va/content/francesco/en/encyclicals/documents/papa-francesco_20150524_enciclica-laudato-si.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Laudato Si': On Care for Our Common Home</em></a>. Vatican.</li>
+                        <li>Pope Leo XIII (1891). <a href="https://www.vatican.va/content/leo-xiii/en/encyclicals/documents/hf_l-xiii_enc_15051891_rerum-novarum.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400"><em>Rerum Novarum: On Capital and Labor</em></a>. Vatican, 15 May 1891. [영어 원문]</li>
                         <li>Dicastery for the Doctrine of the Faith &amp; Dicastery for Culture and Education (2025). <em>Antiqua et Nova</em>. Vatican.</li>
                         <li>Vatican News (2026-05). <a href="https://www.vaticannews.va/en/pope/news/2026-05/pope-leo-interdicasterial-artificial-intelligence-commission.html" target="_blank" rel="noopener noreferrer" class="text-orange-500 hover:text-orange-400">AI 위원회 설립</a>.</li>
                     </ol>


### PR DESCRIPTION
## Summary

- §6 → §9 단락 번호 수정 (Vatican 원문 직접 확인)
- Bibliography items 1, 3, 4에 Vatican 공식 URL 링크 추가
- "페블러스에서 더 읽기" 내부 링크 섹션 추가 (KO + EN 양쪽)

## 대상 파일

- `report/pope-magnifica-humanitas/ko/index.html`
- `report/pope-magnifica-humanitas/en/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)