### PR TITLE
fix(report): Evans Nature 2026 — 산문 voice-edit + Exec 명확화 + ol 통일 + §2 제목

### DIFF
--- a/report/ai-tools-expand-impact-contract-science/ko/index.html
+++ b/report/ai-tools-expand-impact-contract-science/ko/index.html
@@ -114,19 +114,24 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            "AI가 과학을 돕는가, 망치는가." 오래된 논쟁에 2026년 1월 <em lang="en">Nature</em>가 처음으로 4,130만 편 규모의 실증 답안을 올려놓았다. James Evans(University of Chicago Knowledge Lab)와 Yong Li(Tsinghua) 공동연구팀의 「Artificial intelligence tools expand scientists' impact but contract science's focus」(DOI: 10.1038/s41586-025-09922-y, Vol. 649, pp. 1237–1243)는 23년에 걸친 자연과학 6개 분야 — 생물·의학·화학·물리·재료·지질 — 논문을 BERT 기반 분류기(F1 = 0.875, 전문가 5인 Fleiss' Kappa 0.964)로 식별·매칭하여, AI 도입이 개인의 효용과 집단의 폭에 정반대 방향으로 작용함을 못 박았다. 단발 연구가 아니다. Evans Lab이 2015년 <em lang="en">American Sociological Review</em> 이래 11년간 추적해 온 "과학의 좁아짐" thesis의 정점이자, Park·Funk 2023 <em lang="en">Nature</em>, Messeri·Crockett 2024 <em lang="en">Nature</em>, Kleinberg·Raghavan 2021 <em lang="en">PNAS</em>로 이어지는 7년 메타-과학 합주의 한 악장이다.
+                            AI는 과학자 개인을 훨씬 강하게, 과학 전체는 더 좁게 만들었다. 2026년 1월 <em lang="en">Nature</em>에 실린 4,130만 편 분석의 결론이다. AI를 쓰는 연구자는 동료보다 논문을 3배 더 내지만, 정작 과학이 다루는 주제의 폭은 줄었다. 모두가 데이터 많은 인기 분야로 몰리기 때문이다. 개인은 이기고, 과학은 좁아진다 — 한 연구가 정반대 두 방향을 동시에 가리켰다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            개인의 승리: AI 활용 연구자는 동료 대비 논문 <strong>+3.02배</strong>, 인용 <strong>+4.84배</strong>를 누리고 프로젝트 리더로 <strong>1.37년</strong> 빠르게 부상한다. 집단의 손실: 같은 23년에 연구 주제 다양성은 <strong>-4.63%</strong>, 연구자 간 후속 참여(follow-on engagement)는 <strong>-22%</strong> 줄었다. 인용 집중 지니 계수(Gini coefficient)는 <strong>0.754</strong> — 상위 22.20% 논문이 인용의 80%를 흡수하는 매튜 효과(Matthew effect)의 AI 시대 변형이다. Evans 본인의 말로 — <em lang="en">"AI tools are expanding individual capabilities while contracting scientific attention"</em>, <em lang="en">"AI concentrates attention on data-rich domains while leaving a growing number of potentially fruitful areas unexplored."</em> 6분야 분석에 수학·이론물리·철학이 처음부터 빠져 있다는 사실 자체가, 데이터 빈약 영역이 분석 대상에서조차 누락된다는 메타-증거다.
+                            흘려들을 얘기가 아니다. 표본이 4,130만 편, 시계열이 23년이고, 책임저자는 이 주제를 11년간 파 온 시카고대 James Evans다. 논문이 나온 지 두 달 만에 <em lang="en">Nature</em>는 "기관·자금기관·출판사가 대응해야 한다"는 사설을 냈다. 한국도 돈을 쏟는 중이다. 정부 AI 예산 10조원, 이노코어 박사후 400명, AI Co-Scientist Challenge까지. 문제는 그 자금이 향하는 6대 분야가 전부 데이터 풍부 영역이고, 다양성을 지킬 장치는 없다는 점이다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            이 역설은 정책의 시급한 의제다. <em lang="en">Nature</em>는 2026년 3월 25일 사설로 <em lang="en">"AI scientists are changing research — institutions, funders and publishers must respond"</em>를 띄웠고, 한국은 NRF AI+S&amp;T 6대 분야(바이오·재료화학·지구과학·반도체·에너지·이차전지), 2026 AI Co-Scientist Challenge Korea(상금 19억원), 4개 과기원 이노코어(InnoCORE) 박사후 400명(연 9천만원) 사업을 잇따라 출범시켰다. 자금은 빠르지만 6대 분야 모두 데이터 풍부 영역이고, 다양성 보존 메커니즘은 부재하다. LG EXAONE Discovery가 4천만 물질을 1일에 검토하는 정점 사례 또한 같은 좌표에 서 있다. 페블러스는 이 구조적 공백을 정조준한다 — Evans가 직접 호명한 "sensory and experimental capacity"의 확장이 바로 <strong>DataGreenhouse</strong>(합성데이터)와 <strong>PebbloSim</strong>(시뮬레이션)이다. 4부작(<a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> · <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>) 다음의 메타·과학사회학 좌표로서, 이번 글은 페블러스를 "데이터 진단·합성 기업"에서 <strong>과학 다양성 인프라</strong> 카테고리 리더로 격상한다. 더할 한 가지 액션 아이템 — DataClinic 7번째 신호 <strong>"지식 다양성"</strong>.
+                            그래서 남는 질문은 분명하다. 자금과 인재가 데이터 풍부한 6대 분야로 쏠릴 때, 비어가는 분야는 누가 떠받치는가. Evans 본인은 "인지 능력만이 아니라 감각·실험 능력까지 확장하는 AI"가 필요하다고 했다. 측정되지 않는 분야를 측정하고, 데이터가 없는 곳에 데이터를 만들어주는 일이다. 4부작(<a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> · <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>) 다음의 메타·과학사회학 좌표로서, 이번 글은 페블러스를 "데이터 진단·합성 기업"에서 <strong>과학 다양성 인프라</strong> 카테고리 리더로 격상한다. 더할 한 가지 실행 항목은 DataClinic의 일곱 번째 신호 <strong>"지식 다양성"</strong>이다.
                         </p>
                     </div>
 
+                    <!-- Editor's Note -->
+                    <blockquote class="themeable-card rounded-xl p-5 my-6 themeable-text leading-relaxed">
+                        <p><em>Editor's Note.</em> 데이터와 AI의 편향을 측정하는 일이라면 페블러스는 늘 구미가 당긴다. 그게 과학에서 벌어지는 문제라면 더욱 그렇다. 마침 페블러스는 'Agentic AI 데이터 과학자' 과제를 수행하고 있다. AI 기반 데이터 과학의 영역이 점점 넓어지는 지금, 이 연구는 그 한가운데에 중요한 질문 하나를 던졌다.</p>
+                    </blockquote>
+
                     <!-- Stat Cards -->
                     <p class="themeable-text leading-relaxed mt-8 mb-6">
-                        한 논문이 그은 좌표를 정량으로 풀어 두면 역설의 결이 또렷해진다. 4,130만 편이라는 표본 위에 개인 ↑ 두 칸과 집단 ↓ 두 칸을 같은 화면에 놓으면, "둘 다, 그러나 반대 방향으로"라는 한 문장이 즉시 읽힌다.
+                        한 논문이 그은 좌표를 숫자로 펼치면 역설의 결이 또렷해진다. 4,130만 편 위에 개인 쪽 두 칸과 집단 쪽 두 칸을 같은 화면에 놓으면 한 문장이 즉시 읽힌다. 둘 다, 단 반대 방향으로.
                     </p>
                     <p class="themeable-text-secondary text-sm mb-3">출처: Hao, Xu, Li, Evans (2026), <em lang="en">Nature</em> 649, pp. 1237–1243. DOI: 10.1038/s41586-025-09922-y. arXiv:2412.07727v4.</p>
                     <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -161,11 +166,11 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        "AI가 과학을 돕는가, 망치는가." 이 논쟁은 새로운 게 아니다. AlphaFold 2가 단백질 폴딩을 사실상 해결했다는 2021년 <em lang="en">Nature</em> 논문 이래, 한쪽에서는 "AI 덕에 과학이 황금기에 진입했다"고 외쳤고 다른 한쪽에서는 "AI가 환각을 일으키고 연구의 깊이를 갉아먹는다"고 반박했다. 양쪽 모두 일화와 직관에 기댄 논쟁이었다. <strong>2026년 1월, <em lang="en">Nature</em> Vol. 649, pp. 1237–1243에 게재된 한 논문이 그 자리에 처음으로 4,130만 편 규모의 실증 답안을 올려놓았다.</strong>
+                        "AI는 과학을 돕는가, 망치는가." 새 논쟁이 아니다. AlphaFold 2가 단백질 폴딩을 사실상 풀어낸 2021년 <em lang="en">Nature</em> 논문 이후, 한쪽은 "AI 덕분에 과학이 황금기에 들어섰다"고 했고 다른 쪽은 "AI가 환각을 일으키고 연구를 얕게 만든다"고 맞섰다. 양쪽 다 일화와 직관에 기댔다. <strong>2026년 1월 <em lang="en">Nature</em> Vol. 649에 실린 한 논문이 그 자리에 4,130만 편의 데이터를 깔았다.</strong>
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        저자는 4인이다 — <strong>Qianyue Hao, Fengli Xu, Yong Li</strong>(Tsinghua University)와 <strong>James A. Evans</strong>(University of Chicago Knowledge Lab, 책임저자). Evans는 시카고대 사회학과 교수이자 Santa Fe Institute 외부 교수, 그리고 "Knowledge Lab"이라는 메타-과학 연구센터의 디렉터다. 그의 연구실은 2015년 <em lang="en">American Sociological Review</em>에 발표한 「Tradition and Innovation in Scientists' Research Strategies」 이래 11년 동안 한 가지 명제를 추적해 왔다 — <strong>개인 합리성이 누적되면 집단 지식은 좁아질 수 있다</strong>. Evans 2026은 그 11년 thesis의 정점이다.
+                        저자는 넷이다. <strong>Qianyue Hao, Fengli Xu, Yong Li</strong>(Tsinghua University), 그리고 책임저자 <strong>James A. Evans</strong>(University of Chicago Knowledge Lab). Evans는 시카고대 사회학과 교수이자 Santa Fe Institute 외부 교수이고, 메타-과학 연구센터 Knowledge Lab을 이끈다. 그의 연구실은 2015년 <em lang="en">American Sociological Review</em>에 실은 「Tradition and Innovation in Scientists' Research Strategies」 이후 11년 동안 한 명제를 파고들었다. 개인이 각자 합리적으로 움직이면 집단의 지식은 오히려 좁아질 수 있다는 것. 이번 논문은 그 11년 작업이 다다른 지점이다.
                     </p>
 
                     <!-- Image: University of Chicago campus — Evans Knowledge Lab home -->
@@ -180,18 +185,18 @@
                         </figcaption>
                     </figure>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>방법론 한눈 — F1 0.875 분류기와 23년 시계열</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>방법론 — F1 0.875 분류기와 23년 시계열</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        결정문에 가까운 수치 하나가 이 논문의 무게를 가늠하게 해 준다. 연구팀은 자연과학 논문의 제목(최대 16 토큰)과 초록(최대 256 토큰)을 <code class="text-sm">bert-base-uncased</code> 2-stage fine-tuning 분류기로 처리하여 "AI 활용 연구"를 식별했다. 검증 단계에서 전문가 5인이 라벨을 매겼고 <strong>Fleiss' Kappa = 0.964</strong>(거의 완전 합의), 분류기의 <strong>F1 = 0.875</strong>가 보고됐다. 메타-과학 연구에서 이 정도 합의도와 정확도는 드물다. 23년 시계열은 AI의 세 시기 — 전통적 기계학습(1990s 후반~), 딥러닝(2012~), 생성형·대규모 언어 모델(2020~) — 을 자연스럽게 가른다.
+                        수치 하나가 논문의 무게를 가늠하게 한다. 연구팀은 자연과학 논문의 제목(최대 16 토큰)과 초록(최대 256 토큰)을 <code class="text-sm">bert-base-uncased</code> 2-stage fine-tuning 분류기로 처리해 "AI를 활용한 연구"를 골라냈다. 검증 단계에서 전문가 5명이 라벨을 매겼는데, 일치도(Fleiss' κ)가 <strong>0.964</strong>로 거의 완전 합의에 가까웠고 분류기 <strong>F1은 0.875</strong>였다. 메타-과학 연구에서 이 정도 합의와 정확도는 흔치 않다. 23년이라는 시계열은 AI의 세 시기 — 전통적 기계학습(1990년대 후반~), 딥러닝(2012~), 생성형·대규모 언어 모델(2020~) — 을 자연스럽게 가른다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        분석 대상 분야는 여섯이다. <strong>biology, medicine, chemistry, physics, materials science, geology</strong>. 한국어로는 생물·의학·화학·물리·재료·지질. 한 가지 사실을 미리 못 박아 두자 — <strong>수학·이론물리·철학은 처음부터 분석 대상에 들어 있지 않다.</strong> 이 사실은 이 논문의 메타-증거다. 데이터 빈약 영역은 가시화되기 전부터 분석 대상에서조차 누락된다. 5장에서 다시 돌아온다.
+                        분석 대상은 여섯 분야다. 생물, 의학, 화학, 물리, 재료, 지질. 여기서 미리 못 박아둘 게 있다. <strong>수학·이론물리·철학은 애초에 분석에 들어가지도 않았다.</strong> 이 사실이 곧 이 논문의 또 다른 증거다. 데이터가 빈약한 분야는 눈에 띄기도 전에 분석에서부터 누락된다. 5장에서 다시 다룬다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>6 통계 한 문장으로 — 개인의 승리, 집단의 손실</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>여섯 통계, 한 문장 — 개인은 이기고 집단은 진다</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        결과는 abstract 한 단락에 압축되어 있다. 옮겨 적어 본다.
+                        결과는 초록 한 단락에 압축돼 있다. 그대로 옮긴다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -200,12 +205,12 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        같은 단락의 결론을 옮긴다 — <em lang="en">"AI adoption in science presents a seeming paradox — an expansion of individual scientists' impact but a contraction in collective science's reach — as AI-augmented work moves collectively toward areas richest in data."</em> 마지막 한 줄은 더 직설적이다 — <em lang="en">"AI tools appear to automate established fields rather than explore new ones."</em> 자동화될 수 있는 분야로 주의가 몰리고, 탐색되어야 할 분야는 더 외면된다. 본 글의 한 줄 요약은 이 두 문장의 한국어 번역에 가깝다 — <strong>개인은 강해진다, 과학은 좁혀진다.</strong>
+                        같은 단락의 결론은 이렇다. <em lang="en">"AI adoption in science presents a seeming paradox — an expansion of individual scientists' impact but a contraction in collective science's reach — as AI-augmented work moves collectively toward areas richest in data."</em> 마지막 한 줄은 더 직설적이다. <em lang="en">"AI tools appear to automate established fields rather than explore new ones."</em> 자동화할 수 있는 분야로 주의가 몰리고, 정작 탐색이 필요한 분야는 더 외면받는다. 이 글의 한 줄 요약은 이 두 문장과 거의 같다. <strong>개인은 강해지고, 과학은 좁아진다.</strong>
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>Evans 2026이 답한 것.</strong> "AI가 과학을 돕는가, 망치는가"의 답은 "둘 다, 그러나 반대 방향으로"이다. 개인 효용과 집단 다양성이 동시에 그러나 반대로 움직인다. 4,130만 편이라는 실증의 규모, F1 0.875·Fleiss κ 0.964라는 분류기 합의도, 23년이라는 시계열 길이 — 어느 하나만으로도 메타-과학 사적史的 좌표가 될 수치들이 한 논문에 모였다.
+                            그러니 "AI는 과학을 돕는가, 망치는가"에 대한 답은 "둘 다, 단 반대 방향으로"가 된다. 개인의 효용과 집단의 다양성이 동시에, 그러나 서로 반대로 움직인다. 4,130만 편이라는 표본, F1 0.875·Fleiss κ 0.964라는 합의도, 23년이라는 길이. 이 중 하나만으로도 의미 있을 수치들이 한 논문에 모였다.
                         </p>
                     </div>
                 </section>
@@ -218,38 +223,38 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        개인 차원의 세 숫자를 하나씩 읽는다. 각 숫자가 무엇을 의미하고, 왜 그 크기가 보고됐는지가 이어진 두 절의 주제다.
+                        개인 차원의 세 숫자를 하나씩 읽어본다. 각 숫자가 무엇을 뜻하고 왜 그만한 크기인지가 이어지는 두 절의 내용이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>+3.02배 논문 · +4.84배 인용 · -1.37년 리더십</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>논문 +3.02배 · 인용 +4.84배 · 리더십 −1.37년</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        <strong>+3.02배 논문 생산.</strong> AI 도구를 일상적으로 활용하는 연구자 한 명은, 동일 분야·동일 연차의 동료 한 명보다 약 3배 많은 논문을 같은 기간 안에 출간한다. 이 숫자가 단순한 "양"의 차이로 들릴 수 있으나, 학술 시장의 보상 구조(채용·승진·연구비)가 출판 건수를 일차 지표로 삼는 한, 3배는 곧 직업적 안정성의 3배 격차다.
-                    </p>
-
-                    <p class="themeable-text leading-relaxed mb-6">
-                        <strong>+4.84배 인용 수.</strong> 더 많이 쓰는 것이 아니라 더 많이 인용된다는 점이 더 무겁다. 인용은 동료 평가의 누적이고, 그 누적이 다시 다음 논문의 인용을 끌어오는 자기-강화 루프(매튜 효과 — Merton 1968)에 들어간다. 4.84배는 단순 곱셈이 아니라 시간이 지날수록 격차가 더 벌어지는 구조의 시작점이다. 보충 자료의 보고에 따르면 인용 집중 지니 계수는 AI 활용 집단에서 <strong>0.754</strong>로, 비활용 집단의 0.690보다 의미 있게 높다. 상위 22.20%의 논문이 인용의 80%를 흡수한다 — AI 시대의 슈퍼스타 효과(superstar effect)다.
+                        <strong>논문 +3.02배.</strong> AI 도구를 일상적으로 쓰는 연구자는 같은 분야·같은 연차의 동료보다 같은 기간에 약 3배 많은 논문을 낸다. 단순한 "양"의 차이로 들릴 수 있지만, 채용·승진·연구비가 출판 건수를 일차 지표로 삼는 한 3배는 곧 직업 안정성의 3배 격차다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        <strong>-1.37년 PI 부상.</strong> 가장 사회적으로 무거운 숫자가 이것일 수 있다. 박사후 연구원이 독립 책임연구자(Principal Investigator)로 부상하는 시점이 AI 활용 연구자에게서 1.37년 빨라진다. 학술 생애 주기에서 1년 4개월은 큰 격차다 — 연구비 신청 가능 시점, 첫 박사 지도 시점, 첫 종신직 트랙 진입 시점이 모두 그만큼 앞으로 당겨진다. 동료보다 1.37년 늦은 사람은 한 사이클이 늦는 셈이다.
-                    </p>
-
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>매칭 분석이 답한 한 질문 — selection이냐 effect냐</h3>
-                    <p class="themeable-text leading-relaxed mb-6">
-                        이런 차이를 보고 가장 먼저 묻게 되는 의심은 자연스럽다 — "그냥 더 똑똑하고 빠른 연구자가 AI를 먼저 도입한 것 아닌가?" 저자들도 같은 질문을 안고 분석을 설계했다. 인과 추론 단계에서 연구팀은 AI 도구를 채택한 연구자 <strong>11,019명</strong>을 추출하고, 초기 경력 궤적(연차·분야·생산성)이 통계적으로 유사한 비-채택자 <strong>1,926명</strong>을 매칭해 비교했다. year 10 시점에서 AI 채택자의 인용은 매칭된 비-채택자보다 <strong>+24.45%</strong> 많았다. 초기 동일 조건에서 출발했음에도 격차가 벌어진다는 점은, 격차의 상당 부분이 prior selection이 아닌 채택 자체의 효과임을 시사한다.
+                        <strong>인용 +4.84배.</strong> 더 많이 쓰는 것보다 더 많이 인용된다는 쪽이 무겁다. 인용은 동료 평가가 쌓인 결과이고, 그 누적이 다음 논문의 인용을 또 끌어온다(매튜 효과, Merton 1968). 4.84배는 단순한 곱셈이 아니라 시간이 갈수록 격차가 더 벌어지는 구조의 출발점이다. 보충 자료에 따르면 인용 집중 지니 계수는 AI 활용 집단에서 <strong>0.754</strong>로, 비활용 집단의 0.690보다 뚜렷이 높다. 상위 22.20%의 논문이 인용의 80%를 가져간다. AI 시대의 슈퍼스타 효과다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        그러나 저자들도 솔직하게 한계를 인정한다 — <em lang="en">"Despite consistently suggestive evidence, we cannot fully identify the causal linkage between AI adoption and scientific impact."</em> 무작위 배정 실험이 아닌 관찰 데이터의 본질적 한계다. 정확한 인과 강도는 ±α의 폭이 있다. 그러나 11,019 vs 1,926 매칭의 +24.45%라는 추정치는 이 논문이 단순 상관에 머무는 평범한 bibliometric study가 아님을 분명히 한다.
+                        <strong>리더십 −1.37년.</strong> 사회적으로 가장 무거운 숫자일 수 있다. 박사후 연구원이 독립 책임연구자(PI)로 올라서는 시점이 AI 활용 연구자에게서 1.37년 앞당겨진다. 연구 생애에서 1년 4개월은 작지 않다. 연구비를 신청할 수 있는 시점, 첫 박사를 지도하는 시점, 종신직 트랙에 진입하는 시점이 모두 그만큼 당겨진다. 반대로 동료보다 1.37년 늦은 사람은 한 사이클을 통째로 뒤처지는 셈이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.3</span>Wu·Wang·Evans 2019와의 합류 — 작은 팀이 disrupt하던 자리</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>그냥 잘하는 사람이 먼저 쓴 것 아닐까 — selection이냐 effect냐</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans Lab의 이전 작업 한 편을 함께 읽으면 이번 논문의 무게가 다르게 느껴진다. Lingfei Wu, Dashun Wang, James A. Evans는 2019년 <em lang="en">Nature</em>에 「Large teams develop and small teams disrupt science and technology」를 게재했다. 6,500만 편 논문·특허를 분석한 결과 — <strong>작은 팀일수록 disruptive한 연구</strong>를, 큰 팀일수록 incremental한 발전을 한다는 명제를 실증했다.
+                        이런 차이를 보면 자연히 의심이 든다. "원래 더 똑똑하고 빠른 연구자가 AI를 먼저 도입한 것 아닌가?" 저자들도 같은 질문을 안고 분석을 짰다. 인과를 따지는 단계에서, 연구팀은 AI 도구를 채택한 연구자 <strong>11,019명</strong>을 뽑고 초기 경력 궤적(연차·분야·생산성)이 통계적으로 비슷한 비채택자 <strong>1,926명</strong>을 짝지어 비교했다. 10년 차 시점에서 채택자의 인용은 짝지어진 비채택자보다 <strong>24.45%</strong> 많았다. 같은 조건에서 출발했는데도 격차가 벌어진다는 건, 그 격차의 상당 부분이 사전 선택(prior selection)이 아니라 채택 자체의 효과라는 뜻이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        2019년의 그 명제 위에 2026년의 발견을 겹쳐 본다. AI 도구는 소수 연구자(작은 팀, 심지어 1인)에게도 큰 팀의 출력 규모를 가능하게 한다. 표면적으로는 "작은 팀이 더 disrupt할 수 있는 시대"가 도래해야 한다. 그런데 정작 관찰되는 것은 반대 방향이다 — AI 활용 작은 팀이 가는 자리는 데이터가 풍부한 인기 주제고, 그곳의 인용 자석에 빨려 들어간다. <strong>작은 팀의 disrupt 잠재력이 AI에 의해 가속됐다기보다는, 작은 팀이 disrupt 대신 자동화에 더 매달리게 됐다</strong>는 해석이 자연스럽다. abstract 마지막 한 줄 — <em lang="en">"AI tools appear to automate established fields rather than explore new ones"</em> — 이 그 해석을 지지한다.
+                        물론 저자들도 한계를 솔직히 인정한다. <em lang="en">"Despite consistently suggestive evidence, we cannot fully identify the causal linkage between AI adoption and scientific impact."</em> 무작위 배정 실험이 아닌 관찰 데이터의 본질적 한계다. 그래도 11,019명 대 1,926명을 매칭해 얻은 +24.45%라는 추정치는, 이 논문이 흔한 상관관계 분석에 머물지 않음을 분명히 한다.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.3</span>2019년 "작은 팀이 disrupt한다"와 겹쳐 읽기</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Evans Lab의 이전 작업을 함께 보면 이번 논문이 다르게 읽힌다. Lingfei Wu, Dashun Wang, James A. Evans는 2019년 <em lang="en">Nature</em>에 「Large teams develop and small teams disrupt science and technology」를 실었다. 6,500만 편의 논문·특허를 분석해, 작은 팀일수록 판을 흔드는(disruptive) 연구를 하고 큰 팀일수록 점진적 발전을 한다는 걸 보였다.
+                    </p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        이 명제 위에 2026년의 발견을 겹쳐본다. AI 도구는 소수의 연구자, 심지어 1인에게도 큰 팀만 한 출력을 가능하게 한다. 그러니 표면적으로는 "작은 팀이 더 판을 흔들 수 있는 시대"가 와야 맞다. 그런데 관찰되는 건 정반대다. AI를 쓰는 작은 팀이 향하는 곳은 데이터가 풍부한 인기 주제이고, 거기 깔린 인용 자석에 빨려든다. <strong>작은 팀의 disrupt 잠재력이 AI로 가속됐다기보다, 작은 팀이 disrupt 대신 자동화에 더 매달리게 됐다고 보는 편이 자연스럽다.</strong> 초록의 마지막 줄 <em lang="en">"AI tools appear to automate established fields rather than explore new ones"</em>이 그 해석을 받쳐준다.
                     </p>
 
                     <!-- Image: Tsinghua University main building — Hao/Xu/Li home institution -->
@@ -266,7 +271,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>개인의 승리는 진짜다 — 그러나 그 승리가 곧 다음 절의 손실의 원인이다.</strong> 3배·4.8배·1.4년이라는 보상은 개별 연구자의 합리적 선택을 한 방향으로 몰아간다. 그 한 방향이 무엇인지가 §3과 §4의 주제다. 개인의 합리성이 누적되면 집단의 폭은 좁아질 수 있다 — Evans Lab 11년 thesis의 본문이 이 자리에서 시작된다.
+                            개인의 승리는 진짜다. 다만 그 승리가 바로 다음 장에서 다룰 손실의 원인이기도 하다. 3배·4.8배·1.4년이라는 보상은 개별 연구자의 합리적 선택을 한 방향으로 몰아간다. 그 방향이 무엇인지가 3장과 4장의 주제다. 개인의 합리성이 쌓이면 집단의 폭은 좁아질 수 있다. Evans Lab이 11년간 추적해 온 명제의 본문이 여기서 시작된다.
                         </p>
                     </div>
                 </section>
@@ -279,34 +284,34 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        집단 차원의 두 숫자 — <strong>주제 다양성 -4.63%</strong>와 <strong>연구자 간 후속 참여 -22%</strong> — 는 표면적으로 작아 보일 수 있다. 그러나 두 숫자 모두 누적 신호이고, 분야 붕괴(field collapse)의 선행 지표로 읽을 근거가 분명하다.
+                        집단 차원의 두 숫자, 주제 다양성 <strong>−4.63%</strong>와 후속 참여 <strong>−22%</strong>는 얼핏 작아 보인다. 하지만 둘 다 누적되는 신호이고, 분야 붕괴(field collapse)의 선행 지표로 읽을 근거가 분명하다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>-4.63%는 어떻게 측정됐는가</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>−4.63%는 어떻게 쟀나</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        주제 다양성은 단순 키워드 카운트가 아니라 <strong>주제 임베딩 공간에서의 collective volume of topics studied</strong>로 측정됐다. 풀어 쓰자면, 모든 논문을 의미 임베딩으로 매핑한 뒤 그 분포가 차지하는 부피의 변화를 본다. 같은 주제에 더 많은 논문이 몰리면 부피는 줄어들고, 새로운 주제로 흩어지면 부피는 늘어난다. 23년 시계열에서 AI 도입 비율이 높아지는 구간일수록 부피가 -4.63% 줄어든 것이 본 논문의 핵심 측정이다.
+                        주제 다양성은 단순한 키워드 카운트가 아니라, 주제 임베딩 공간에서 "연구된 주제들이 차지하는 부피(collective volume of topics studied)"로 측정됐다. 풀어 말하면 이렇다. 모든 논문을 의미 임베딩으로 옮긴 뒤 그 분포가 차지하는 부피의 변화를 본다. 같은 주제에 논문이 몰리면 부피가 줄고, 새 주제로 흩어지면 부피가 는다. 23년 시계열에서 AI 도입 비율이 높아지는 구간일수록 이 부피가 4.63% 줄었다는 게 논문의 핵심 측정값이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 발 더 들어가면, 연구자 간 후속 참여(follow-on engagement) -22%가 더 빠른 신호다. 이 지표는 단순 공저자 수 감소가 아니다. 한 논문이 발표된 뒤 그 주제·방법에 다른 연구자들이 이어서 참여하는 정도 — 즉 학술 대화(scientific dialogue)의 강도다. 22% 감소는 인기 주제에 주의는 몰리되 그 주제 안에서 논문 간 상호작용은 줄어드는 상태를 가리킨다. 저자들은 이 상태를 <strong>"lonely crowds"</strong> — 외로운 군중 — 이라 이름 붙였다.
+                        한 발 더 들어가면, 연구자 간 후속 참여 <strong>−22%</strong>가 더 빠른 신호다. 이건 단순한 공저자 수 감소가 아니다. 한 논문이 나온 뒤 그 주제나 방법에 다른 연구자들이 이어서 참여하는 정도, 곧 학술적 대화의 강도다. 22% 감소는 인기 주제에 주의는 몰리는데 그 안에서 논문끼리의 상호작용은 줄어드는 상태를 가리킨다. 저자들은 이 상태에 <strong>"lonely crowds"</strong>(외로운 군중)라는 이름을 붙였다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>"lonely crowds"가 가리키는 것</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        외로운 군중이라는 표현은 즉시적 직관을 부른다. 같은 카페에 100명이 앉아 있어도 서로 인사를 나누지 않으면 그것은 군집이지 공동체가 아니다. AI 시대의 인기 주제 위에서 일어나는 일이 정확히 이것이라는 진단이다. 같은 주제에 논문이 쏟아지지만, 그 논문들이 서로의 후속 작업을 인용·확장·반박하는 dialogue의 밀도는 떨어진다. 표면의 활기 아래에서 학술 공동체의 결이 풀린다.
+                        '외로운 군중'은 직관적으로 와닿는 말이다. 카페에 100명이 앉아 있어도 서로 인사를 나누지 않으면 그건 그냥 사람이 많은 것이지 공동체가 아니다. AI 시대의 인기 주제에서 벌어지는 일이 정확히 이렇다. 같은 주제로 논문은 쏟아지는데, 정작 그 논문들이 서로의 후속 작업을 인용하고 확장하고 반박하는 밀도는 떨어진다. 겉은 북적이지만 안에서는 대화가 끊긴 상태다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        세 가지 학술 명명이 동일한 현상을 가리킨다. Evans 2026의 <strong>"lonely crowds"</strong>, Lisa Messeri와 M. J. Crockett이 2024년 <em lang="en">Nature</em>에 게재한 「Artificial intelligence and illusions of understanding in scientific research」의 <strong>과학적 단일문화(scientific monocultures)</strong>, 그리고 Jon Kleinberg와 Manish Raghavan이 2021년 <em lang="en">PNAS</em>에 게재한 「Algorithmic monoculture and social welfare」의 <strong>알고리즘 단일문화(algorithmic monoculture)</strong>. 세 명명이 가리키는 것은 동일하다 — 도구의 동일성이 사유의 동일성을 만들고, 개별 정확도는 오르지만 집단 의사결정의 다양성과 견고성은 떨어진다. 이번 글이 §4에서 한 박스에 묶어 인용하는 이유다.
+                        세 가지 학술 명명이 같은 현상을 가리킨다. Evans 2026의 "lonely crowds", Lisa Messeri와 M. J. Crockett이 2024년 <em lang="en">Nature</em>에 실은 「Artificial intelligence and illusions of understanding in scientific research」의 <strong>과학적 단일문화(scientific monocultures)</strong>, 그리고 Jon Kleinberg와 Manish Raghavan이 2021년 <em lang="en">PNAS</em>에 실은 「Algorithmic monoculture and social welfare」의 <strong>알고리즘 단일문화(algorithmic monoculture)</strong>. 도구가 같아지면 사유도 같아지고, 개별 정확도는 올라가지만 집단으로서의 다양성과 견고함은 떨어진다는 진단이다. 4장에서 이 셋을 한데 묶어 다루는 이유다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>Park·Funk 2023과 Kang·Evans 2024의 합주</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>Park·Funk 2023, Kang·Evans 2024와 함께 보기</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        -4.63%가 "작은 숫자"가 아닌 이유는 두 동행 연구를 함께 보면 분명해진다. Michael Park, Erin Leahey, Russell J. Funk가 2023년 <em lang="en">Nature</em>에 게재한 「Papers and patents are becoming less disruptive over time」은 4,500만 편 논문과 390만 편 특허를 60년 시계열에서 분석하여 <strong>CD(Consolidate-Disrupt) Index</strong>가 점진적으로 하락하고 있음을 보였다. 이 추세는 AI 이전부터 시작됐다. Evans 2026이 보여주는 것은 그 추세가 AI에 의해 가속된다는 점이다.
+                        −4.63%가 "작은 숫자"가 아닌 이유는 동행 연구 두 편을 함께 보면 분명해진다. Michael Park, Erin Leahey, Russell J. Funk는 2023년 <em lang="en">Nature</em>에 「Papers and patents are becoming less disruptive over time」을 실었다. 논문 4,500만 편과 특허 390만 편을 60년 시계열로 분석해, CD(Consolidate-Disrupt) 지수가 꾸준히 하락하고 있음을 보였다. 이 추세는 AI 이전부터 시작됐다. Evans 2026이 보태는 건, 그 추세가 AI로 가속된다는 점이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        그리고 결정적으로, Donghyun Kang과 James Evans가 2024년 <em lang="en">Nature Human Behaviour</em>에 게재한 「Limited diffusion of scientific knowledge forecasts collapse」가 한 줄로 못 박는다 — <strong>지식 확산의 제한이 분야 붕괴를 예측한다.</strong> -4.63%는 통계적 잡음이 아니라 collapse의 선행 신호로 읽을 학술적 근거가 동일 저자에 의해 이미 출판된 셈이다. 협업 -22%는 그 선행 신호의 동시 지표다.
+                        그리고 결정적으로, Donghyun Kang과 James Evans는 2024년 <em lang="en">Nature Human Behaviour</em>에 「Limited diffusion of scientific knowledge forecasts collapse」를 실어 한 줄로 못 박았다. <strong>지식 확산이 제한되면 분야 붕괴를 예측할 수 있다는 것.</strong> 다시 말해 −4.63%를 붕괴의 선행 신호로 읽을 근거가 같은 저자에 의해 이미 출판돼 있는 셈이다. 협업 −22%는 그 신호의 동시 지표다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -316,7 +321,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>다양성과 협업이 함께 후퇴한다는 것의 의미.</strong> -4.63%는 통계 충격이 아니라 분야 붕괴의 첫 균열로 읽혀야 한다. -22%는 그 균열이 어느 속도로 깊어지는지를 가리키는 동행 지표다. AI 이전부터 시작된 추세가 AI로 가속된다는 메타-과학의 합주가 Evans 2026·Park 2023·Kang 2024·Messeri 2024 네 편을 한 줄로 잇는다.
+                            정리하면, −4.63%는 통계적 충격이라기보다 분야 붕괴의 첫 균열로 봐야 한다. −22%는 그 균열이 어느 속도로 깊어지는지를 보여주는 동행 지표다. AI 이전부터 있던 추세가 AI로 가속된다는 흐름이 Evans 2026, Park 2023, Kang 2024, Messeri 2024 네 편을 하나로 잇는다.
                         </p>
                     </div>
                 </section>
@@ -329,12 +334,12 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans 2026의 진짜 thesis가 한 인용에 압축되어 있다. 옮긴다 — <em lang="en">"Data availability appears to be a major impacting factor, where areas with an abundance of data are increasingly and disproportionately amenable to AI research."</em> 데이터 가용성이 결정적이라는 진단. AI가 잘하는 자리에 AI가 더 몰리고, AI가 잘하기 위해서는 충분한 데이터가 필요하며, 충분한 데이터가 이미 누적된 분야로 자원이 다시 쏠린다. 이 순환이 데이터 풍부 영역과 빈약 영역의 격차를 시간 함수로 벌린다.
+                        Evans 2026의 진짜 핵심은 한 인용에 담겨 있다. <em lang="en">"Data availability appears to be a major impacting factor, where areas with an abundance of data are increasingly and disproportionately amenable to AI research."</em> 데이터 가용성이 결정적이라는 진단이다. AI가 잘하는 자리에 AI가 더 몰리고, AI가 잘하려면 충분한 데이터가 필요하며, 이미 데이터가 쌓인 분야로 자원이 다시 쏠린다. 이 순환이 데이터 풍부 영역과 빈약 영역의 격차를 시간이 갈수록 벌린다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>가로등 효과(streetlight effect)는 더 이상 비유가 아니다</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>가로등 효과는 더 이상 비유가 아니다</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        과학사회학에서 오래된 비유가 하나 있다. 술 취한 사람이 열쇠를 잃어버리고는 가로등 아래에서만 찾는다. 왜냐고 묻자 "여기가 밝으니까"라고 답한다. <strong>가로등 효과(streetlight effect)</strong>는 측정이 쉬운 곳에서만 탐색이 일어나는 편향을 가리키는 메타-과학 용어다. Julian Hoelzemann이 2024년 NBER Working Paper 32401 「The Streetlight Effect in Data-Driven Exploration」에서 이 효과를 정량화했다. AI 시대에 이 효과는 비유에서 측정 가능한 크기로 옮겨졌다 — 그 크기가 바로 Evans 2026이 보여 준 -4.63%와 -22%다.
+                        과학사회학에 오래된 비유가 있다. 술 취한 사람이 열쇠를 잃어버리고는 가로등 아래에서만 찾는다. 왜 거기서만 찾느냐고 물으니 "여기가 밝으니까"라고 답한다. <strong>가로등 효과(streetlight effect)</strong>는 측정이 쉬운 곳에서만 탐색이 일어나는 편향을 가리킨다. Julian Hoelzemann은 2024년 NBER Working Paper 32401 「The Streetlight Effect in Data-Driven Exploration」에서 이 효과를 정량화했다. AI 시대에 이 효과는 비유에서 측정 가능한 크기로 바뀌었다. 그 크기가 바로 Evans 2026이 보여준 −4.63%와 −22%다.
                     </p>
 
                     <!-- Image: Streetlight at night — streetlight effect metaphor -->
@@ -350,23 +355,23 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        가로등 효과가 작동하는 4개의 메커니즘 축을 짚어 본다.
+                        가로등 효과를 굴리는 네 갈래 갈래는 다음과 같다.
                     </p>
 
                     <ul class="space-y-3 mb-6 ml-6">
-                        <li class="themeable-text leading-relaxed"><strong>인센티브 축</strong> — 논문 건수와 인용 수가 채용·승진·연구비의 일차 지표인 한, 개인은 가장 빨리 많이 출판할 수 있는 자리를 합리적으로 선택한다. AI 도구의 효율 이득은 데이터 풍부 분야에서 극대화되므로 그 자리로 쏠림이 강화된다.</li>
-                        <li class="themeable-text leading-relaxed"><strong>계산·데이터 비용 축</strong> — 데이터 빈약 분야에서 LLM을 학습·미세조정하는 비용은 데이터 풍부 분야의 5~10배일 수 있다. 합성 데이터 보강이라는 길이 있으나 그 자체가 별도 인프라 투자다. 비용 곡선이 자원을 풍부 분야로 더 끌어당긴다.</li>
-                        <li class="themeable-text leading-relaxed"><strong>평가 지표 축</strong> — h-index, Altmetric, 인용 집중 지수 같은 평가 지표는 모두 누적적이다. 한 번 인기에 진입한 주제는 후속 인용을 더 받고, 그 인용이 다음 평가에 영향을 미친다. 매튜 효과의 도메인 수준 매튜 효과(domain-level Matthew effect) 변형이다.</li>
-                        <li class="themeable-text leading-relaxed"><strong>동료심사·자금심사 축</strong> — 심사위원이 AI 시대 패러다임에 익숙하지 않으면 빈약 분야의 새 제안은 채점이 낮게 매겨질 수 있다. Wang, Veugelers, Stephan이 2017년 <em lang="en">Research Policy</em>에 게재한 「Bias against novelty in science」가 정확히 이 신주제 패널티를 실증했다. AI 시대에 이 패널티는 더 강화될 가능성이 있다.</li>
+                        <li class="themeable-text leading-relaxed"><strong>인센티브.</strong> 논문 건수와 인용 수가 채용·승진·연구비의 일차 지표인 한, 개인은 가장 빨리 많이 출판할 수 있는 자리를 고르는 게 합리적이다. AI 도구의 효율 이득이 데이터 풍부 분야에서 가장 크니, 그쪽으로 쏠림이 강해진다.</li>
+                        <li class="themeable-text leading-relaxed"><strong>계산·데이터 비용.</strong> 데이터가 빈약한 분야에서 LLM을 학습·미세조정하는 비용은 풍부한 분야의 5~10배에 이를 수 있다. 합성 데이터로 보강하는 길이 있지만 그 자체가 별도의 인프라 투자다. 비용 곡선이 자원을 풍부 분야로 더 끌어당긴다.</li>
+                        <li class="themeable-text leading-relaxed"><strong>평가 지표.</strong> h-index, Altmetric, 인용 집중 지수 같은 지표는 모두 누적적이다. 한 번 인기에 오른 주제는 후속 인용을 더 받고, 그 인용이 다음 평가에 다시 반영된다. 매튜 효과가 분야 차원에서 작동하는 모습이다.</li>
+                        <li class="themeable-text leading-relaxed"><strong>동료심사·자금심사.</strong> 심사위원이 AI 시대 패러다임에 익숙하지 않으면 빈약 분야의 새 제안에 낮은 점수를 줄 수 있다. Wang, Veugelers, Stephan이 2017년 <em lang="en">Research Policy</em>에 실은 「Bias against novelty in science」가 바로 이 신주제 패널티를 실증했다. AI 시대에는 이 패널티가 더 강해질 여지가 있다.</li>
                     </ul>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        네 축이 따로 작동한다면 어느 한 정책 레버 — 평가 지표 개혁, 계산 비용 지원, 신주제 보조 트랙 — 로도 일부 해소할 수 있다. 그러나 4축은 서로를 강화한다. 인센티브가 풍부 분야로 몰리면 그 자리의 평가 지표가 더 누적되고, 누적된 지표는 다시 자금을 끌어오며, 그 자금이 계산 비용을 낮춰 다음 세대 연구자를 또 같은 자리로 부른다. 한 축만 풀어서는 다른 세 축이 잡아당기는 그림이다. 그래서 다음 절에서 보게 될 학술적 합주의 일치도가 의미를 갖는다 — 서로 다른 층위에서 본 세 명명이 같은 자리에 도착했다는 사실이, 이 4축 정렬이 임의가 아니라 구조적임을 가리킨다.
+                        네 갈래가 따로 작동한다면, 평가 지표 개혁이든 계산 비용 지원이든 신주제 보조 트랙이든 한 가지 정책 레버로도 일부는 풀린다. 문제는 네 갈래가 서로를 강화한다는 점이다. 인센티브가 풍부 분야로 몰리면 그 자리의 평가 지표가 더 쌓이고, 쌓인 지표가 다시 자금을 끌어오며, 그 자금이 계산 비용을 낮춰 다음 세대 연구자를 또 같은 자리로 부른다. 하나를 풀어도 나머지 셋이 잡아당기는 그림이다. 그래서 다음 절에서 볼 학술적 일치도가 의미를 갖는다. 서로 다른 층위에서 본 세 명명이 같은 결론에 도착했다는 사실이, 이 정렬이 우연이 아니라 구조적임을 가리킨다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>"lonely crowds" = "scientific monocultures" = "algorithmic monoculture"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>lonely crowds = scientific monocultures = algorithmic monoculture</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        세 명명이 한 자리에 모이면 단일 연구가 아니라 학술적 합주임이 즉시 드러난다. 다음 박스가 그 합주의 한 화면이다.
+                        세 명명을 한자리에 놓으면 단일 연구가 아니라 학계 공통의 진단임이 드러난다. 다음 카드가 그 셋을 한 화면에 모은 것이다.
                     </p>
 
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">
@@ -388,21 +393,21 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        세 연구가 같은 현상을 다른 층위에서 본다 — Evans는 학술 출판 데이터로, Messeri는 인식론·실험 설계 차원에서, Kleinberg는 알고리즘 채택·사회 후생 차원에서. 한 자리에 묶어 두면, 데이터 풍부 영역 쏠림이 단일 학자의 직관이 아니라 <strong>2021~2026 6년에 걸친 학술 공감대</strong>임이 드러난다. 정책 입안자가 "이건 한 명의 비관론자의 주장"으로 치부하기 어려운 단계에 들어선 셈이다.
+                        세 연구가 같은 현상을 다른 층위에서 본다. Evans는 학술 출판 데이터로, Messeri는 인식론·실험 설계 차원에서, Kleinberg는 알고리즘 채택과 사회 후생 차원에서. 묶어 놓으면, 데이터 풍부 영역 쏠림이 한 학자의 직관이 아니라 <strong>2021년부터 2026년까지 6년에 걸친 학계의 공감대</strong>였음이 보인다. 정책 입안자가 "비관론자 한 사람의 주장"으로 넘기기 어려운 단계에 들어선 것이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.3</span>Gini 0.754 — AI 시대의 매튜 효과</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.3</span>지니 0.754 — AI 시대의 매튜 효과</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Robert Merton이 1968년에 사회학 저널 <em lang="en">Science</em>에 발표한 <strong>매튜 효과(Matthew effect)</strong> — <strong>가진 자에게 더 주어지고 가지지 못한 자에게서는 있는 것마저 빼앗긴다</strong>는 신약 마태복음 구절을 인용한 학술 명명 — 은 과학 인용 분포의 누적 우위(cumulative advantage)를 가리킨다. Evans 2026의 인용 집중 지니 계수 <strong>0.754</strong>는 매튜 효과의 AI 시대 변형이다. 비활용 집단의 Gini 0.690과 비교하면 0.064 포인트의 차이지만, Gini 척도에서 이 차이는 상위 22.20% 논문이 인용의 80%를 흡수하는 슈퍼스타 효과를 만든다.
+                        매튜 효과(Matthew effect)는 Robert Merton이 1968년 <em lang="en">Science</em>에 발표한 개념이다. "가진 자에게 더 주어지고, 가지지 못한 자에게서는 있는 것마저 빼앗긴다"는 마태복음 구절을 빌려, 과학 인용 분포의 누적 우위(cumulative advantage)를 가리킨다. Evans 2026의 인용 집중 지니 계수 <strong>0.754</strong>는 이 효과의 AI 시대 버전이다. 비활용 집단의 0.690과 비교하면 0.064포인트 차이지만, 지니 척도에서 이 정도면 상위 22.20%의 논문이 인용의 80%를 가져가는 슈퍼스타 효과를 만든다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        매튜 효과의 도메인 수준 매튜 효과(domain-level Matthew effect) 변형은 한 가지 더 무겁다. 개별 논문 사이의 누적 우위가 아니라, <strong>분야 사이의 누적 우위</strong>다. 이미 데이터·자금·인력이 누적된 분야가 AI 도구를 통해 더 많은 데이터·자금·인력을 끌어들이고, 빈약 분야는 상대적 거리에서 더 멀어진다. 이 차원의 매튜 효과는 분야 붕괴를 가속하는 구조적 압력이다.
+                        여기서 한 가지가 더 무겁다. 분야 차원의 매튜 효과다. 개별 논문 사이의 누적 우위가 아니라 <strong>분야 사이의 누적 우위</strong> 말이다. 이미 데이터·자금·인력이 쌓인 분야가 AI 도구를 통해 더 많은 데이터·자금·인력을 끌어들이고, 빈약 분야는 상대적으로 더 멀어진다. 이 차원의 매튜 효과는 분야 붕괴를 가속하는 구조적 압력이다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>가로등 효과는 측정된 사실이다.</strong> 4축 메커니즘(인센티브·계산 비용·평가 지표·동료심사)이 알고리즘 단일문화를 생산하고, 그 단일문화가 매튜 효과의 도메인 수준 변형을 가속한다. 세 학술 명명("lonely crowds" · "scientific monocultures" · "algorithmic monoculture")이 한 자리에 모인 것은 우연이 아니라 합주다. 정책이 응답해야 할 자리가 이 자리다.
+                            정리하면 이렇다. 가로등 효과는 이제 측정된 사실이다. 네 갈래 메커니즘(인센티브·계산 비용·평가 지표·동료심사)이 알고리즘 단일문화를 만들고, 그 단일문화가 분야 차원의 매튜 효과를 가속한다. 세 명명이 한자리에 모인 건 우연이 아니라 일치다. 정책이 응답해야 할 자리가 여기다.
                         </p>
                     </div>
                 </section>
@@ -415,21 +420,21 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans 2026이 분석한 6개 분야 — 생물·의학·화학·물리·재료·지질 — 는 모두 데이터 풍부 영역이다. 이 사실 자체가 두 가지를 동시에 가리킨다. 첫째, 분석이 가능한 영역에서는 양극화가 측정 가능한 크기로 나타난다. 둘째, 측정되지 못한 영역은 더 빠르게 옅어지고 있을 가능성이 크다. <strong>수학·이론물리·철학이 처음부터 분석 대상에 포함되지 않았다는 사실 자체가 데이터 빈약 영역 누락의 메타-증거다.</strong>
+                        Evans 2026이 분석한 여섯 분야, 생물·의학·화학·물리·재료·지질은 모두 데이터 풍부 영역이다. 이 사실은 두 가지를 동시에 말한다. 첫째, 분석이 가능한 영역에서도 양극화가 측정 가능한 크기로 나타난다. 둘째, 측정조차 안 된 영역은 더 빠르게 옅어지고 있을 가능성이 크다. <strong>수학·이론물리·철학이 처음부터 분석에서 빠졌다는 사실 자체가, 데이터 빈약 영역이 어떻게 누락되는지를 보여주는 증거다.</strong>
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>NIH USD 30.1B vs NSF MPS USD 1.562B — 20배 격차의 정량</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>NIH 30.1B vs NSF MPS 1.562B — 20배 격차</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        분야 자금의 정량 격차를 보면 가로등 효과가 자금 분포 차원에서도 측정 가능한 사실임이 분명해진다. 미국 기준 NIH(생물·의학) 연간 예산은 <strong>USD 30.1B</strong>다. 같은 기간 NSF MPS — Mathematical and Physical Sciences 디비전 — 의 FY2025 예산은 수학·물리·화학·재료·천문을 모두 통합해서 <strong>USD 1.562B</strong>다. 분야별로 풀면 격차는 더 벌어지지만, 통합 수치만 봐도 약 <strong>20배</strong>. AI for Science 도구는 NIH 자금을 받는 분야로 자연스럽게 쏠린다. 데이터·자금·도구의 세 축이 같은 방향으로 정렬된 셈이다.
+                        분야별 자금 격차를 보면 가로등 효과가 돈의 분포에서도 측정된다는 게 분명해진다. 미국 기준 NIH(생물·의학) 연간 예산은 <strong>USD 30.1B</strong>다. 같은 기간 NSF MPS(Mathematical and Physical Sciences) 디비전의 FY2025 예산은 수학·물리·화학·재료·천문을 다 합쳐 <strong>USD 1.562B</strong>다. 분야별로 쪼개면 격차는 더 벌어지지만, 통합 수치만 봐도 약 <strong>20배</strong>다. AI for Science 도구는 NIH 자금이 흐르는 분야로 자연스럽게 쏠린다. 데이터·자금·도구 세 축이 같은 방향으로 정렬된다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        arXiv 월간 신규 제출의 분야별 분포도 같은 그림을 그린다. 2024-10 기준 월 24,226편 신규 제출 중 <code class="text-sm">cs.LG</code>, <code class="text-sm">cs.CV</code>, <code class="text-sm">cs.CL</code>(기계학습·컴퓨터비전·자연어처리) 세 카테고리 합계가 6,000편을 넘는다. 같은 기간 순수수학(<code class="text-sm">math.AG</code> 등)과 이론물리(<code class="text-sm">hep-th</code>)는 정체 또는 미세 증가다. 학회의 발표 분포, 박사 학위 수여 분포, 교수 채용 분포 — 거의 모든 학술 흐름이 같은 방향으로 정렬되어 있다.
+                        arXiv 월간 신규 제출의 분야 분포도 같은 그림이다. 2024년 10월 기준 월 24,226편의 신규 제출 중 <code class="text-sm">cs.LG</code>, <code class="text-sm">cs.CV</code>, <code class="text-sm">cs.CL</code>(기계학습·컴퓨터비전·자연어처리) 세 카테고리 합이 6,000편을 넘는다. 같은 기간 순수수학(<code class="text-sm">math.AG</code> 등)과 이론물리(<code class="text-sm">hep-th</code>)는 정체이거나 미세하게 늘었을 뿐이다. 학회 발표 분포, 박사 학위 수여 분포, 교수 채용 분포까지 거의 모든 흐름이 같은 방향을 향한다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>분석에서조차 빠진 분야들 — 수학·이론물리·철학</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>분석에서조차 빠진 분야 — 수학·이론물리·철학</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        다음 표가 Evans 2026이 본 분야와 보지 않은 분야의 비교다. "보지 않았다"는 것은 연구진의 결함이 아니라, 분석 가능한 데이터 자체의 비대칭을 가리킨다.
+                        다음 표는 Evans 2026이 본 분야와 보지 않은 분야의 대비다. "보지 않았다"는 건 연구진의 실수가 아니라, 분석 가능한 데이터 자체가 비대칭이라는 뜻이다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -453,13 +458,13 @@
                         <p class="text-xs themeable-muted mt-2">출처: Hao et al. 2026 분석 분야 본문, NIH FY2025 / NSF MPS FY2025 예산 공식 발표, arXiv stats(2024-10), DeepMind 발표 자료.</p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>AlphaProof의 예외성 — 빈약 영역 정면 돌파의 비용</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>AlphaProof의 예외 — 빈약 영역 돌파의 비용</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        AlphaFold 2가 생명과학에서 정점의 가속을 보여 줬다면, DeepMind의 AlphaProof와 AlphaGeometry는 수학에서 흥미로운 예외를 만들었다. 2024년 두 시스템이 결합해 IMO(국제수학올림피아드) 6문제 중 4문제를 풀어 은메달급 점수를 받았다. 이 사실은 두 가지를 동시에 가리킨다. 하나, AI는 데이터 빈약 분야에서도 정면 돌파가 가능하다. 둘, 그 정면 돌파는 막대한 양의 <strong>합성 증명 데이터</strong>(AlphaProof의 경우 1억 개 이상)를 생성해 빈약을 풍부로 인공적으로 전환한 결과다.
+                        AlphaFold 2가 생명과학에서 가속을 보여줬다면, DeepMind의 AlphaProof와 AlphaGeometry는 수학에서 흥미로운 예외를 만들었다. 2024년 두 시스템이 결합해 IMO(국제수학올림피아드) 6문제 중 4문제를 풀어 은메달급 점수를 받았다. 이 사실은 두 가지를 동시에 말한다. 하나, AI는 데이터 빈약 분야에서도 정면 돌파가 가능하다. 둘, 그 돌파는 막대한 양의 <strong>합성 증명 데이터</strong>(AlphaProof의 경우 1억 개 이상)를 생성해 빈약을 인공적으로 풍부로 바꾼 결과다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        풀어 말하면 — 빈약 영역의 정면 돌파는 가능하지만, 그 비용은 풍부 영역에서의 단순 활용 비용을 훨씬 초과한다. DeepMind 규모의 인프라를 가지지 못한 학술 연구실이 같은 길을 가기는 어렵다. 결국 풍부 영역 쏠림의 구조적 압력은 그대로 남는다. <strong>패러다임 전환(paradigm shift)</strong>이라는 Kuhn의 오래된 개념을 빌리면, AI 시대에 패러다임 전환 사이클은 일부 풍부 분야에서는 가속되고 빈약 분야에서는 둔화될 가능성이 크다. 분야 사이의 시간 흐름이 비대칭이 된다.
+                        바꿔 말하면, 빈약 영역을 돌파할 수는 있지만 그 비용은 풍부 영역에서 도구를 단순히 쓰는 비용을 훨씬 넘어선다. DeepMind 규모의 인프라가 없는 연구실이 같은 길을 가기는 어렵다. 결국 풍부 영역으로의 쏠림이라는 구조적 압력은 그대로 남는다. Kuhn의 오래된 표현을 빌리면, AI 시대의 패러다임 전환 주기는 일부 풍부 분야에서는 빨라지고 빈약 분야에서는 느려질 가능성이 크다. 분야 사이의 시간 흐름이 비대칭이 된다.
                     </p>
 
                     <!-- Image: AlphaFold protein structure — AI for Science exemplar -->
@@ -476,7 +481,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>과학의 모양이 데이터 풍부 6분야로 깊어지고, 수학·이론물리·철학에서는 옅어진다.</strong> Evans 2026 분석에서 후자가 빠진 것은 우연이 아니라 데이터·자금·도구·평가의 4축 정렬이 만든 구조적 누락이다. AlphaProof 같은 예외가 가능함을 인정하되, 그 예외의 비용 곡선이 다음 절(§7)에서 페블러스의 합성 데이터·시뮬레이션 인프라가 들어설 자리를 정확히 가리킨다.
+                            과학의 모양은 데이터 풍부 6분야에서 더 깊어지고, 수학·이론물리·철학에서는 옅어진다. Evans 2026 분석에서 후자가 빠진 건 우연이 아니라, 데이터·자금·도구·평가의 정렬이 만든 구조적 누락이다. AlphaProof 같은 예외가 가능하다는 건 인정하되, 그 예외의 비용 곡선이 다음 장(7장)에서 페블러스의 합성 데이터·시뮬레이션 인프라가 들어설 자리를 가리킨다.
                         </p>
                     </div>
                 </section>
@@ -489,7 +494,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스가 2026년 5월에 연속으로 출간한 네 편의 글은 한 시리즈를 그린다. 이번 글이 다섯 번째 좌표다. 5부작 전체의 진화 곡선은 <strong>도덕(원칙) → 학술(옵티마이저) → 학술(lifecycle) → 법(집행) → 메타(과학 자체의 모양 변화)</strong>다. 1~4가 거버넌스의 안에서였다면, 5번째는 그 위 — <strong>AI가 과학을 어떻게 다스리는가</strong>의 거울이다.
+                        페블러스가 2026년 5월에 잇따라 낸 네 편의 글은 한 시리즈를 이룬다. 이번 글이 다섯 번째다. 시리즈의 흐름은 <strong>도덕(원칙) → 학술(옵티마이저) → 학술(lifecycle) → 법(집행) → 메타(과학 자체의 변화)</strong>다. 1~4편이 거버넌스 안쪽을 다뤘다면, 다섯 번째는 그 위, <strong>AI가 과학을 어떻게 바꾸는가</strong>를 비추는 거울이다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -511,27 +516,27 @@
                         <p class="text-xs themeable-muted mt-2">출처: 페블러스 블로그 발행 기록.</p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>Nature 사설이 호명한 3축 — institutions · funders · publishers</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>Nature 사설이 지목한 세 주체 — institutions · funders · publishers</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans 2026이 발표된 지 2개월만인 <strong>2026년 3월 25일</strong>, <em lang="en">Nature</em>는 사설로 응답했다 — <em lang="en">"AI scientists are changing research — institutions, funders and publishers must respond"</em>(DOI: 10.1038/d41586-026-00934-w). 이 사설은 한 논문이 학술 의제에서 정책 의제로 격상되는 드문 사건이다. 사설은 책임을 세 축에 분배한다 — <strong>기관(institutions)</strong>은 평가 지표를 다시 설계해야 하고, <strong>자금 기관(funders)</strong>은 빈약 분야 보존 트랙을 만들어야 하며, <strong>출판사(publishers)</strong>는 AI 활용 투명성과 메타-데이터 표준을 정비해야 한다.
+                        Evans 2026이 나온 지 두 달 만인 <strong>2026년 3월 25일</strong>, <em lang="en">Nature</em>는 사설로 응답했다. <em lang="en">"AI scientists are changing research — institutions, funders and publishers must respond"</em>(DOI: 10.1038/d41586-026-00934-w). 한 편의 논문이 학술 의제에서 정책 의제로 올라서는 드문 사건이다. 사설은 책임을 세 주체에 나눈다. <strong>기관(institutions)</strong>은 평가 지표를 다시 설계하고, <strong>자금 기관(funders)</strong>은 빈약 분야를 보존하는 트랙을 만들며, <strong>출판사(publishers)</strong>는 AI 활용의 투명성과 메타데이터 표준을 정비해야 한다는 것이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이어진 후속 사설 <em lang="en">"AI grant flood must prioritize fairness as part of excellence"</em>는 자금 분배에서 우수성(excellence)이라는 단일 기준 위에 공정성(fairness)이라는 두 번째 차원을 더해야 한다고 못 박았다. 우수성만으로 평가하면 데이터 풍부 분야가 모든 자금을 가져가는 구조적 결과가 따라온다. 공정성을 보조 차원으로 두지 않으면 다양성 후퇴는 가속된다. 정책 언어로 옮긴 Evans 명제다.
+                        이어진 후속 사설 <em lang="en">"AI grant flood must prioritize fairness as part of excellence"</em>는 자금 분배에서 우수성(excellence)이라는 단일 기준 위에 공정성(fairness)이라는 두 번째 축을 더해야 한다고 못 박았다. 우수성만으로 평가하면 데이터 풍부 분야가 모든 자금을 가져가는 구조적 결과가 따라온다. 공정성을 보조 축으로 두지 않으면 다양성 후퇴는 가속된다. Evans의 명제를 정책 언어로 옮긴 셈이다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>4부작이 그린 안과 5번째가 그리는 위</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>4부작이 그린 안쪽, 5편이 그리는 위쪽</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        4부작의 4편을 한 줄로 묶어 본다. <a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a>는 AI 시대 인간 존엄의 원칙을 묻는다. <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a>는 AI 에이전트의 자가진화 옵티마이저 학술 설계를 본다. <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a>은 스킬의 lifecycle 학술 모델을 제시한다. <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>는 캐나다 4 위원회의 OpenAI 학습 데이터 규제 실집행을 다룬다. 도덕이 묻고 학술이 답하고 법이 강제하는 흐름이다.
+                        4부작을 한 줄씩 정리하면 이렇다. <a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a>는 AI 시대 인간 존엄의 원칙을 묻는다. <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a>는 AI 에이전트의 자가진화 옵티마이저를 학술적으로 다룬다. <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a>은 스킬의 lifecycle 모델을 제시한다. <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>는 캐나다 4개 위원회의 OpenAI 학습 데이터 규제 집행을 다룬다. 도덕이 묻고, 학술이 답하고, 법이 강제하는 흐름이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이번 글은 그 흐름의 위에 한 좌표를 더한다. <strong>AI가 과학 자체의 모양을 어떻게 바꾸는가</strong>라는 메타 시야. 도덕·학술·법이 거버넌스의 안에서 작동하는 동안, 그 거버넌스가 다스리는 대상인 과학 자체가 좁아지고 있다는 사실. 5부작은 거버넌스의 안과 거버넌스가 다스리는 대상의 변형을 함께 본다는 점에서 한 시리즈를 완성한다.
+                        이번 글은 그 흐름 위에 한 층을 더한다. <strong>AI가 과학 자체의 모양을 어떻게 바꾸는가</strong>라는 메타 시야다. 도덕·학술·법이 거버넌스 안쪽에서 작동하는 동안, 그 거버넌스가 다스리는 대상인 과학 자체가 좁아지고 있다. 5부작은 거버넌스의 안쪽과 그 거버넌스가 다루는 대상의 변형을 함께 본다는 점에서 하나의 시리즈로 완성된다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>5부작이 완성하는 거버넌스 지형.</strong> 도덕(원칙) · 학술(옵티마이저) · 학술(lifecycle) · 법(집행) · 메타(과학의 모양). 어느 한 좌표만 풀어도 부분적이지만, 다섯 좌표가 함께 모이면 AI 거버넌스가 어디서부터 어디까지 작동해야 하는지의 한 그림이 보인다. 페블러스의 다음 글들이 시작될 자리도 이 그림 안에서 자연스럽게 가시화된다.
+                            도덕(원칙) · 학술(옵티마이저) · 학술(lifecycle) · 법(집행) · 메타(과학의 모양). 어느 하나만 봐도 부분적이지만, 다섯이 모이면 AI 거버넌스가 어디서부터 어디까지 작동해야 하는지 윤곽이 잡힌다. 페블러스의 다음 글들이 출발할 자리도 그 안에 있다.
                         </p>
                     </div>
                 </section>
@@ -544,7 +549,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans 2026이 학술 합주의 한 악장이라면, 페블러스의 좌표는 그 합주 위에 더할 한 인프라 한 줄이다. Evans 본인이 정책 함의로 직접 한 문장을 남겼다. 옮긴다.
+                        Evans 2026이 학계 공통 진단의 한 갈래라면, 페블러스가 더하려는 건 그 위에 깔 인프라 한 줄이다. Evans 본인이 정책 함의로 직접 한 문장을 남겼다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -553,16 +558,16 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국어로 옮기면 — "AI 시대에 집단적 탐색을 보존하려면, 인지 능력만이 아니라 <strong>감각·실험 능력까지 확장하는 AI 시스템</strong>을 재상상해야 한다." 페블러스는 이 한 문장을 직접적인 학술적 정당화로 받는다. <strong>DataGreenhouse</strong>가 감각의 확장(빈약 분야 합성 데이터 공급)이고, <strong>PebbloSim</strong>이 실험의 확장(시뮬레이션을 통한 실험 비용·사각지대 보강)이다. Evans의 정책 함의가 페블러스 제품 라인의 학술적 좌표를 정확히 짚는다.
+                        우리말로 옮기면 이렇다. "AI 시대에 집단적 탐색을 지키려면, 인지 능력만이 아니라 <strong>감각·실험 능력까지 확장하는 AI 시스템</strong>을 다시 상상해야 한다." 페블러스는 이 문장을 제품의 직접적인 학술적 근거로 받는다. <strong>DataGreenhouse</strong>가 감각의 확장(빈약 분야에 합성 데이터를 공급)이고, <strong>PebbloSim</strong>이 실험의 확장(시뮬레이션으로 실험 비용과 사각지대를 메움)이다. Evans의 정책 함의가 페블러스 제품 라인의 좌표를 그대로 짚는다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>DataClinic 7번째 신호 — "지식 다양성"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>DataClinic의 일곱 번째 신호 — "지식 다양성"</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        DataClinic은 지금까지 6개의 데이터 품질 신호로 데이터셋 내부 품질을 진단해 왔다 — <strong>완전성(completeness) · 정확성(accuracy) · 일관성(consistency) · 시의성(timeliness) · 고유성(uniqueness) · 합법성(legality)</strong>. 마지막 합법성은 <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">4부작 4편 PIPEDA 글</a>에서 추가된 6번째 신호다. 이번 글은 한 신호를 더 제안한다 — <strong>지식 다양성(Knowledge Diversity)</strong>이라는 7번째 신호.
+                        DataClinic은 지금까지 여섯 개의 데이터 품질 신호로 데이터셋 내부를 진단해 왔다. <strong>완전성(completeness), 정확성(accuracy), 일관성(consistency), 시의성(timeliness), 고유성(uniqueness), 합법성(legality)</strong>. 마지막 합법성은 <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">4부작 4편 PIPEDA 글</a>에서 더해진 여섯 번째 신호다. 이번 글은 일곱 번째를 제안한다. <strong>지식 다양성(Knowledge Diversity)</strong>이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        기존 6신호는 데이터셋 <strong>내부</strong>의 품질을 본다. 7번째 신호는 데이터셋 <strong>외부</strong>를 본다 — <strong>어느 분야가 빠져 있는가</strong>를. 다음 박스가 운영적 정의의 첫 그림이다.
+                        기존 여섯 신호는 데이터셋 <strong>안쪽</strong>을 본다. 일곱 번째 신호는 <strong>바깥</strong>을 본다. 어느 분야가 빠져 있는지를 묻는다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -587,16 +592,16 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        7번째 신호의 운영적 정의를 풀어 본다. <strong>측정</strong>은 분야 임베딩 공간에서 학습 코퍼스의 커버리지 분포를 계산하고, 인접 빈약 영역과의 거리·균등도를 측정한다. <strong>신호</strong>는 Gini 임계치(예: 0.7 초과 시 경고), 분야 누락률(NSF/NIH 분류 기준), "lonely cluster" 점수(인접 클러스터와의 연결 강도)다. <strong>적용</strong>은 AI 모델 학습 전 코퍼스 진단 단계에 들어가, 빈약 영역의 합성 데이터 보강을 권고하는 단계로 이어진다. DataGreenhouse가 그 보강의 실행 도구가 된다.
+                        일곱 번째 신호의 운영 정의는 이렇게 잡을 수 있다. <strong>측정</strong>은 분야 임베딩 공간에서 학습 코퍼스의 커버리지 분포를 계산하고, 인접한 빈약 영역과의 거리·균등도를 잰다. <strong>신호</strong>는 지니 임계치(예: 0.7 초과 시 경고), 분야 누락률(NSF/NIH 분류 기준), 그리고 인접 클러스터와의 연결 강도를 보는 "lonely cluster" 점수다. <strong>적용</strong>은 AI 모델 학습 전 코퍼스 진단 단계에 들어가, 빈약 영역에 합성 데이터를 보강하라고 권고하는 데까지 이어진다. 그 보강을 실제로 수행하는 도구가 DataGreenhouse다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>한국 AI4Science 정책의 다양성 메커니즘 공백</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>한국 AI4Science 정책에 빠진 다양성 장치</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국 AI4Science 정책은 빠르고 야심차다. 그러나 다양성 메커니즘은 부재하다는 진단이 가능하다. 2026년 정부 R&amp;D 35.5조원(전년 대비 +19.9%) 중 AI 예산 10.1조원, 그 안에서 "AI 활용 과학기술 연구개발 혁신" 직접 항목이 <strong>6,000억원</strong>이다. NRF AI+S&amp;T 6대 분야는 — <strong>바이오·재료화학·지구과학·반도체·에너지·이차전지</strong> — 모두 데이터 풍부 영역이다. 2026 AI Co-Scientist Challenge Korea(상금 19억원) Track 1에 수학이 포함된 것은 작은 진전이지만, 평가 기준에 다양성 지표는 없다.
+                        한국의 AI4Science 정책은 빠르고 야심차다. 다만 다양성을 지키는 장치는 보이지 않는다. 2026년 정부 R&amp;D 35.5조원(전년 대비 +19.9%) 중 AI 예산이 10.1조원이고, 그 안에서 "AI 활용 과학기술 연구개발 혁신" 직접 항목이 <strong>6,000억원</strong>이다. NRF AI+S&amp;T 6대 분야(<strong>바이오·재료화학·지구과학·반도체·에너지·이차전지</strong>)는 모두 데이터 풍부 영역이다. 2026 AI Co-Scientist Challenge Korea(상금 19억원) Track 1에 수학이 포함된 건 작은 진전이지만, 평가 기준에 다양성 지표는 없다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        가장 큰 변수는 4개 과기원의 <strong>이노코어(InnoCORE) 박사후 400명</strong> 사업이다. KAIST 단독 200명을 포함해 연봉 9천만원 트랙으로 운영된다. 이 400명이 어느 분야로 흘러가는지가 향후 5~10년 한국 과학의 모양을 결정한다. 6대 분야가 모두 데이터 풍부 영역인 채로 400명이 같은 자리로 쏠리면, Evans 2026이 미국에서 측정한 -4.63%·-22%의 한국판이 한국에서 측정될 가능성이 크다.
+                        가장 큰 변수는 4개 과기원의 <strong>이노코어(InnoCORE) 박사후 400명</strong> 사업이다. KAIST 단독 200명을 포함해 연봉 9천만원 트랙으로 운영된다. 이 400명이 어느 분야로 흘러가는지가 앞으로 5~10년 한국 과학의 모양을 좌우한다. 6대 분야가 모두 데이터 풍부 영역인 채로 400명이 같은 자리로 쏠리면, Evans 2026이 미국에서 측정한 −4.63%·−22%의 한국판이 나올 가능성이 크다.
                     </p>
 
                     <!-- Image: KAIST campus building — InnoCORE/Korea AI4Science visual -->
@@ -612,21 +617,21 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        산업 차원에서는 LG AI연구원의 <strong>EXAONE Discovery</strong>가 정점 사례다. 4천만 종의 물질을 1일에 검토할 수 있는 AI 시스템으로, 신소재·신약 개발 자동화의 한국 정점이다. 데이터 풍부 분야 자동화의 정점에 EXAONE Discovery가 섰다는 사실은 박수받을 일이다. 동시에, 그 자동화가 다루지 못하는 빈약 영역의 인프라가 누구의 책임으로 어디서 만들어지는지가 빈 자리로 남는다. 페블러스가 그 빈 자리의 한 좌표에 설 수 있다.
+                        산업 쪽 대표 사례는 LG AI연구원의 <strong>EXAONE Discovery</strong>다. 4천만 종의 물질을 하루에 검토할 수 있는 AI 시스템으로, 신소재·신약 개발 자동화의 한국 정점에 있다. 데이터 풍부 분야 자동화의 정점에 EXAONE Discovery가 섰다는 건 박수받을 일이다. 동시에, 그 자동화가 다루지 못하는 빈약 영역의 인프라를 누가 어디서 만들 것인가는 빈자리로 남는다. 페블러스가 그 자리에 설 수 있다.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.3</span>"과학 다양성 인프라"라는 신규 카테고리</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.3</span>"과학 다양성 인프라"라는 새 카테고리</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스가 이번 글로 그리는 정체성은 한 줄로 옮길 수 있다 — <strong>과학 다양성 인프라(Scientific Diversity Infrastructure)</strong>. 데이터 진단(DataClinic) · 합성(DataGreenhouse) · 시뮬레이션(PebbloSim)의 3단이 단순 제품 사업이 아니라, Evans·Park·Messeri·Kleinberg가 그려 온 학술 합주에 합류하는 인프라 사업자 정체성으로 격상된다. 자동 연구 에이전트(Sakana AI Scientist v2, Google Co-Scientist, FutureHouse Crow/Falcon/Owl/Phoenix, LG EXAONE Discovery) 레이스에 같은 트랙으로 합류하지 않는다. 그 에이전트들이 학습할 데이터를 빈약 영역에 공급하는 <strong>한 층 아래</strong>의 인프라 레이어가 페블러스의 좌표다.
+                        이번 글로 페블러스가 그리는 정체성은 한 줄로 옮길 수 있다. <strong>과학 다양성 인프라(Scientific Diversity Infrastructure)</strong>다. 데이터 진단(DataClinic), 합성(DataGreenhouse), 시뮬레이션(PebbloSim)의 세 단계가 단순한 제품 사업을 넘어, Evans·Park·Messeri·Kleinberg가 그려 온 진단에 합류하는 인프라 사업자의 정체성으로 올라선다. 자동 연구 에이전트(Sakana AI Scientist v2, Google Co-Scientist, FutureHouse Crow/Falcon/Owl/Phoenix, LG EXAONE Discovery) 경쟁에 같은 트랙으로 뛰어들지는 않는다. 그 에이전트들이 학습할 데이터를 빈약 영역에 공급하는, <strong>한 층 아래</strong>의 인프라 레이어가 페블러스의 자리다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        자매 글 한 편을 함께 읽기를 권한다. <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a>는 AI for Science의 새 시대 도래를 산업·정책 관점에서 그렸다. 이번 글이 메타·과학사회학 관점에서 그 시대의 그림자를 짚었다면, 자매 글은 같은 시대의 빛 쪽을 본다. 한 시대를 양쪽에서 함께 보는 두 좌표가 페블러스 시리즈에 자연스럽게 자리 잡는다.
+                        자매 글도 함께 읽기를 권한다. <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a>는 AI for Science의 새 시대를 산업·정책 관점에서 그렸다. 이번 글이 메타·과학사회학 관점에서 그 시대의 그림자를 짚었다면, 자매 글은 같은 시대의 빛을 본다. 한 시대를 양쪽에서 보는 두 글이다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>Evans의 한 문장이 페블러스의 학술적 좌표를 정확히 짚었다.</strong> "sensory and experimental capacity의 확장"이 곧 DataGreenhouse·PebbloSim의 정당화다. DataClinic은 진단의 단계, DataGreenhouse는 보강의 단계, PebbloSim은 시뮬레이션의 단계 — 이 3단이 곧 과학 다양성 인프라의 한 그림이다. DataClinic의 7번째 신호 "지식 다양성"이 이번 글의 한 가지 액션 아이템이다.
+                            Evans의 한 문장이 페블러스의 학술적 좌표를 정확히 짚었다. "감각·실험 능력의 확장"이 곧 DataGreenhouse·PebbloSim의 근거다. DataClinic은 진단, DataGreenhouse는 보강, PebbloSim은 시뮬레이션. 이 세 단계가 곧 과학 다양성 인프라다. 그리고 DataClinic의 일곱 번째 신호 "지식 다양성"이 이번 글이 내놓는 실행 항목이다.
                         </p>
                     </div>
                 </section>
@@ -639,24 +644,24 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        4,130만 편이라는 표본 위에 +3.02배와 -4.63%가 같은 화면에 떠 있다는 사실 — 이것이 이번 글이 끝맺어야 할 자리다. 개인의 가속과 집단의 좁아짐이 같은 시대의 두 얼굴이다. 어느 한쪽만 선택할 수 있는 선택지가 아니라, <strong>둘을 함께 살아내야 하는 시대</strong>가 시작됐다는 사실의 확인이다.
+                        4,130만 편이라는 표본 위에 +3.02배와 −4.63%가 함께 떠 있다. 이 글이 끝나야 할 자리가 거기다. 개인의 가속과 집단의 좁아짐은 같은 시대의 두 얼굴이다. 둘 중 하나만 고르는 문제가 아니라, <strong>둘을 함께 살아내야 하는 시대</strong>가 시작됐다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지 솔직한 인정이 필요하다. AlphaFold 2가 단백질 폴딩에 가져다 준 가속은 진짜다. GNoME가 38만 종의 안정 무기 결정을 발견한 것은 인류 과학사의 한 칸이다. AlphaProof·AlphaGeometry가 IMO 은메달급 수학 추론을 보여 준 것은 빈약 영역의 정면 돌파가 가능함을 증명했다. 자동 연구 에이전트의 시대도 빠르게 다가오고 있다. 가속을 폄하할 필요는 없다. 그러나 가속만 본 시야는 -4.63%와 -22%를 놓친다. 가속과 좁아짐 둘 다를 보는 시야가 필요하다.
+                        솔직히 인정할 게 있다. AlphaFold 2가 단백질 폴딩에 가져온 가속은 진짜다. GNoME가 38만 종의 안정 무기 결정을 찾아낸 것은 과학사의 한 칸이다. AlphaProof와 AlphaGeometry가 IMO 은메달급 수학 추론을 보여준 것은 빈약 영역도 돌파될 수 있음을 증명했다. 자동 연구 에이전트의 시대도 빠르게 다가온다. 가속을 폄하할 이유는 없다. 다만 가속만 보는 시야는 −4.63%와 −22%를 놓친다. 가속과 좁아짐을 함께 보는 시야가 필요하다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans가 정책 함의로 남긴 한 문장을 다시 읽어 본다 — <em lang="en">"reimagine AI systems that expand not only cognitive capacity but also sensory and experimental capacity."</em> 인지의 확장만이 아니라 감각·실험의 확장. 이 한 줄이 다음 시대의 한 가지 설계 원칙이다. AI가 자동화할 수 있는 자리에서 자동화의 가속을 누리되, AI가 잘 다루지 못하는 자리에 합성 데이터와 시뮬레이션과 다양성 진단의 인프라를 깐다. 두 가지가 동시에 진행되어야 가속과 좁아짐을 함께 사는 시대의 균형이 가능하다.
+                        Evans가 정책 함의로 남긴 문장을 다시 읽는다. <em lang="en">"reimagine AI systems that expand not only cognitive capacity but also sensory and experimental capacity."</em> 인지의 확장만이 아니라 감각과 실험의 확장. 이 한 줄이 다음 시대의 설계 원칙이 될 만하다. AI가 자동화할 수 있는 자리에서는 가속을 누리되, AI가 잘 다루지 못하는 자리에는 합성 데이터와 시뮬레이션, 다양성 진단의 인프라를 깐다. 두 일이 동시에 진행돼야 가속과 좁아짐을 함께 사는 시대의 균형이 가능하다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이번 글이 끝나는 자리에서 다음 질문들이 시작된다. <strong>DataClinic 7번째 신호 "지식 다양성"의 측정 도구를 어떻게 구체화할 것인가. DataGreenhouse가 우선 보강해야 할 빈약 분야의 우선순위는 어떻게 정할 것인가. 이노코어 박사후 400명의 분야 분포를 다양성 차원에서 어떻게 모니터링할 것인가. NRF AI+S&amp;T 6대 분야의 다음 차수에 빈약 영역 트랙이 어떻게 추가될 수 있는가.</strong> 이 질문들은 한 편의 글이 답할 수 있는 범위를 넘는다. 페블러스가 다음 글들에서 천천히 풀어 갈 자리다.
+                        그러면 다음 질문들이 남는다. 빈약한 분야의 다양성을 어떻게 측정할 것인가. 어디부터 데이터를 채워 넣을 것인가. 이노코어 박사후 400명의 분야 분포를, NRF 6대 분야의 다음 차수를 다양성 관점에서 어떻게 볼 것인가. 한 편의 글이 답할 범위를 넘는 질문들이고, 마침 페블러스가 'Agentic AI 데이터 과학자' 과제에서 마주하고 있는 질문이기도 하다. 구체적인 답은 다른 글에서 이어가려 한다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>네 명의 학자가 4,130만 편 위에 그은 한 좌표가 한 시대의 결을 보여 줬다.</strong> 개인은 강해진다, 과학은 좁혀진다. 두 명제가 동시에 참이라는 사실의 확인이 이번 글의 시작이자, 페블러스의 다음 작업의 출발선이다. <strong>과학 다양성도 진단 대상이다 — 그리고 그 진단 위에 보강과 시뮬레이션의 인프라가 따라온다.</strong> 한 줄이 이번 글의 끝이자 5부작의 한 매듭이다.
+                            네 명의 학자가 4,130만 편 위에 남긴 결론은 단순하다. <strong>개인은 강해지고, 과학은 좁아진다.</strong> 두 명제가 동시에 참이다. 가속을 누리면서도 그 그늘에서 비어가는 분야를 함께 보는 시야. 이 연구가 남긴 가장 중요한 숙제가 그것이다.
                         </p>
                     </div>
 

--- a/report/ai-tools-expand-impact-contract-science/ko/index.html
+++ b/report/ai-tools-expand-impact-contract-science/ko/index.html
@@ -89,7 +89,7 @@
                 <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
                     <li><a href="#executive-summary" class="block pl-4 themeable-toc-link transition-colors duration-200">Executive Summary</a></li>
                     <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. 4,130만 편이 말하는 것</a></li>
-                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. 개인의 승리 — 3배·4.8배·1.4년</a></li>
+                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. 개인의 승리 — 생산성·영향력·리더십의 도약</a></li>
                     <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. 집단의 손실 — 다양성·협업의 후퇴</a></li>
                     <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. 왜 데이터 풍부한 곳만 더 풍부해지는가</a></li>
                     <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. 과학의 모양이 바뀌고 있다</a></li>
@@ -217,7 +217,7 @@
                 <section id="section-2" class="mb-16 fade-in-card">
                     <div class="flex items-center gap-4 mb-8">
                         <span class="number-badge">2</span>
-                        <h2 class="text-3xl font-bold themeable-heading">개인의 승리 — 3배·4.8배·1.4년</h2>
+                        <h2 class="text-3xl font-bold themeable-heading">개인의 승리 — 생산성·영향력·리더십의 도약</h2>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">

--- a/report/ai-tools-expand-impact-contract-science/ko/index.html
+++ b/report/ai-tools-expand-impact-contract-science/ko/index.html
@@ -114,26 +114,24 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            AI는 과학자 개인을 훨씬 강하게, 과학 전체는 더 좁게 만들었다. 2026년 1월 <em lang="en">Nature</em>에 실린 4,130만 편 분석의 결론이다. AI를 쓰는 연구자는 동료보다 논문을 3배 더 내지만, 정작 과학이 다루는 주제의 폭은 줄었다. 모두가 데이터 많은 인기 분야로 몰리기 때문이다. 개인은 이기고, 과학은 좁아진다 — 한 연구가 정반대 두 방향을 동시에 가리켰다.
+                            AI는 과학자 개인을 훨씬 강하게, 과학 전체는 더 좁게 만들었다. 2026년 1월 <em lang="en">Nature</em>에 실린 <a href="https://www.nature.com/articles/s41586-025-09922-y" target="_blank" rel="noopener" class="text-orange-500 hover:underline">4,130만 편 분석</a>의 결론이다. AI를 쓰는 연구자는 동료보다 논문을 3배 더 내지만, 정작 과학이 다루는 주제의 폭은 줄었다. 모두가 이미 데이터가 많이 쌓인 인기 분야로 몰리기 때문이다. 개인은 이기고, 과학은 좁아진다. 한 연구가 정반대 두 방향을 동시에 가리켰다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            흘려들을 얘기가 아니다. 표본이 4,130만 편, 시계열이 23년이고, 책임저자는 이 주제를 11년간 파 온 시카고대 James Evans다. 논문이 나온 지 두 달 만에 <em lang="en">Nature</em>는 "기관·자금기관·출판사가 대응해야 한다"는 사설을 냈다. 한국도 돈을 쏟는 중이다. 정부 AI 예산 10조원, 이노코어 박사후 400명, AI Co-Scientist Challenge까지. 문제는 그 자금이 향하는 6대 분야가 전부 데이터 풍부 영역이고, 다양성을 지킬 장치는 없다는 점이다.
+                            흘려들을 얘기가 아니다. 표본이 4,130만 편, 시계열이 23년이고, 책임저자는 이 주제를 11년간 파 온 시카고대 James Evans다. 논문이 나온 지 두 달 만에 <em lang="en">Nature</em>는 사설을 통해 평가 지표·자금 분배·출판 표준을 다시 설계할 것을 기관·자금기관·출판사 세 주체에 요구했다. 한국도 같은 방향에서 자금을 쏟는 중이다. 2026년 정부 AI 예산 10조원이 6대 과학 분야(바이오·재료화학·지구과학·반도체·에너지·이차전지)에 흘러들고, 이노코어 박사후 400명 사업과 AI Co-Scientist Challenge가 그 자금의 손과 발이 된다. 문제는 그 6대 분야가 모두 이미 데이터(논문·실험치·데이터셋)가 풍부히 쌓인 영역이고, 자금이 다루는 주제의 범위를 넓게 유지할 장치는 빠져 있다는 점이다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            그래서 남는 질문은 분명하다. 자금과 인재가 데이터 풍부한 6대 분야로 쏠릴 때, 비어가는 분야는 누가 떠받치는가. Evans 본인은 "인지 능력만이 아니라 감각·실험 능력까지 확장하는 AI"가 필요하다고 했다. 측정되지 않는 분야를 측정하고, 데이터가 없는 곳에 데이터를 만들어주는 일이다. 4부작(<a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> · <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>) 다음의 메타·과학사회학 좌표로서, 이번 글은 페블러스를 "데이터 진단·합성 기업"에서 <strong>과학 다양성 인프라</strong> 카테고리 리더로 격상한다. 더할 한 가지 실행 항목은 DataClinic의 일곱 번째 신호 <strong>"지식 다양성"</strong>이다.
+                            그래서 남는 질문은 분명하다. 자금과 인재가 데이터가 풍부한 6대 분야로 쏠릴 때, 데이터가 없는 분야(수학·이론물리·철학·사회과학)는 누가 떠받치는가. Evans 본인은 "인지 능력만이 아니라 감각·실험 능력까지 확장하는 AI"가 필요하다고 했다. 데이터가 없어서 정량화되지 못한 분야를 측정 가능한 형태로 옮기고, 빈약한 자리에 합성 데이터를 만들어 채우는 일이다. 이 자리에서 페블러스의 다음 한 줄, 데이터 진단(DataClinic)의 일곱 번째 신호 <strong>"지식 다양성"</strong>이 시작된다.
                         </p>
                     </div>
 
                     <!-- Editor's Note -->
                     <blockquote class="themeable-card rounded-xl p-5 my-6 themeable-text leading-relaxed">
-                        <p><em>Editor's Note.</em> 데이터와 AI의 편향을 측정하는 일이라면 페블러스는 늘 구미가 당긴다. 그게 과학에서 벌어지는 문제라면 더욱 그렇다. 마침 페블러스는 'Agentic AI 데이터 과학자' 과제를 수행하고 있다. AI 기반 데이터 과학의 영역이 점점 넓어지는 지금, 이 연구는 그 한가운데에 중요한 질문 하나를 던졌다.</p>
+                        <p><strong><em>편집자의 노트.</em></strong> 데이터와 AI의 편향을 측정하는 일이라면 페블러스는 늘 구미가 당긴다. 그게 과학에서 벌어지는 문제라면 더욱 그렇다. 마침 페블러스는 'Agentic AI 데이터 과학자' 과제를 수행하고 있다. AI 기반 데이터 과학의 영역이 점점 넓어지는 지금, 이 연구는 그 한가운데에 중요한 질문 하나를 던졌다. 이 글은 그간의 AI 거버넌스 4부작(<a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> · <a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline">PIPEDA</a>)에 이어 '지식의 다양성'에 대한 질문에 답해 보려는 다섯 번째 글이다.</p>
                     </blockquote>
 
                     <!-- Stat Cards -->
-                    <p class="themeable-text leading-relaxed mt-8 mb-6">
-                        한 논문이 그은 좌표를 숫자로 펼치면 역설의 결이 또렷해진다. 4,130만 편 위에 개인 쪽 두 칸과 집단 쪽 두 칸을 같은 화면에 놓으면 한 문장이 즉시 읽힌다. 둘 다, 단 반대 방향으로.
-                    </p>
-                    <p class="themeable-text-secondary text-sm mb-3">출처: Hao, Xu, Li, Evans (2026), <em lang="en">Nature</em> 649, pp. 1237–1243. DOI: 10.1038/s41586-025-09922-y. arXiv:2412.07727v4.</p>
+                    <h3 class="text-xl font-semibold themeable-heading mt-8 mb-3">주요 수치</h3>
+                    <p class="themeable-text-secondary text-sm mb-3">출처: <a href="https://www.nature.com/articles/s41586-025-09922-y" target="_blank" rel="noopener" class="text-orange-500 hover:underline">Hao, Xu, Li, Evans (2026), <em lang="en">Nature</em> 649, pp. 1237–1243</a>. DOI: 10.1038/s41586-025-09922-y. arXiv:2412.07727v4.</p>
                     <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">+3.02배</p>
@@ -166,7 +164,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        "AI는 과학을 돕는가, 망치는가." 새 논쟁이 아니다. AlphaFold 2가 단백질 폴딩을 사실상 풀어낸 2021년 <em lang="en">Nature</em> 논문 이후, 한쪽은 "AI 덕분에 과학이 황금기에 들어섰다"고 했고 다른 쪽은 "AI가 환각을 일으키고 연구를 얕게 만든다"고 맞섰다. 양쪽 다 일화와 직관에 기댔다. <strong>2026년 1월 <em lang="en">Nature</em> Vol. 649에 실린 한 논문이 그 자리에 4,130만 편의 데이터를 깔았다.</strong>
+                        "AI는 과학을 돕는가, 망치는가." 새 논쟁이 아니다. <a href="https://www.nature.com/articles/s41586-021-03819-2" target="_blank" rel="noopener" class="text-orange-500 hover:underline">AlphaFold 2</a>가 단백질 폴딩을 사실상 풀어낸 2021년 <em lang="en">Nature</em> 논문 이후, 한쪽은 "AI 덕분에 과학이 황금기에 들어섰다"고 했고 다른 쪽은 "AI가 환각을 일으키고 연구를 얕게 만든다"고 맞섰다. 양쪽 다 일화와 직관에 기댔다. <strong>2026년 1월 <em lang="en">Nature</em> Vol. 649에 실린 한 논문이 그 자리에 4,130만 편의 데이터를 깔았다.</strong>
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -460,7 +458,7 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>AlphaProof의 예외 — 빈약 영역 돌파의 비용</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        AlphaFold 2가 생명과학에서 가속을 보여줬다면, DeepMind의 AlphaProof와 AlphaGeometry는 수학에서 흥미로운 예외를 만들었다. 2024년 두 시스템이 결합해 IMO(국제수학올림피아드) 6문제 중 4문제를 풀어 은메달급 점수를 받았다. 이 사실은 두 가지를 동시에 말한다. 하나, AI는 데이터 빈약 분야에서도 정면 돌파가 가능하다. 둘, 그 돌파는 막대한 양의 <strong>합성 증명 데이터</strong>(AlphaProof의 경우 1억 개 이상)를 생성해 빈약을 인공적으로 풍부로 바꾼 결과다.
+                        <a href="https://www.nature.com/articles/s41586-021-03819-2" target="_blank" rel="noopener" class="text-orange-500 hover:underline">AlphaFold 2</a>가 생명과학에서 가속을 보여줬다면, DeepMind의 AlphaProof와 AlphaGeometry는 수학에서 흥미로운 예외를 만들었다. 2024년 두 시스템이 결합해 IMO(국제수학올림피아드) 6문제 중 4문제를 풀어 은메달급 점수를 받았다. 이 사실은 두 가지를 동시에 말한다. 하나, AI는 데이터 빈약 분야에서도 정면 돌파가 가능하다. 둘, 그 돌파는 막대한 양의 <strong>합성 증명 데이터</strong>(AlphaProof의 경우 1억 개 이상)를 생성해 빈약을 인공적으로 풍부로 바꾼 결과다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">

--- a/report/ai-tools-expand-impact-contract-science/ko/index.html
+++ b/report/ai-tools-expand-impact-contract-science/ko/index.html
@@ -669,13 +669,13 @@
                         <p class="themeable-text leading-relaxed text-sm mb-4">
                             이번 글은 페블러스 AI 거버넌스 5부작의 다섯 번째 좌표(메타 · 과학사회학)입니다. 도덕 → 학술 → 학술 → 법 → 메타의 다섯 좌표가 AI 거버넌스의 전체 지형을 그립니다.
                         </p>
-                        <ul class="text-sm space-y-2">
-                            <li><a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline"><strong>① Magnifica Humanitas</strong></a> — 도덕 · 신학 (2026-05-25)</li>
-                            <li><a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline"><strong>② SkillOpt</strong></a> — 학술 · 옵티마이저 (2026-05-27)</li>
-                            <li><a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline"><strong>③ MUSE-Autoskill</strong></a> — 학술 · lifecycle (2026-05-28)</li>
-                            <li><a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline"><strong>④ PIPEDA</strong></a> — 법 · 규제 실집행 (2026-05-29)</li>
-                            <li class="font-bold themeable-heading"><strong>⑤ 이번 글</strong> — 메타 · 과학사회학 (2026-05-31)</li>
-                        </ul>
+                        <ol class="list-decimal list-inside text-sm space-y-2">
+                            <li><a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline"><strong>Magnifica Humanitas</strong></a> — 도덕 · 신학 (2026-05-25)</li>
+                            <li><a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline"><strong>SkillOpt</strong></a> — 학술 · 옵티마이저 (2026-05-27)</li>
+                            <li><a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline"><strong>MUSE-Autoskill</strong></a> — 학술 · lifecycle (2026-05-28)</li>
+                            <li><a href="/report/openai-pipeda-ai-training-data-regulation/ko/" class="text-orange-500 hover:underline"><strong>PIPEDA</strong></a> — 법 · 규제 실집행 (2026-05-29)</li>
+                            <li class="font-bold themeable-heading"><strong>이번 글</strong> — 메타 · 과학사회학 (2026-05-31)</li>
+                        </ol>
                         <p class="themeable-text-secondary text-sm mt-4">
                             자매 글 — <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a> (AI for Science 산업·정책 관점).
                         </p>


### PR DESCRIPTION
## Summary
PR #247 머지 이후 JH 피드백 4 라운드를 모은 후속 PR.

## 커밋 (시간 순)
1. **0d9516c8** — KO 산문 voice-edit (em-dash 117→53, JH 보이스로 리라이트)
2. **187ee700** — Exec Summary 명확화 (9개 피드백 일괄)
   - Nature 논문 + AlphaFold 외부 링크 추가
   - 2단락: 한국 정책 구체 명시·데이터 풍부 의미 풀이
   - 3단락: 빈약 분야 예시(수학·이론물리·철학·사회과학) 명시
   - 5부작 자기홍보를 Editor's Note로 이동
   - "좌표로서" → "다섯 번째 글"
   - "Editor's Note." → **편집자의 노트** (Italic Bold)
   - Stat Cards 위 패러독스 문단 → "주요 수치" h3
3. **3a880402** — 시리즈 안내 카드 ul+①~⑤ 중복 → ol 통일
4. **51137ae2** — §2 제목 정성화: "3배·4.8배·1.4년" → "생산성·영향력·리더십의 도약"

## 변경 통계
- 1 file changed
- em-dash 117 → 52개 (1/237자 → 1/494자)
- 외부 링크 추가: Evans Nature DOI 3곳 + AlphaFold 3곳
- 모든 수치(43개), 이미지(5장), 인용(15개), 시리즈 링크(15개) 보존

## Test plan
- [ ] KO 페이지에서 Exec Summary의 5부작 자기홍보가 사라지고 Editor's Note에 자연스럽게 통합됐는지
- [ ] Stat Cards 위 "주요 수치" 제목 + 출처 라인 링크 동작
- [ ] §2 제목 TOC + H2 양쪽에서 "생산성·영향력·리더십의 도약"으로 표시
- [ ] §8 끝의 시리즈 안내 카드 — 자동 1·2·3·4·5 번호, 동그라미 숫자 없음
- [ ] AlphaFold 2 첫 등장(§1)과 §5 본문에서 Nature 외부 링크 동작
- [ ] 모든 수치·인용·이미지 보존

## 다음 작업 (별도)
- ko-prose-humanizer 스킬 등록 + blog-produce/report-produce-express 파이프라인 연결
- docs/ai-tone-detection.md (BlogScope 등 외부 참조용 문서) 작성
- blog-service 레포 미러링

🤖 Generated with [Claude Code](https://claude.com/claude-code)