### PR TITLE
chore(report-produce): SkillOpt 보고서 Phase 8.5/9 로그 보존

### DIFF
--- a/report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.jsonl
+++ b/report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.jsonl
@@ -32,3 +32,6 @@
 {"event": "phase_start", "phase": "7-B", "agent": "sns-write", "model": "sonnet", "mode": "express", "ts": "2026-05-27T07:31:11Z"}
 {"event": "phase_end", "phase": "7-B", "agent": "sns-write", "status": "ok", "output_path": "report/microsoft-skillopt-self-evolving-agents/sns/", "notes": "4 채널 + Medium 1,753 words", "ts": "2026-05-27T07:36:42Z"}
 {"event": "phase_start", "phase": "8", "agent": "blog-publisher", "model": "haiku", "mode": "express", "ts": "2026-05-27T07:36:42Z"}
+{"event": "phase_end", "phase": "8", "agent": "blog-publisher", "status": "ok", "output_path": "", "notes": "PR #229 / commit 3103fc48 / articles.json 473 / validate PASS / SEO 100%", "ts": "2026-05-27T07:40:37Z"}
+{"event": "note", "kind": "info", "content": "Preview: KO=https://west-trustee-mozilla-powell.trycloudflare.com/report/microsoft-skillopt-self-evolving-agents/ko/  EN=https://west-trustee-mozilla-powell.trycloudflare.com/report/microsoft-skillopt-self-evolving-agents/en/  (cloudflared, 세션 종료 시 만료)", "ts": "2026-05-27T07:40:59Z"}
+{"event": "note", "kind": "info", "content": "Phase 9: iMessage 발송 OK / Gmail Draft 생성 OK (id=r5867267732838485535)", "ts": "2026-05-27T07:43:11Z"}

--- a/report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.md
+++ b/report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.md
@@ -1,0 +1,57 @@
+# report-produce 실행 로그 — Microsoft SkillOpt — 자기진화 AI 에이전트
+
+- slug: `microsoft-skillopt-self-evolving-agents`
+- 실행일: 2026-05-27
+- 모드: `express`
+- 시작: 2026-05-27T06:14:49Z
+- 종료: 2026-05-27T07:40:37Z
+- 총 소요 (단계 합): 1h 47m 19s
+
+> ⛔ 이 파일은 색인되지 않는다 (articles.json/sitemap 미등록). 재현성·투명성 목적으로 보관.
+
+## 단계별 실행
+
+| Phase | 에이전트 | 모델 | 상태 | 소요 | 산출물 |
+|-------|---------|------|------|------|--------|
+| Pre | topic-coverage-checker | haiku | ok | 3m 34s | `…t/microsoft-skillopt-self-evolving-agents/pre_coverage.md` |
+| Pre | topic-value-assessor | sonnet | ok | 3m 34s | `…port/microsoft-skillopt-self-evolving-agents/pre_value.md` |
+| 1 | report-planner | opus | ok | 3m 58s | `…report/microsoft-skillopt-self-evolving-agents/00_plan.md` |
+| 2 | arxiv-researcher | opus | ok | 9m 29s | `…port/microsoft-skillopt-self-evolving-agents/02a_arxiv.md` |
+| 2 | industry-researcher | sonnet | ok | 9m 29s | `…t/microsoft-skillopt-self-evolving-agents/02b_industry.md` |
+| 2 | data-researcher | sonnet | ok | 9m 29s | `…eport/microsoft-skillopt-self-evolving-agents/02c_data.md` |
+| 3 | report-synthesizer | opus | ok | 10m 29s | `…t/microsoft-skillopt-self-evolving-agents/03_synthesis.md` |
+| 4 | report-writer | opus | ok | 13m 29s | `…ort/microsoft-skillopt-self-evolving-agents/ko/index.html` |
+| 5-A | self-review | sonnet | ok | 16.0s | `—` |
+| 5-B | text-reinforce | sonnet | ok | 1m 29s | `—` |
+| 5-C | image-reinforce | haiku | ok | 6m 20s | `—` |
+| 5-D | bibliography | haiku | ok | 5m 1s | `—` |
+| 6 | report-en-writer | opus | ok | 17m 46s | `…ort/microsoft-skillopt-self-evolving-agents/en/index.html` |
+| 7-A | seo-check | haiku | ok | 3m 30s | `—` |
+| 7-B | sns-write | sonnet | ok | 5m 31s | `report/microsoft-skillopt-self-evolving-agents/sns/` |
+| 8 | blog-publisher | haiku | ok | 3m 55s | `—` |
+
+## 단계별 노트
+
+- **Phase Pre (topic-coverage-checker)**: 부분 중복 — Hermes/Voyager 선행 글. 차별화: Microsoft 학술 원리 + 모델 간 전이 실증
+- **Phase Pre (topic-value-assessor)**: 강력 추천 — 페블러스 AI-Ready Data 행동 버전으로 직결
+- **Phase 1 (report-planner)**: 텍스트 공간 gradient descent + 모델 전이 + 행동 데이터베이스 3축. 8섹션 구조
+- **Phase 2 (arxiv-researcher)**: arXiv:2605.23904, 학술 계보 7편, verbatim 10개
+- **Phase 2 (industry-researcher)**: 진영분기 + 표준화 대칭성 + 한컴·LG 한국 동시일
+- **Phase 2 (data-researcher)**: 벤치마크 6개 + 비용 자릿수 6-7개 + AgentOps .4B
+- **Phase 3 (report-synthesizer)**: 10블록 + 5신호 재맵핑 + 인용 풀 7개 + 메타 후보 (mainTitle: 스킬 문서가 학습하기 시작했다)
+- **Phase 4 (report-writer)**: 6,299자 / 8섹션 / FAQ 10 / refs 27 / mainTitle: 스킬 문서가 학습하기 시작했다
+- **Phase 5-A (self-review)**: 모든 self-check 통과: 금지 패턴 0, themeable-card 15, key-insight 5, number-badge 18, FAQ 10, italic 0, TechArticle 2
+- **Phase 5-B (text-reinforce)**: 1곳 보강 (+115자, 약 +2.2%) — Section 4 stat-card 그리드 직전. 나머지는 Text-First 이미 충족
+- **Phase 5-C (image-reinforce)**: 3장 삽입 (모두 SkillOpt 공식 figure: pipeline/text-space landscape/epoch trends) — 주제 매칭 100%. 한국 동시일 슬롯은 일반 추상 회피로 skip
+- **Phase 5-D (bibliography)**: references.json 27 entries (5 카테고리) / BibTeX+RIS / scholar meta 6 / 모든 grep PASS
+- **Phase 6 (report-en-writer)**: 837 lines / 10 FAQ / mainTitle: When Skill Documents Began to Learn / og:image EN 경로 OK
+- **Phase 7-A (seo-check)**: KO 22/22 + EN 22/22 (100%) — OG 자동 생성, 정적 JSON-LD 중복 제거, EN title/desc 단축
+- **Phase 7-B (sns-write)**: 4 채널 + Medium 1,753 words
+- **Phase 8 (blog-publisher)**: PR #229 / commit 3103fc48 / articles.json 473 / validate PASS / SEO 100%
+
+## 자유 노트 (theme adequity, intervention 등)
+
+- `adequity` (2026-05-27T06:18:23Z): coverage=부분중복(Hermes/Voyager), value=강력추천 — express 모드 자동 진행. 차별화 각도: Microsoft 학술 원리 + 모델 간 전이 실증 + 행동 데이터베이스 명제
+- `info` (2026-05-27T06:42:47Z): Phase 2 industry-researcher 파일 저장 누락 → 오케스트레이터가 재구성 저장. synthesizer는 입력 프롬프트에서 industry 데이터를 받았으므로 영향 없음
+- `info` (2026-05-27T06:56:34Z): Phase 4.5 자동 진행 — JH 리뷰 생략 (express 모드)
+- `info` (2026-05-27T07:40:59Z): Preview: KO=https://west-trustee-mozilla-powell.trycloudflare.com/report/microsoft-skillopt-self-evolving-agents/ko/  EN=https://west-trustee-mozilla-powell.trycloudflare.com/report/microsoft-skillopt-self-evolving-agents/en/  (cloudflared, 세션 종료 시 만료)


### PR DESCRIPTION
## Summary

PR #229 머지 후 express 파이프라인이 추가로 기록한 Phase 8.5(preview tunnel) + Phase 9(iMessage/Gmail Draft) 로그를 영구 보관.

## 변경
- `report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.jsonl` (추가 라인 7개)
- `report/microsoft-skillopt-self-evolving-agents/log/report-produce-2026-05-27.md` (신규, finalize 산출)

## 정책
- 무인 실행의 재현성·투명성 확보 (express 정책)
- articles.json / sitemap.xml에 등록되지 않음 (CLAUDE.md 색인 금지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)