### PR TITLE
fix(style): stat-card 텍스트 넘침 + 5칸 그리드 제한 정책

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,8 @@ The `key-insight` box provides the teal-bordered highlight. Content should be 3 
 - **Text-First, Visual-Second**: Always place explanation paragraph before any chart/card/diagram
 - Source MD documents are the narrative backbone — preserve original sentences
 - Featured articles: max 3 per category
+- **⛔ Stat-card 그리드 최대 4칸**: Executive Summary 등의 stat-card 그리드는 `grid-cols-2 sm:grid-cols-2 lg:grid-cols-4` 까지만 사용. 5칸(`lg:grid-cols-5`) 금지 — 데스크탑에서도 텍스트 캡션이 좁아져 카드 밖으로 넘침. 더 많은 지표가 필요하면 두 줄(grid 자체 wrap) 또는 본문 표로 분리.
+- **카드 내 텍스트 캡션 길이**: 카드 안의 `<p class="text-xs themeable-muted">` 보조 캡션은 **한 줄 30자(한글) / 40자(영어) 이내**가 안전. 더 길면 `word-break: keep-all` 적용된 themeable-card에서도 자연스러운 줄바꿈이 어렵다. 필요하면 핵심 한 줄로 압축하고 부가 설명은 본문 단락으로 옮긴다.
 
 ### ⛔ 한국어 본문 — 영어 용어 도입 규칙
 

--- a/report/muse-autoskill-self-evolving-skill-lifecycle/en/index.html
+++ b/report/muse-autoskill-self-evolving-skill-lifecycle/en/index.html
@@ -126,31 +126,26 @@
 
                     <!-- Stat Cards -->
                     <p class="themeable-text-secondary text-sm mt-8 mb-3">A one-glance read of the MUSE-Autoskill frame and the quantitative signals around it. Sources: arXiv:2605.27366, arXiv:2602.12670, McKinsey State of AI 2026, LangChain State of AI Agents 2025 (n=1,340), Mem0.ai.</p>
-                    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+                    <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
-                            <p class="text-2xl font-bold" style="color: #F86825;">5</p>
-                            <p class="text-sm themeable-text-secondary mt-1">lifecycle stages</p>
-                            <p class="text-xs themeable-muted mt-1">Creation · Memory · Management · Evaluation · Refinement</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">5 stages</p>
+                            <p class="text-sm themeable-text-secondary mt-1">skill lifecycle</p>
+                            <p class="text-xs themeable-muted mt-1">Creation · Memory · Mgmt · Eval · Refine</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">88% / 64%</p>
-                            <p class="text-sm themeable-text-secondary mt-1">production failure</p>
-                            <p class="text-xs themeable-muted mt-1">McKinsey: 88% of pilots stall; 64% of those cite an evaluation gap</p>
+                            <p class="text-sm themeable-text-secondary mt-1">pilot failure</p>
+                            <p class="text-xs themeable-muted mt-1">McKinsey — 64% cite evaluation gap</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">31% → 79%</p>
                             <p class="text-sm themeable-text-secondary mt-1">task completion</p>
-                            <p class="text-xs themeable-muted mt-1">LangChain n=1,340 — with layered memory; cost −62%</p>
+                            <p class="text-xs themeable-muted mt-1">LangChain — cost −62%</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">+16.2pp</p>
                             <p class="text-sm themeable-text-secondary mt-1">curated skills</p>
-                            <p class="text-xs themeable-muted mt-1">SkillsBench: self-generated ≈ 0; curated skills lift performance</p>
-                        </div>
-                        <div class="themeable-card rounded-xl p-4 text-center">
-                            <p class="text-2xl font-bold" style="color: #F86825;">2026-05-22</p>
-                            <p class="text-sm themeable-text-secondary mt-1">a Korean coincidence</p>
-                            <p class="text-xs themeable-muted mt-1">Hancom × LG ChatEXAONE alliance = same day SkillOpt arXiv</p>
+                            <p class="text-xs themeable-muted mt-1">SkillsBench — self-gen ≈ 0</p>
                         </div>
                     </div>
                 </section>

--- a/report/muse-autoskill-self-evolving-skill-lifecycle/ko/index.html
+++ b/report/muse-autoskill-self-evolving-skill-lifecycle/ko/index.html
@@ -126,31 +126,26 @@
 
                     <!-- Stat Cards -->
                     <p class="themeable-text-secondary text-sm mt-8 mb-3">MUSE-Autoskill 프레임의 핵심 좌표와 주변 정량 신호를 한눈에 본다. 출처: arXiv:2605.27366·arXiv:2602.12670, McKinsey State of AI 2026, LangChain State of AI Agents 2025(n=1,340), Mem0.ai.</p>
-                    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+                    <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
-                            <p class="text-2xl font-bold" style="color: #F86825;">5</p>
-                            <p class="text-sm themeable-text-secondary mt-1">lifecycle 단계</p>
-                            <p class="text-xs themeable-muted mt-1">Creation·Memory·Management·Evaluation·Refinement</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">5단계</p>
+                            <p class="text-sm themeable-text-secondary mt-1">스킬 lifecycle</p>
+                            <p class="text-xs themeable-muted mt-1">생성·기억·관리·평가·정제</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">88% / 64%</p>
-                            <p class="text-sm themeable-text-secondary mt-1">production 실패</p>
-                            <p class="text-xs themeable-muted mt-1">McKinsey: 파일럿 88% 실패, 그중 64% evaluation gap</p>
+                            <p class="text-sm themeable-text-secondary mt-1">파일럿 실패</p>
+                            <p class="text-xs themeable-muted mt-1">McKinsey — 64%가 평가 부재</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">31% → 79%</p>
-                            <p class="text-sm themeable-text-secondary mt-1">task completion</p>
-                            <p class="text-xs themeable-muted mt-1">LangChain n=1,340 — Layered memory 도입, 비용 −62%</p>
+                            <p class="text-sm themeable-text-secondary mt-1">작업 완료율</p>
+                            <p class="text-xs themeable-muted mt-1">LangChain — 비용 −62%</p>
                         </div>
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">+16.2pp</p>
-                            <p class="text-sm themeable-text-secondary mt-1">curated skill</p>
-                            <p class="text-xs themeable-muted mt-1">SkillsBench: self-gen ≒ 0, 큐레이션은 향상</p>
-                        </div>
-                        <div class="themeable-card rounded-xl p-4 text-center">
-                            <p class="text-2xl font-bold" style="color: #F86825;">2026-05-22</p>
-                            <p class="text-sm themeable-text-secondary mt-1">한국 동시일</p>
-                            <p class="text-xs themeable-muted mt-1">한컴·LG ChatEXAONE 협약 = SkillOpt arXiv</p>
+                            <p class="text-sm themeable-text-secondary mt-1">큐레이션 효과</p>
+                            <p class="text-xs themeable-muted mt-1">SkillsBench — self-gen ≒ 0</p>
                         </div>
                     </div>
                 </section>

--- a/styles/common-styles.css
+++ b/styles/common-styles.css
@@ -223,6 +223,10 @@ a {
     border: 1px solid rgba(248, 104, 37, 0.18);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
     transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    /* 텍스트 카드 밖 넘침 방지 — 한글 어절 고수(keep-all) + 긴 영어 단어는 줄바꿈 */
+    word-break: keep-all;
+    overflow-wrap: anywhere;
+    min-width: 0;
 }
 .themeable-card:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary

JH 리뷰 — MUSE-Autoskill Exec Summary 카드 박스에서 두 문제 발견:
1. **5칸 lg:grid-cols-5** 라 캡션이 카드 폭을 넘어 옆 카드와 겹침
2. **'Creation·Memory·Management·Evaluation·Refinement'** 같은 긴 캡션이 themeable-card 안에 들어가지 못함

## 조치

### 1. CSS 강화 (모든 블로그/리포트 자동 공유)
`.themeable-card` 에 추가:
- `word-break: keep-all` — 한글 어절 고수
- `overflow-wrap: anywhere` — 영어 긴 단어 안전 줄바꿈
- `min-width: 0` — flex/grid 자식의 overflow를 부모가 잘라낼 수 있게

→ 5칸 그리드를 쓰는 기존 글 10+ 편의 넘침도 자동 완화.

### 2. MUSE-Autoskill 5칸 → 4칸 (KO+EN)
- '2026-05-22 한국 동시일' 카드 제거 — 본문 §6/§7에 이미 충분히 다룸
- 남은 4개: 정량 임팩트 (5단계 / 88%·64% / 31%→79% / +16.2pp)
- 긴 캡션 짧게 편집

### 3. CLAUDE.md 정책 명시
- Stat-card 그리드 최대 4칸 (`lg:grid-cols-5` 금지)
- 카드 내 보조 캡션 30자(한글)/40자(영어) 이내

## 영향 범위

| 항목 | 범위 |
|------|------|
| CSS word-break 강화 | **모든 블로그/리포트 자동 공유** |
| 5→4칸 마이그레이션 | MUSE 글만 (다른 5칸 글 10+ 편은 별도 chore로) |
| 정책 문서화 | 앞으로 모든 신규 글에 자동 적용 |

## Test plan

- [x] grid-cols-5 제거 검증 (MUSE KO/EN 0건)
- [x] Tailwind 빌드 완료
- [ ] 머지 후 다른 5칸 글들 마이그레이션 chore PR (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)