### PR TITLE
chore(report-produce): PIPEDA 보고서 로그 보존

### DIFF
--- a/report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.jsonl
+++ b/report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.jsonl
@@ -1,0 +1,37 @@
+{"event": "phase_start", "phase": "Pre", "agent": "topic-coverage-checker", "model": "haiku", "mode": "express", "ts": "2026-05-29T00:33:58Z"}
+{"event": "phase_start", "phase": "Pre", "agent": "topic-value-assessor", "model": "sonnet", "mode": "express", "ts": "2026-05-29T00:33:58Z"}
+{"event": "phase_end", "phase": "Pre", "agent": "topic-coverage-checker", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/pre_coverage.md", "notes": "신규. 차별화 — 법집행 판례 각도. AI 거버넌스 4부작 시리즈 형성 (Magnifica/SkillOpt/MUSE/PIPEDA)", "ts": "2026-05-29T00:36:40Z"}
+{"event": "phase_end", "phase": "Pre", "agent": "topic-value-assessor", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/pre_value.md", "notes": "강력 추천. AI-Ready Data → AI-Ready Compliance 확장. 사후 동의 불가능 선언 = AI 제품 문화 전환점", "ts": "2026-05-29T00:36:40Z"}
+{"event": "note", "kind": "adequity", "content": "coverage=신규(차별화 명확), value=강력추천 — express 자동 진행. 핵심 프레임: 'AI-Ready Data → AI-Ready Compliance', 'BC/Alberta 사후 동의 불가능 선언 = AI 제품 문화 전환점'. 시리즈 4부작 완성", "ts": "2026-05-29T00:36:40Z"}
+{"event": "phase_start", "phase": "1", "agent": "report-planner", "model": "opus", "mode": "express", "ts": "2026-05-29T00:36:40Z"}
+{"event": "phase_end", "phase": "1", "agent": "report-planner", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/00_plan.md", "notes": "mainTitle: 사후 동의는 불가능하다 / 8섹션 / 4부작 시리즈 완성 좌표", "ts": "2026-05-29T00:42:15Z"}
+{"event": "phase_start", "phase": "2", "agent": "arxiv-researcher", "model": "opus", "mode": "express", "ts": "2026-05-29T00:42:15Z"}
+{"event": "phase_start", "phase": "2", "agent": "industry-researcher", "model": "sonnet", "mode": "express", "ts": "2026-05-29T00:42:15Z"}
+{"event": "phase_start", "phase": "2", "agent": "data-researcher", "model": "sonnet", "mode": "express", "ts": "2026-05-29T00:42:15Z"}
+{"event": "phase_end", "phase": "2", "agent": "arxiv-researcher", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/02a_arxiv.md", "notes": "PIPEDA verbatim 10+ (단락 번호 정확), 학술 8 카테고리, 3 이론적 함의", "ts": "2026-05-29T00:51:21Z"}
+{"event": "phase_end", "phase": "2", "agent": "industry-researcher", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/02b_industry.md", "notes": "4 위원회 위원장 verbatim + 8 관할 비교 + 한국 AI 기본법 매핑 + 페블러스 시장 빈 공간", "ts": "2026-05-29T00:51:21Z"}
+{"event": "phase_end", "phase": "2", "agent": "data-researcher", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/02c_data.md", "notes": "4중 과징금 비교 + OpenAI 900M WAU B ARR + 한국 ChatGPT 23.45M MAU + 페블러스 TAM B", "ts": "2026-05-29T00:51:21Z"}
+{"event": "note", "kind": "info", "content": "Phase 2 industry-researcher 파일 저장 누락 → 오케스트레이터가 출력 받아 02b_industry.md로 저장", "ts": "2026-05-29T00:51:21Z"}
+{"event": "phase_start", "phase": "3", "agent": "report-synthesizer", "model": "opus", "mode": "express", "ts": "2026-05-29T00:51:21Z"}
+{"event": "phase_end", "phase": "3", "agent": "report-synthesizer", "status": "ok", "output_path": "_workspace/report/openai-pipeda-ai-training-data-regulation/03_synthesis.md", "notes": "8섹션 + Exec 3문단 + 6 핵심 발견 + DataClinic 6번째 신호(합법성) + 4중 한국 대응 가이드 + FAQ 9 + refs 35", "ts": "2026-05-29T00:57:44Z"}
+{"event": "phase_start", "phase": "4", "agent": "report-writer", "model": "opus", "mode": "express", "ts": "2026-05-29T00:57:44Z"}
+{"event": "phase_end", "phase": "4", "agent": "report-writer", "status": "ok", "output_path": "report/openai-pipeda-ai-training-data-regulation/ko/index.html", "notes": "7,500자 / 8섹션 / FAQ 9 / refs 35 / mainTitle: 사후 동의는 불가능하다", "ts": "2026-05-29T01:10:58Z"}
+{"event": "note", "kind": "info", "content": "Phase 4.5 자동 진행 — JH 리뷰 생략 (express)", "ts": "2026-05-29T01:10:58Z"}
+{"event": "phase_start", "phase": "5-A", "agent": "self-review", "model": "sonnet", "mode": "express", "ts": "2026-05-29T01:10:58Z"}
+{"event": "phase_end", "phase": "5-A", "agent": "self-review", "status": "ok", "output_path": "", "notes": "모든 self-check 통과 / 한국어 italic 1건 즉시 수정 (PIPC 안내서 → span font-semibold)", "ts": "2026-05-29T01:11:50Z"}
+{"event": "phase_start", "phase": "5-B", "agent": "text-reinforce", "model": "sonnet", "mode": "express", "ts": "2026-05-29T01:11:50Z"}
+{"event": "phase_start", "phase": "5-C", "agent": "image-reinforce", "model": "haiku", "mode": "express", "ts": "2026-05-29T01:11:50Z"}
+{"event": "phase_start", "phase": "5-D", "agent": "bibliography", "model": "haiku", "mode": "express", "ts": "2026-05-29T01:11:50Z"}
+{"event": "phase_end", "phase": "5-B", "agent": "text-reinforce", "status": "ok", "output_path": "", "notes": "2곳 보강 (+224자) — Exec stat-card 앞 / §4 인트로~타임라인 사이", "ts": "2026-05-29T01:16:09Z"}
+{"event": "phase_end", "phase": "5-D", "agent": "bibliography", "status": "ok", "output_path": "", "notes": "35 entries / 5 카테고리 / legal_case type 1건 fallback 처리 / 모든 grep PASS", "ts": "2026-05-29T01:16:10Z"}
+{"event": "phase_end", "phase": "5-C", "agent": "image-reinforce", "status": "ok", "output_path": "", "notes": "4장 (OPC 오타와 + ChatGPT 로고 + BC 빅토리아 + EU 브뤼셀) — Wikimedia 공공 도메인, 주제 매칭 우수", "ts": "2026-05-29T01:16:33Z"}
+{"event": "phase_start", "phase": "6", "agent": "report-en-writer", "model": "opus", "mode": "express", "ts": "2026-05-29T01:16:33Z"}
+{"event": "phase_end", "phase": "6", "agent": "report-en-writer", "status": "ok", "output_path": "report/openai-pipeda-ai-training-data-regulation/en/index.html", "notes": "898 lines / FAQ 9 / KO 4장 이미지 복사 / /en/image/ 경로 OK", "ts": "2026-05-29T01:26:44Z"}
+{"event": "phase_start", "phase": "7-A", "agent": "seo-check", "model": "haiku", "mode": "express", "ts": "2026-05-29T01:26:44Z"}
+{"event": "phase_end", "phase": "7-A", "agent": "seo-check", "status": "ok", "output_path": "", "notes": "KO 16/16 + EN 16/16 (위반 0) — OG 자동 KO 179KB EN 184KB / description 자동 압축", "ts": "2026-05-29T01:30:00Z"}
+{"event": "phase_start", "phase": "7-B", "agent": "sns-write", "model": "sonnet", "mode": "express", "ts": "2026-05-29T01:30:00Z"}
+{"event": "phase_end", "phase": "7-B", "agent": "sns-write", "status": "ok", "output_path": "report/openai-pipeda-ai-training-data-regulation/sns/", "notes": "4 채널 6슬롯 + Medium 1,300 words / reflective 4 호흡 적용", "ts": "2026-05-29T01:34:39Z"}
+{"event": "phase_start", "phase": "8", "agent": "blog-publisher", "model": "haiku", "mode": "express", "ts": "2026-05-29T01:34:39Z"}
+{"event": "phase_end", "phase": "8", "agent": "blog-publisher", "status": "ok", "output_path": "", "notes": "PR #239 / commit f88ec257 / articles.json 479 / validate PASS / SEO KO 16 EN 16", "ts": "2026-05-29T01:37:55Z"}
+{"event": "note", "kind": "info", "content": "Preview: KO=https://nodes-flowers-objects-practices.trycloudflare.com/report/openai-pipeda-ai-training-data-regulation/ko/  EN=https://nodes-flowers-objects-practices.trycloudflare.com/report/openai-pipeda-ai-training-data-regulation/en/  (cloudflared, 세션 종료 시 만료)", "ts": "2026-05-29T01:38:16Z"}
+{"event": "note", "kind": "info", "content": "Phase 9: iMessage 발송 OK / Gmail Draft 생성 OK (id=r-8853191438217063047)", "ts": "2026-05-29T01:39:37Z"}

--- a/report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.md
+++ b/report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.md
@@ -1,0 +1,57 @@
+# report-produce 실행 로그 — 캐나다 PIPEDA #2026-002 + AI 훈련 데이터 글로벌 규제
+
+- slug: `openai-pipeda-ai-training-data-regulation`
+- 실행일: 2026-05-29
+- 모드: `express`
+- 시작: 2026-05-29T00:33:58Z
+- 종료: 2026-05-29T01:37:55Z
+- 총 소요 (단계 합): 1h 33m 30s
+
+> ⛔ 이 파일은 색인되지 않는다 (articles.json/sitemap 미등록). 재현성·투명성 목적으로 보관.
+
+## 단계별 실행
+
+| Phase | 에이전트 | 모델 | 상태 | 소요 | 산출물 |
+|-------|---------|------|------|------|--------|
+| Pre | topic-coverage-checker | haiku | ok | 2m 42s | `…openai-pipeda-ai-training-data-regulation/pre_coverage.md` |
+| Pre | topic-value-assessor | sonnet | ok | 2m 42s | `…rt/openai-pipeda-ai-training-data-regulation/pre_value.md` |
+| 1 | report-planner | opus | ok | 5m 35s | `…port/openai-pipeda-ai-training-data-regulation/00_plan.md` |
+| 2 | arxiv-researcher | opus | ok | 9m 6s | `…rt/openai-pipeda-ai-training-data-regulation/02a_arxiv.md` |
+| 2 | industry-researcher | sonnet | ok | 9m 6s | `…openai-pipeda-ai-training-data-regulation/02b_industry.md` |
+| 2 | data-researcher | sonnet | ok | 9m 6s | `…ort/openai-pipeda-ai-training-data-regulation/02c_data.md` |
+| 3 | report-synthesizer | opus | ok | 6m 23s | `…openai-pipeda-ai-training-data-regulation/03_synthesis.md` |
+| 4 | report-writer | opus | ok | 13m 14s | `…t/openai-pipeda-ai-training-data-regulation/ko/index.html` |
+| 5-A | self-review | sonnet | ok | 52.0s | `—` |
+| 5-B | text-reinforce | sonnet | ok | 4m 19s | `—` |
+| 5-C | image-reinforce | haiku | ok | 4m 43s | `—` |
+| 5-D | bibliography | haiku | ok | 4m 20s | `—` |
+| 6 | report-en-writer | opus | ok | 10m 11s | `…t/openai-pipeda-ai-training-data-regulation/en/index.html` |
+| 7-A | seo-check | haiku | ok | 3m 16s | `—` |
+| 7-B | sns-write | sonnet | ok | 4m 39s | `report/openai-pipeda-ai-training-data-regulation/sns/` |
+| 8 | blog-publisher | haiku | ok | 3m 16s | `—` |
+
+## 단계별 노트
+
+- **Phase Pre (topic-coverage-checker)**: 신규. 차별화 — 법집행 판례 각도. AI 거버넌스 4부작 시리즈 형성 (Magnifica/SkillOpt/MUSE/PIPEDA)
+- **Phase Pre (topic-value-assessor)**: 강력 추천. AI-Ready Data → AI-Ready Compliance 확장. 사후 동의 불가능 선언 = AI 제품 문화 전환점
+- **Phase 1 (report-planner)**: mainTitle: 사후 동의는 불가능하다 / 8섹션 / 4부작 시리즈 완성 좌표
+- **Phase 2 (arxiv-researcher)**: PIPEDA verbatim 10+ (단락 번호 정확), 학술 8 카테고리, 3 이론적 함의
+- **Phase 2 (industry-researcher)**: 4 위원회 위원장 verbatim + 8 관할 비교 + 한국 AI 기본법 매핑 + 페블러스 시장 빈 공간
+- **Phase 2 (data-researcher)**: 4중 과징금 비교 + OpenAI 900M WAU B ARR + 한국 ChatGPT 23.45M MAU + 페블러스 TAM B
+- **Phase 3 (report-synthesizer)**: 8섹션 + Exec 3문단 + 6 핵심 발견 + DataClinic 6번째 신호(합법성) + 4중 한국 대응 가이드 + FAQ 9 + refs 35
+- **Phase 4 (report-writer)**: 7,500자 / 8섹션 / FAQ 9 / refs 35 / mainTitle: 사후 동의는 불가능하다
+- **Phase 5-A (self-review)**: 모든 self-check 통과 / 한국어 italic 1건 즉시 수정 (PIPC 안내서 → span font-semibold)
+- **Phase 5-B (text-reinforce)**: 2곳 보강 (+224자) — Exec stat-card 앞 / §4 인트로~타임라인 사이
+- **Phase 5-C (image-reinforce)**: 4장 (OPC 오타와 + ChatGPT 로고 + BC 빅토리아 + EU 브뤼셀) — Wikimedia 공공 도메인, 주제 매칭 우수
+- **Phase 5-D (bibliography)**: 35 entries / 5 카테고리 / legal_case type 1건 fallback 처리 / 모든 grep PASS
+- **Phase 6 (report-en-writer)**: 898 lines / FAQ 9 / KO 4장 이미지 복사 / /en/image/ 경로 OK
+- **Phase 7-A (seo-check)**: KO 16/16 + EN 16/16 (위반 0) — OG 자동 KO 179KB EN 184KB / description 자동 압축
+- **Phase 7-B (sns-write)**: 4 채널 6슬롯 + Medium 1,300 words / reflective 4 호흡 적용
+- **Phase 8 (blog-publisher)**: PR #239 / commit f88ec257 / articles.json 479 / validate PASS / SEO KO 16 EN 16
+
+## 자유 노트 (theme adequity, intervention 등)
+
+- `adequity` (2026-05-29T00:36:40Z): coverage=신규(차별화 명확), value=강력추천 — express 자동 진행. 핵심 프레임: 'AI-Ready Data → AI-Ready Compliance', 'BC/Alberta 사후 동의 불가능 선언 = AI 제품 문화 전환점'. 시리즈 4부작 완성
+- `info` (2026-05-29T00:51:21Z): Phase 2 industry-researcher 파일 저장 누락 → 오케스트레이터가 출력 받아 02b_industry.md로 저장
+- `info` (2026-05-29T01:10:58Z): Phase 4.5 자동 진행 — JH 리뷰 생략 (express)
+- `info` (2026-05-29T01:38:16Z): Preview: KO=https://nodes-flowers-objects-practices.trycloudflare.com/report/openai-pipeda-ai-training-data-regulation/ko/  EN=https://nodes-flowers-objects-practices.trycloudflare.com/report/openai-pipeda-ai-training-data-regulation/en/  (cloudflared, 세션 종료 시 만료)


### PR DESCRIPTION
## Summary

PR #239 머지 후 추가 기록된 Phase 8.5/9 로그 영구 보관.

## 변경
- `report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.jsonl` (37 lines)
- `report/openai-pipeda-ai-training-data-regulation/log/report-produce-2026-05-29.md` (57 lines, finalize)

## 정책
- 무인 실행 재현성·투명성 (express)
- articles.json / sitemap.xml 미등록 (CLAUDE.md 색인 금지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)