### PR TITLE
fix: intelligent-parrot/en에 subtitle 추가

### DIFF
--- a/project/CURK/intelligent-parrot/en/index.html
+++ b/project/CURK/intelligent-parrot/en/index.html
@@ -947,6 +947,7 @@
                 publisher: "Pebblous Data Communication Team",
                 pageTitle: "The Birth of the Intelligent Parrot: The LLM Intelligence Debate and Emergent Possibilities | Pebblous",
                 mainTitle: "Is Your AI Just a Very Good Parrot?",
+                subtitle: "From Stochastic Parrot to World Model: The LLM intelligence debate and emergent possibilities",
                 defaultTheme: "light",
 
                 // SEO Phase 2: Related Posts & Breadcrumbs


### PR DESCRIPTION
## 변경

EN sister에 subtitle 키 추가. KO에는 있는데 EN에 누락되어 있었음.

```diff
                 mainTitle: "Is Your AI Just a Very Good Parrot?",
+                subtitle: "From Stochastic Parrot to World Model: The LLM intelligence debate and emergent possibilities",
                 defaultTheme: "light",
```

## 배경

PebblousPage.init() 캐논상 mainTitle+subtitle 모두 필수:
- Hero h1 아래 subtitle (1.875rem) 렌더링
- PebblousSchema가 Article JSON-LD에 사용

BlogScope v0.3.8이 탐지한 'no JSON-LD' 8건 중 하나.

## 번역

KO: 'LLM 지능 논쟁과 창발적 가능성 — 확률적 앵무새에서 세계 모델까지'
EN (이번 PR): 'From Stochastic Parrot to World Model: The LLM intelligence debate and emergent possibilities'

— punchline (확률적 앵무새 → 세계 모델)을 앞으로, 콜론으로 정리.

## 검증

- BlogScope audit #12: SHIP fp 1%
- JS 구문 ok, 캐논 위반 해소, 다른 라인 무변경
- 한 줄 추가만