### PR TITLE
voice(report): Evans Nature 2026 EN — KO 동등 수준 voice-edit (em-dash 143→70)

### DIFF
--- a/report/ai-tools-expand-impact-contract-science/en/index.html
+++ b/report/ai-tools-expand-impact-contract-science/en/index.html
@@ -89,7 +89,7 @@
                 <ul id="toc-links" class="space-y-3 text-sm border-l-2 themeable-toc-border">
                     <li><a href="#executive-summary" class="block pl-4 themeable-toc-link transition-colors duration-200">Executive Summary</a></li>
                     <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. What 41.3M Papers Are Saying</a></li>
-                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. The Individual Victory — 3x · 4.8x · 1.4 Years</a></li>
+                    <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. The Individual Victory — A Leap in Productivity, Influence, and Leadership</a></li>
                     <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. The Collective Loss — Diversity & Collaboration Retreat</a></li>
                     <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. Why the Data-Rich Get Richer</a></li>
                     <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. The Shape of Science Is Changing</a></li>
@@ -114,21 +114,24 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            "Does AI help science or hurt it?" An old argument, finally given an empirical answer at scale. In January 2026, <em>Nature</em> published the first study to weigh 41.3 million papers on this question. James Evans (University of Chicago Knowledge Lab) and Yong Li (Tsinghua), with co-authors Qianyue Hao and Fengli Xu, published "Artificial intelligence tools expand scientists' impact but contract science's focus" (DOI: 10.1038/s41586-025-09922-y, Vol. 649, pp. 1237–1243). Using a BERT-based classifier (F1 = 0.875, five-expert Fleiss' Kappa 0.964) across 23 years of papers in six natural-science fields — biology, medicine, chemistry, physics, materials science, geology — the team nailed down a finding that had long lived only in anecdotes: AI adoption pushes individual utility and collective breadth in opposite directions. This is not a one-off study. It is the apex of the "narrowing of science" thesis that Evans Lab has been tracking since its 2015 paper in <em>American Sociological Review</em>, and one movement in a seven-year meta-science chord that also includes Park · Funk 2023 <em>Nature</em>, Messeri · Crockett 2024 <em>Nature</em>, and Kleinberg · Raghavan 2021 <em>PNAS</em>.
+                            AI has made individual scientists much stronger and the field of science as a whole much narrower. That is the conclusion of a <a href="https://www.nature.com/articles/s41586-025-09922-y" target="_blank" rel="noopener" class="text-orange-500 hover:underline">41.3-million-paper study</a> published in <em>Nature</em> in January 2026. Researchers who use AI publish three times as many papers as their peers, but the range of topics that science as a whole studies has actually shrunk. Everyone is moving to popular fields where data has already piled up. The individual wins, and science narrows. One study pointed in two opposite directions at once.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            The individual victory: scientists who use AI publish <strong>3.02x more</strong> papers, receive <strong>4.84x more</strong> citations, and rise to project leader <strong>1.37 years earlier</strong> than their peers. The collective loss, in the same 23 years: the collective volume of topics studied shrinks by <strong>4.63%</strong>, and follow-on engagement among scientists drops by <strong>22%</strong>. The citation-concentration Gini coefficient is <strong>0.754</strong> — an AI-era variant of the Matthew effect, where the top 22.20% of papers absorb 80% of citations. In Evans's own words — <em>"AI tools are expanding individual capabilities while contracting scientific attention,"</em> and <em>"AI concentrates attention on data-rich domains while leaving a growing number of potentially fruitful areas unexplored."</em> The fact that mathematics, theoretical physics, and philosophy were absent from the six analyzed fields from the start is itself meta-evidence: data-poor domains drop out of analysis before they drop out of attention.
+                            This is not something to brush off. The sample is 41.3 million papers, the time series is 23 years, and the senior author is James Evans at the University of Chicago, who has been working on this question for 11 years. Two months after the paper appeared, a <em>Nature</em> editorial called on institutions, funders, and publishers to redesign evaluation metrics, funding allocation, and publishing standards. Korea is pouring money in the same direction. In 2026, KRW 10 trillion (~$7B) of the government's AI budget flows into six scientific fields (bio, materials chemistry, earth science, semiconductors, energy, secondary batteries), with the InnoCORE postdoc program (400 researchers) and the AI Co-Scientist Challenge serving as that money's hands and feet. The problem: all six are already rich in data (papers, experimental measurements, datasets), and no mechanism is in place to keep the range of topics that this money supports broad.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            The paradox is now a policy agenda. On March 25, 2026, <em>Nature</em> ran an editorial titled <em>"AI scientists are changing research — institutions, funders and publishers must respond."</em> Korea, in turn, launched a rapid sequence: the National Research Foundation of Korea (NRF) AI+S&amp;T six priority fields (bio, materials chemistry, earth science, semiconductors, energy, secondary batteries); the 2026 AI Co-Scientist Challenge Korea (KRW 1.9B prize pool, ~$1.3M); and the InnoCORE postdoc program across four science-and-technology institutes (400 researchers at KRW 90M / ~$62K per year). Funding moves fast, but all six fields are data-rich, and no diversity-preservation mechanism is in place. LG's EXAONE Discovery — screening 40 million materials per day — stands at the same coordinate. Pebblous targets this structural gap head-on. Evans himself named the expansion needed: <em>"sensory and experimental capacity."</em> That is exactly the brief of <strong>DataGreenhouse</strong> (synthetic data) and <strong>PebbloSim</strong> (simulation). Following our four-part series — <a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> · <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA</a> — this meta-and-sociology-of-science coordinate elevates Pebblous from "data diagnostics and synthesis company" to a category leader in <strong>scientific-diversity infrastructure</strong>. With one concrete action item: a seventh DataClinic signal — <strong>"Knowledge Diversity."</strong>
+                            The remaining question is plain. When money and talent concentrate in six data-rich fields, who holds up the fields without data — mathematics, theoretical physics, philosophy, parts of the social sciences? Evans himself said we need "AI that expands not only cognitive capacity but also sensory and experimental capacity." That means moving fields with no data into a form that can be measured, and filling thin spots with synthetic data. This is where Pebblous's next line begins: <strong>"Knowledge Diversity,"</strong> the seventh signal of DataClinic.
                         </p>
                     </div>
 
+                    <!-- Editor's Note -->
+                    <blockquote class="themeable-card rounded-xl p-5 my-6 themeable-text leading-relaxed">
+                        <p><strong><em>Editor's Note.</em></strong> Measuring bias in data and AI is something Pebblous always finds itself drawn to. When the bias shows up in science, even more so. Pebblous is currently running an "Agentic AI Data Scientist" project. As the territory of AI-based data science keeps widening, this study landed a serious question in the middle of it. This piece is the fifth in our AI Governance series, following <a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline">Magnifica Humanitas</a>, <a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline">SkillOpt</a>, <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline">MUSE-Autoskill</a>, and <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA</a>, and an attempt to answer the question of the diversity of knowledge.</p>
+                    </blockquote>
+
                     <!-- Stat Cards -->
-                    <p class="themeable-text leading-relaxed mt-8 mb-6">
-                        Put the numbers on one screen and the grain of the paradox becomes legible. Two individual-level gains and two collective-level losses on the same canvas, across a sample of 41.3 million papers, deliver the headline in one breath: both directions, at once.
-                    </p>
-                    <p class="themeable-text-secondary text-sm mb-3">Source: Hao, Xu, Li, Evans (2026), <em>Nature</em> 649, pp. 1237–1243. DOI: 10.1038/s41586-025-09922-y. arXiv:2412.07727v4.</p>
+                    <h3 class="text-xl font-semibold themeable-heading mt-8 mb-3">Key Metrics</h3>
+                    <p class="themeable-text-secondary text-sm mb-3">Source: <a href="https://www.nature.com/articles/s41586-025-09922-y" target="_blank" rel="noopener" class="text-orange-500 hover:underline">Hao, Xu, Li, Evans (2026), <em>Nature</em> 649, pp. 1237–1243</a>. DOI: 10.1038/s41586-025-09922-y. arXiv:2412.07727v4.</p>
                     <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">+3.02x</p>
@@ -161,11 +164,11 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        "Does AI help science or hurt it?" The debate is not new. Ever since AlphaFold 2 effectively solved protein folding in the 2021 <em>Nature</em> paper, one camp has been arguing that AI ushered science into a golden age, while the other has been countering that AI hallucinates and erodes depth. Both sides have leaned on anecdote and intuition. <strong>In January 2026, a paper in <em>Nature</em> Vol. 649, pp. 1237–1243 placed the first empirical answer at scale on the table — 41.3 million papers worth of evidence.</strong>
+                        "Does AI help science or hurt it?" The debate is not new. After <a href="https://www.nature.com/articles/s41586-021-03819-2" target="_blank" rel="noopener" class="text-orange-500 hover:underline">AlphaFold 2</a> effectively solved protein folding in its 2021 <em>Nature</em> paper, one camp argued that AI had ushered science into a golden age, while the other countered that AI hallucinates and erodes depth. Both leaned on anecdote and intuition. <strong>In January 2026, a paper in <em>Nature</em> Vol. 649 put 41.3 million papers' worth of data on the table.</strong>
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Four authors: <strong>Qianyue Hao, Fengli Xu, Yong Li</strong> (Tsinghua University) and <strong>James A. Evans</strong> (University of Chicago Knowledge Lab, corresponding author). Evans is a professor of sociology at Chicago, an external professor at the Santa Fe Institute, and director of the meta-science research center known as Knowledge Lab. His lab has been tracking one proposition since its 2015 paper "Tradition and Innovation in Scientists' Research Strategies" in <em>American Sociological Review</em>: <strong>aggregated individual rationality can narrow collective knowledge</strong>. Evans 2026 is the apex of that eleven-year thesis.
+                        There are four authors. <strong>Qianyue Hao, Fengli Xu, Yong Li</strong> (Tsinghua University), and the corresponding author <strong>James A. Evans</strong> (University of Chicago Knowledge Lab). Evans is a professor of sociology at Chicago and an external professor at the Santa Fe Institute, and he runs the meta-science research center known as Knowledge Lab. His lab has been working on one proposition for 11 years since its 2015 paper "Tradition and Innovation in Scientists' Research Strategies" in <em>American Sociological Review</em>: when individuals each act rationally, collective knowledge can actually narrow. This paper is where that 11-year project lands.
                     </p>
 
                     <!-- Image: University of Chicago campus — Evans Knowledge Lab home -->
@@ -180,18 +183,18 @@
                         </figcaption>
                     </figure>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>The Method at a Glance — an F1 = 0.875 Classifier Across 23 Years</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.1</span>Method — an F1 = 0.875 Classifier Across 23 Years</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        One number conveys the weight of this paper. The team processed titles (up to 16 tokens) and abstracts (up to 256 tokens) of natural-science papers with a two-stage fine-tuned <code class="text-sm">bert-base-uncased</code> classifier to identify "AI-augmented research." In validation, five domain experts labeled the data with <strong>Fleiss' Kappa = 0.964</strong> (near-perfect agreement) and the classifier scored <strong>F1 = 0.875</strong>. For meta-science work, that level of agreement and accuracy is rare. The 23-year time series naturally spans three eras of AI: classical machine learning (late 1990s onward), deep learning (2012 onward), and generative / large language models (2020 onward).
+                        One number conveys the weight of this paper. The team ran titles (up to 16 tokens) and abstracts (up to 256 tokens) of natural-science papers through a two-stage fine-tuned <code class="text-sm">bert-base-uncased</code> classifier to identify "AI-augmented research." In validation, five domain experts labeled the data with a Fleiss' κ of <strong>0.964</strong>, near-perfect agreement, and the classifier scored <strong>F1 = 0.875</strong>. For meta-science work, that level of agreement and accuracy is rare. The 23-year time series naturally spans three eras of AI: classical machine learning (late 1990s onward), deep learning (2012 onward), and generative or large language models (2020 onward).
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Six fields are analyzed: <strong>biology, medicine, chemistry, physics, materials science, geology</strong>. One fact is worth naming up front — <strong>mathematics, theoretical physics, and philosophy are not in the analysis from the start.</strong> That fact is the paper's meta-evidence. Data-poor fields drop out of analysis before they drop out of attention. We return to this in §5.
+                        Six fields are analyzed: biology, medicine, chemistry, physics, materials science, and geology. One fact deserves to be named up front. <strong>Mathematics, theoretical physics, and philosophy are not in the analysis from the start.</strong> That fact is itself another piece of evidence. Data-poor fields drop out of analysis before they drop out of attention. We return to this in §5.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>Six Statistics in One Breath — Individual Victory, Collective Loss</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">1.2</span>Six Statistics, One Sentence — Individuals Win, the Collective Loses</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        The result fits in one paragraph of the abstract. We quote.
+                        The result fits into one paragraph of the abstract. Verbatim:
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -200,12 +203,12 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        And the conclusion of the same paragraph — <em>"AI adoption in science presents a seeming paradox — an expansion of individual scientists' impact but a contraction in collective science's reach — as AI-augmented work moves collectively toward areas richest in data."</em> The last sentence is more pointed still — <em>"AI tools appear to automate established fields rather than explore new ones."</em> Attention rushes to fields that can be automated; fields that should be explored fall further out of view. The one-line summary of this piece is simply the headline of those two sentences — <strong>individuals get stronger, science gets narrower.</strong>
+                        The conclusion of the same paragraph reads: <em>"AI adoption in science presents a seeming paradox — an expansion of individual scientists' impact but a contraction in collective science's reach — as AI-augmented work moves collectively toward areas richest in data."</em> The last sentence is even more direct. <em>"AI tools appear to automate established fields rather than explore new ones."</em> Attention rushes to fields that can be automated, and fields that need exploration fall further out of view. The one-line summary of this piece is almost a translation of those two sentences. <strong>Individuals get stronger, and science gets narrower.</strong>
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>What Evans 2026 answers.</strong> "Does AI help science or hurt it?" — the answer is "both, but in opposite directions." Individual utility and collective diversity move at the same time, in opposite directions. 41.3 million papers as a sample. F1 = 0.875 and Fleiss κ = 0.964 as inter-rater agreement. 23 years as a time series. Any one of those would already be a meta-science historical coordinate. They arrive together in one paper.
+                            So the answer to "Does AI help science or hurt it?" is "both, but in opposite directions." Individual utility and collective diversity move at the same time, in opposite directions. 41.3 million papers as a sample. F1 = 0.875 and Fleiss κ = 0.964 as inter-rater agreement. 23 years as a time series. Any one of those would carry weight on its own. They arrived together in one paper.
                         </p>
                     </div>
                 </section>
@@ -214,42 +217,42 @@
                 <section id="section-2" class="mb-16 fade-in-card">
                     <div class="flex items-center gap-4 mb-8">
                         <span class="number-badge">2</span>
-                        <h2 class="text-3xl font-bold themeable-heading">The Individual Victory — 3x · 4.8x · 1.4 Years</h2>
+                        <h2 class="text-3xl font-bold themeable-heading">The Individual Victory — A Leap in Productivity, Influence, and Leadership</h2>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Three individual-level numbers, one at a time. What each one means and why the size of the effect is what it is — that is the work of the next two subsections.
+                        Three individual-level numbers, one at a time. What each one means and why the effect is the size it is — these are the next two subsections.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>+3.02x Papers · +4.84x Citations · 1.37 Years Earlier to PI</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>Papers +3.02x · Citations +4.84x · Leadership −1.37 Years</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        <strong>+3.02x paper output.</strong> A researcher who routinely uses AI tools publishes roughly three times as many papers in the same time window as a peer in the same field at the same career stage. This can sound like a mere "quantity" gap, but as long as the reward structure of the academic market — hiring, promotion, grants — treats publication count as a first-order metric, a 3x output gap translates into a 3x gap in professional stability.
-                    </p>
-
-                    <p class="themeable-text leading-relaxed mb-6">
-                        <strong>+4.84x citations.</strong> Heavier still: it is not that AI users write more, but that what they write is cited more. Citations are accumulated peer judgment, and that accumulation feeds back into the next paper's citations — the self-reinforcing loop Robert Merton named the Matthew effect (1968). 4.84x is not simple multiplication; it is the entry point of a structure where the gap widens with time. Supplementary material reports a citation-concentration Gini coefficient of <strong>0.754</strong> for the AI-using group, meaningfully above the 0.690 for non-users. The top 22.20% of papers absorb 80% of citations — the AI-era superstar effect.
+                        <strong>Papers +3.02x.</strong> A researcher who routinely uses AI tools publishes roughly three times as many papers in the same window as a peer in the same field at the same career stage. This can sound like a difference in "quantity," but as long as hiring, promotion, and grants treat publication count as a first-order metric, a 3x output gap translates into a 3x gap in professional stability.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        <strong>1.37 years earlier to PI.</strong> Socially, this may be the heaviest of the three. The moment a postdoc rises to independent Principal Investigator arrives 1.37 years earlier for AI users. In an academic life cycle, sixteen months is a wide gap — the first grant-eligible year, the first PhD-supervision year, the first tenure-track entry year all shift forward by that much. To be 1.37 years behind a peer is to be one cycle behind.
-                    </p>
-
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>What the Matching Analysis Answered — Selection or Effect?</h3>
-                    <p class="themeable-text leading-relaxed mb-6">
-                        The natural first suspicion is — "aren't the smarter, faster researchers simply the ones who adopt AI first?" The authors carried the same suspicion into the design. In their causal-inference step, they extracted <strong>11,019</strong> researchers who adopted AI tools and matched them with <strong>1,926</strong> non-adopters whose early-career trajectories (years in field, sub-area, productivity) were statistically similar. By year 10, AI adopters had received <strong>+24.45%</strong> more citations than their matched non-adopters. The fact that the gap widens despite a similar starting point suggests that a substantial share of the gap is the effect of adoption, not prior selection.
+                        <strong>Citations +4.84x.</strong> The heavier point is not that AI users write more, but that what they write is cited more. Citations are accumulated peer judgment, and that accumulation pulls in still more citations for the next paper (the Matthew effect, Merton 1968). 4.84x is not simple multiplication. It is the entry point of a structure where the gap widens with time. Supplementary material reports a citation-concentration Gini coefficient of <strong>0.754</strong> for the AI-using group, meaningfully above the 0.690 for non-users. The top 22.20% of papers absorb 80% of citations. The AI-era superstar effect.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The authors are also candid about the limit — <em>"Despite consistently suggestive evidence, we cannot fully identify the causal linkage between AI adoption and scientific impact."</em> That is the inherent boundary of observational data without random assignment. The exact causal magnitude carries a band of ±α. But the +24.45% estimate from an 11,019 vs 1,926 match makes clear this is no run-of-the-mill bibliometric correlation study.
+                        <strong>Leadership −1.37 years.</strong> Socially, this may be the heaviest of the three. The moment a postdoc rises to independent Principal Investigator arrives 1.37 years earlier for AI users. Sixteen months is a wide gap in an academic life cycle. The first year you can apply for grants, the first year you supervise a PhD student, the first year you enter the tenure track — all of them shift forward by that much. To be 1.37 years behind a peer is to be one cycle behind.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.3</span>Joining Wu · Wang · Evans 2019 — Where Small Teams Used to Disrupt</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>Aren't the Better Researchers Just the Early Adopters? — Selection or Effect</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Reading this paper next to an earlier Evans Lab work changes the weight. Lingfei Wu, Dashun Wang, and James A. Evans published "Large teams develop and small teams disrupt science and technology" in <em>Nature</em> in 2019. Analyzing 65 million papers and patents, they established a proposition empirically — <strong>smaller teams disrupt; larger teams develop incrementally</strong>.
+                        The natural first suspicion: "Aren't the smarter, faster researchers simply the ones who adopt AI first?" The authors carried the same question into the design. In their causal-inference step, they extracted <strong>11,019</strong> researchers who adopted AI tools and matched them with <strong>1,926</strong> non-adopters whose early-career trajectories — years in field, sub-area, productivity — were statistically similar. By year 10, AI adopters had received <strong>24.45%</strong> more citations than their matched non-adopters. The fact that the gap widens despite a similar starting point suggests that a substantial share of the gap is the effect of adoption, not prior selection.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Overlay the 2026 finding onto that 2019 thesis. AI tools let a small team — even a single researcher — produce at the output scale of a large team. On the surface, an era of "small teams disrupting more" should have arrived. What we observe instead is the opposite: AI-using small teams go where the data is rich and the topics are popular, and they get pulled into the citation magnet there. <strong>Rather than AI accelerating small teams' disruptive potential, small teams cling more tightly to automation in place of disruption.</strong> The abstract's last line — <em>"AI tools appear to automate established fields rather than explore new ones"</em> — supports the reading.
+                        The authors are candid about the limit. <em>"Despite consistently suggestive evidence, we cannot fully identify the causal linkage between AI adoption and scientific impact."</em> That is the inherent boundary of observational data without random assignment. Still, the +24.45% estimate from an 11,019 vs 1,926 match makes clear this is no run-of-the-mill bibliometric correlation study.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.3</span>Reading This Alongside "Small Teams Disrupt" (Wu·Wang·Evans 2019)</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Reading this paper next to an earlier Evans Lab work changes the weight. Lingfei Wu, Dashun Wang, and James A. Evans published "Large teams develop and small teams disrupt science and technology" in <em>Nature</em> in 2019. Analyzing 65 million papers and patents, they showed that smaller teams produce more disruptive (paradigm-shifting) work while larger teams produce more incremental development.
+                    </p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Overlay the 2026 finding onto that 2019 thesis. AI tools let a small team, even a single researcher, produce at the output scale of a large team. On the surface, an era of "small teams disrupting more" should have arrived. What we observe is the opposite. AI-using small teams head for the rich-data, popular topics, where the citation magnets are, and get pulled in. <strong>Rather than AI accelerating small teams' disruptive potential, small teams cling more tightly to automation in place of disruption.</strong> The abstract's last line, <em>"AI tools appear to automate established fields rather than explore new ones,"</em> supports the reading.
                     </p>
 
                     <!-- Image: Tsinghua University main building — Hao/Xu/Li home institution -->
@@ -266,7 +269,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>The individual victory is real — and that victory is itself the cause of the collective loss in the next section.</strong> A 3x · 4.8x · 1.4-year reward funnels rational individual choice in one direction. What that direction looks like is the work of §3 and §4. Aggregated individual rationality can narrow collective breadth — the body of Evans Lab's eleven-year thesis begins here.
+                            The individual victory is real. The catch is that the same victory is also the cause of the collective loss in the next section. A 3x · 4.8x · 1.4-year reward funnels rational individual choice in one direction. What that direction looks like is the work of §3 and §4. When individual rationality accumulates, collective breadth can narrow. That is where Evans Lab's eleven-year thesis really begins.
                         </p>
                     </div>
                 </section>
@@ -279,34 +282,34 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The two collective numbers — <strong>-4.63% in topic diversity</strong> and <strong>-22% in follow-on engagement among researchers</strong> — may look small on the surface. They are not. Both are cumulative signals, and both have a clear basis for being read as leading indicators of field collapse.
+                        The two collective numbers, <strong>−4.63%</strong> in topic diversity and <strong>−22%</strong> in follow-on engagement among researchers, may look small on the surface. They are not. Both are cumulative signals, and both have a clear basis for being read as leading indicators of field collapse.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>How -4.63% Was Measured</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.1</span>How −4.63% Was Measured</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Topic diversity is not a keyword count. The authors measure it as the <strong>collective volume of topics studied in an embedding space</strong>. Unpacked: every paper is mapped into a semantic embedding, and the change in the volume of the distribution is tracked. When more papers crowd onto the same topic, the volume shrinks; when papers spread into new topics, the volume grows. Across the 23-year time series, the periods of higher AI-adoption rates show a -4.63% contraction in volume. That is the headline measurement.
-                    </p>
-
-                    <p class="themeable-text leading-relaxed mb-6">
-                        Go one step further, and follow-on engagement at -22% is the faster signal. The indicator does not simply count co-authorship. It captures the degree to which other researchers engage with a paper's topic and method after it is published — the intensity of scientific dialogue. A 22% drop describes a state in which attention concentrates on popular topics but interaction across papers thins out. The authors give the state a name — <strong>"lonely crowds."</strong>
-                    </p>
-
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>What "Lonely Crowds" Is Pointing At</h3>
-                    <p class="themeable-text leading-relaxed mb-6">
-                        The image is immediate. A hundred people sitting in the same café without speaking to one another are a cluster, not a community. The diagnosis is that this is exactly what is happening on popular topics in the AI era. Papers pile onto the same topic, but the density of dialogue — citation, extension, rebuttal — among those papers is falling. Beneath the surface vibrancy, the weave of the scholarly community comes loose.
+                        Topic diversity is not a keyword count. The authors measure it as the "collective volume of topics studied" in an embedding space. Unpacked: every paper is mapped into a semantic embedding, and the change in the volume of that distribution is tracked. When more papers crowd onto the same topic, the volume shrinks. When papers spread into new topics, the volume grows. Across the 23-year time series, the periods of higher AI-adoption rates show a 4.63% contraction in volume. That is the headline measurement.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Three scholarly labels point at the same phenomenon. Evans 2026's <strong>"lonely crowds,"</strong> Lisa Messeri and M. J. Crockett's <strong>"scientific monocultures"</strong> in their 2024 <em>Nature</em> article "Artificial intelligence and illusions of understanding in scientific research," and Jon Kleinberg and Manish Raghavan's <strong>"algorithmic monoculture"</strong> from their 2021 <em>PNAS</em> piece "Algorithmic monoculture and social welfare." The three labels are converging on the same thing — sameness of tools begets sameness of thought, and as individual accuracy rises, the diversity and robustness of collective decision-making fall. That is why §4 holds the three in a single box.
+                        Follow-on engagement at <strong>−22%</strong> is the faster signal. It does not simply count co-authorship. It captures the degree to which other researchers engage with a paper's topic and method after it is published, which is the intensity of scientific dialogue. A 22% drop describes a state in which attention concentrates on popular topics but interaction across papers thins out. The authors gave that state a name: <strong>"lonely crowds."</strong>
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>The Park · Funk 2023 and Kang · Evans 2024 Chord</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>What "Lonely Crowds" Points At</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Why -4.63% is not a "small number" becomes clear when you read it next to two companion works. Michael Park, Erin Leahey, and Russell J. Funk published "Papers and patents are becoming less disruptive over time" in <em>Nature</em> in 2023, analyzing 45 million papers and 3.9 million patents across 60 years and showing that the <strong>CD (Consolidate-Disrupt) Index</strong> has been falling steadily. The trend began before AI. What Evans 2026 shows is that AI accelerates it.
+                        The image is immediate. A hundred people sitting in the same café without speaking to one another are a cluster, not a community. The diagnosis is that this is exactly what is happening on popular topics in the AI era. Papers pile onto the same topic, but the density of dialogue — citation, extension, rebuttal — among those papers is falling. The surface is busy. Beneath it, the weave of the scholarly community comes loose.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Decisively, Donghyun Kang and James Evans published "Limited diffusion of scientific knowledge forecasts collapse" in <em>Nature Human Behaviour</em> in 2024 — a paper whose title is the whole argument. <strong>Limited diffusion of scientific knowledge forecasts collapse.</strong> -4.63% is not statistical noise; it is a leading signal of collapse, and the scholarly basis for that reading has already been published by the same authors. -22% in collaboration is the concurrent indicator of that signal.
+                        Three scholarly labels point at the same phenomenon. Evans 2026's "lonely crowds," Lisa Messeri and M. J. Crockett's <strong>scientific monocultures</strong> in their 2024 <em>Nature</em> article "Artificial intelligence and illusions of understanding in scientific research," and Jon Kleinberg and Manish Raghavan's <strong>algorithmic monoculture</strong> from their 2021 <em>PNAS</em> piece "Algorithmic monoculture and social welfare." Sameness of tools begets sameness of thought. Individual accuracy rises, but the diversity and robustness of collective decision-making fall. That is why §4 holds the three in a single box.
+                    </p>
+
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>Reading Park · Funk 2023 and Kang · Evans 2024 Together</h3>
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Why −4.63% is not a "small number" becomes clear when you read it next to two companion works. Michael Park, Erin Leahey, and Russell J. Funk published "Papers and patents are becoming less disruptive over time" in <em>Nature</em> in 2023. Analyzing 45 million papers and 3.9 million patents across 60 years, they showed that the CD (Consolidate-Disrupt) Index has been falling steadily. The trend began before AI. What Evans 2026 adds is that AI accelerates it.
+                    </p>
+
+                    <p class="themeable-text leading-relaxed mb-6">
+                        Decisively, Donghyun Kang and James Evans published "Limited diffusion of scientific knowledge forecasts collapse" in <em>Nature Human Behaviour</em> in 2024, and the title is the whole argument. <strong>Limited diffusion of scientific knowledge forecasts collapse.</strong> In other words, the basis for reading −4.63% as a leading signal of collapse has already been published, by the same author. The −22% in collaboration is the concurrent indicator of that signal.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -316,7 +319,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>What it means that diversity and collaboration retreat together.</strong> -4.63% should be read not as a statistical shock but as the first fracture of field collapse. -22% indicates how fast that fracture is deepening. A trend that began before AI is being accelerated by AI — that is the meta-science chord that ties Evans 2026 · Park 2023 · Kang 2024 · Messeri 2024 into a single line.
+                            So −4.63% should be read not as a statistical shock but as the first fracture of field collapse. −22% indicates how fast that fracture is deepening. A trend that began before AI is being accelerated by AI. That is the throughline that ties Evans 2026, Park 2023, Kang 2024, and Messeri 2024 into a single argument.
                         </p>
                     </div>
                 </section>
@@ -329,12 +332,12 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evans 2026's real thesis condenses into a single quotation. We quote — <em>"Data availability appears to be a major impacting factor, where areas with an abundance of data are increasingly and disproportionately amenable to AI research."</em> Data availability is decisive. AI piles onto the places AI is good at, AI needs enough data to be good, and adequate data already accumulated in a field pulls more resources back. The loop widens the gap between data-rich and data-poor domains as a function of time.
+                        Evans 2026's real core lives in one quotation. <em>"Data availability appears to be a major impacting factor, where areas with an abundance of data are increasingly and disproportionately amenable to AI research."</em> Data availability is decisive. AI piles onto the places AI is good at. AI needs enough data to be good at them. And the fields where the data has already accumulated pull more resources back in. That loop widens the gap between data-rich and data-poor domains over time.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>The Streetlight Effect Is No Longer a Metaphor</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Sociology of science has an old joke. A drunk loses his keys and searches only under a streetlight. Asked why, he answers, "because the light is here." The <strong>streetlight effect</strong> names the bias of searching only where measurement is easy. Julian Hoelzemann quantified the effect in NBER Working Paper 32401 (2024), "The Streetlight Effect in Data-Driven Exploration." In the AI era, the metaphor crossed into a measurable size — and that size is exactly the -4.63% and -22% Evans 2026 reports.
+                        Sociology of science has an old joke. A drunk loses his keys and searches only under a streetlight. Asked why, he answers, "because the light is here." The <strong>streetlight effect</strong> names the bias of searching only where measurement is easy. Julian Hoelzemann quantified the effect in NBER Working Paper 32401 (2024), "The Streetlight Effect in Data-Driven Exploration." In the AI era, the metaphor crossed into a measurable size, and that size is exactly the −4.63% and −22% Evans 2026 reports.
                     </p>
 
                     <!-- Image: Streetlight at night — streetlight effect metaphor -->
@@ -350,23 +353,23 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The streetlight effect runs through four reinforcing axes.
+                        The streetlight effect runs through four reinforcing channels.
                     </p>
 
                     <ul class="space-y-3 mb-6 ml-6">
-                        <li class="themeable-text leading-relaxed"><strong>Incentives.</strong> As long as paper counts and citations are the first-order metrics for hiring, promotion, and grants, individuals rationally choose places where they can publish most and fastest. AI tools' efficiency gains are maximized in data-rich fields, so the pull toward those fields strengthens.</li>
-                        <li class="themeable-text leading-relaxed"><strong>Compute and data cost.</strong> Training or fine-tuning an LLM in a data-poor field can cost 5–10x what it costs in a data-rich one. Synthetic-data augmentation is a path, but it is itself an infrastructure investment. The cost curve pulls resources further toward the rich.</li>
-                        <li class="themeable-text leading-relaxed"><strong>Evaluation metrics.</strong> h-index, Altmetric, citation-concentration indices — all are cumulative. A topic that enters the popular zone earns more follow-on citations, and those citations shape the next evaluation. A domain-level variant of the Matthew effect.</li>
-                        <li class="themeable-text leading-relaxed"><strong>Peer review and grant review.</strong> If reviewers are unfamiliar with AI-era paradigms, new proposals in data-poor fields may be scored lower. Wang, Veugelers, and Stephan documented exactly this "novelty penalty" in their 2017 <em>Research Policy</em> paper "Bias against novelty in science." The AI era is likely to sharpen, not soften, the penalty.</li>
+                        <li class="themeable-text leading-relaxed"><strong>Incentives.</strong> As long as paper counts and citations are the first-order metrics for hiring, promotion, and grants, individuals rationally choose places where they can publish most and fastest. AI tools' efficiency gains are largest in data-rich fields, so the pull toward those fields gets stronger.</li>
+                        <li class="themeable-text leading-relaxed"><strong>Compute and data cost.</strong> Training or fine-tuning an LLM in a data-poor field can cost 5 to 10 times what it costs in a data-rich one. Synthetic-data augmentation is a path, but it is itself an infrastructure investment. The cost curve pulls resources further toward the rich.</li>
+                        <li class="themeable-text leading-relaxed"><strong>Evaluation metrics.</strong> h-index, Altmetric, citation-concentration indices are all cumulative. A topic that enters the popular zone earns more follow-on citations, and those citations shape the next evaluation. That is the Matthew effect operating at the field level.</li>
+                        <li class="themeable-text leading-relaxed"><strong>Peer review and grant review.</strong> If reviewers are unfamiliar with AI-era paradigms, new proposals in data-poor fields may be scored lower. Wang, Veugelers, and Stephan documented exactly this novelty penalty in their 2017 <em>Research Policy</em> paper "Bias against novelty in science." The AI era is likely to sharpen, not soften, that penalty.</li>
                     </ul>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        If the four axes were independent, a single policy lever — reforming evaluation metrics, subsidizing compute, opening a new-topic track — could partially loosen them. The four reinforce one another. When incentives pull toward data-rich fields, evaluation metrics accumulate further there, and that accumulation attracts more funding, which lowers compute costs, which brings the next generation of researchers back to the same spot. Pull one axis and the other three pull back. That is why the convergence of three scholarly labels in the next subsection matters — three names from three different angles arriving at the same coordinate suggests the four-axis alignment is structural, not accidental.
+                        If the four channels were independent, a single policy lever — reforming evaluation metrics, subsidizing compute, opening a new-topic track — could partially loosen them. The trouble is that the four reinforce one another. When incentives pull toward data-rich fields, evaluation metrics accumulate further there. That accumulation attracts more funding. The funding lowers compute costs. The lower costs bring the next generation of researchers back to the same place. Pull one channel and the other three pull back. That is why the convergence in the next subsection matters. Three labels from three different angles arriving at the same coordinate suggests this alignment is structural, not accidental.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>"lonely crowds" = "scientific monocultures" = "algorithmic monoculture"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.2</span>lonely crowds = scientific monocultures = algorithmic monoculture</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Put the three names side by side and it becomes clear this is a scholarly chord, not a single study. The box below holds one frame of that chord.
+                        Put the three names side by side and what emerges is a shared scholarly diagnosis, not a single study. The cards below hold one frame of it.
                     </p>
 
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">
@@ -388,21 +391,21 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The three works look at the same phenomenon from different angles — Evans through scholarly-publication data, Messeri through epistemology and experimental design, Kleinberg through algorithm adoption and social welfare. Bound together, what becomes visible is not the intuition of a single critic but a <strong>six-year (2021–2026) scholarly consensus</strong> about the gravitational pull toward data-rich domains. It is hard to dismiss this as "one pessimist's claim" any longer.
+                        The three works look at the same phenomenon from different angles. Evans through scholarly-publication data. Messeri through epistemology and experimental design. Kleinberg through algorithm adoption and social welfare. Bound together, what shows is not one critic's intuition but a <strong>six-year (2021–2026) scholarly consensus</strong> about the gravitational pull toward data-rich domains. It is hard to dismiss this as "one pessimist's claim" any longer.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.3</span>Gini 0.754 — the Matthew Effect in the AI Era</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Robert Merton published his 1968 essay "The Matthew Effect in Science" in the sociology journal <em>Science</em> — naming, after the Gospel of Matthew, the cumulative advantage that builds in citation distributions ("to those who have, more will be given"). Evans 2026's citation-concentration Gini coefficient of <strong>0.754</strong> is the AI-era variant of that effect. Compared to 0.690 in the non-using group, the gap is 0.064 points, but on the Gini scale that gap is what produces the superstar effect — the top 22.20% of papers absorbing 80% of citations.
+                        Robert Merton published "The Matthew Effect in Science" in <em>Science</em> in 1968. The name, from the Gospel of Matthew ("to those who have, more will be given"), captures the cumulative advantage that builds in citation distributions. Evans 2026's citation-concentration Gini coefficient of <strong>0.754</strong> is the AI-era variant of that effect. Compared to 0.690 in the non-using group, the gap is 0.064 points. On the Gini scale, that gap is what produces the superstar effect, with the top 22.20% of papers absorbing 80% of citations.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        A domain-level variant of the Matthew effect carries even more weight. It is not the cumulative advantage between individual papers but the cumulative advantage <strong>between fields</strong>. Fields where data, funding, and people are already accumulated pull in still more through AI tools; data-poor fields fall further behind. At this level, the Matthew effect is structural pressure that accelerates field collapse.
+                        A field-level variant of the Matthew effect weighs even more. It is not cumulative advantage between individual papers, but cumulative advantage <strong>between fields</strong>. Fields where data, funding, and people are already accumulated pull in still more through AI tools, while data-poor fields fall further behind. At this scale, the Matthew effect is structural pressure that accelerates field collapse.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>The streetlight effect is measured fact.</strong> The four-axis mechanism (incentives · compute cost · evaluation metrics · peer review) produces an algorithmic monoculture, and that monoculture accelerates the domain-level variant of the Matthew effect. Three labels — "lonely crowds" · "scientific monocultures" · "algorithmic monoculture" — converging in one place is not coincidence but chord. Policy needs to respond at this location.
+                            So the streetlight effect is now measured fact. The four-channel mechanism (incentives, compute cost, evaluation metrics, peer review) produces an algorithmic monoculture, and that monoculture accelerates the field-level Matthew effect. Three labels converging at the same place is not coincidence. Policy has to respond here.
                         </p>
                     </div>
                 </section>
@@ -415,21 +418,21 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The six fields Evans 2026 analyzed — biology, medicine, chemistry, physics, materials science, geology — are all data-rich. That fact alone points to two things at once. First: where analysis is possible, the polarization shows up at a measurable size. Second: where analysis was not possible, the thinning is likely happening even faster. <strong>The very fact that mathematics, theoretical physics, and philosophy were not in the analyzed set from the start is meta-evidence of the omission of data-poor fields.</strong>
+                        The six fields Evans 2026 analyzed, biology, medicine, chemistry, physics, materials science, and geology, are all data-rich. That tells two things at once. First, where analysis is possible, polarization shows up at a measurable size. Second, where analysis was not possible, the thinning is likely happening even faster. <strong>The fact that mathematics, theoretical physics, and philosophy were not in the analyzed set from the start is itself evidence of how data-poor fields get omitted.</strong>
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>NIH $30.1B vs NSF MPS $1.562B — Quantifying a 20x Gap</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>NIH $30.1B vs NSF MPS $1.562B — a 20x Funding Gap</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Look at funding and the streetlight effect becomes measurable along that dimension too. In the United States, NIH (biology · medicine) runs an annual budget of <strong>$30.1B</strong>. The NSF MPS — Mathematical and Physical Sciences division — has an FY2025 budget of <strong>$1.562B</strong> across mathematics, physics, chemistry, materials, and astronomy combined. Unpack by field and the gap widens; even at the divisional roll-up it is roughly <strong>20x</strong>. AI-for-Science tooling drifts naturally toward fields NIH funds. Data, money, and tools all align along the same axis.
+                        Look at funding and the streetlight effect shows up in money as well. In the United States, NIH (biology, medicine) runs an annual budget of <strong>$30.1B</strong>. The NSF MPS (Mathematical and Physical Sciences) division has an FY2025 budget of <strong>$1.562B</strong> across mathematics, physics, chemistry, materials, and astronomy combined. Unpack by field and the gap widens. Even at the divisional roll-up it is roughly <strong>20x</strong>. AI-for-Science tooling drifts naturally toward the fields NIH funds. Data, money, and tools align along the same axis.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The arXiv monthly-submissions distribution paints the same picture. Of 24,226 new submissions in October 2024, the three categories <code class="text-sm">cs.LG</code>, <code class="text-sm">cs.CV</code>, and <code class="text-sm">cs.CL</code> (machine learning · computer vision · natural language processing) together exceed 6,000. Pure mathematics (<code class="text-sm">math.AG</code> and the like) and theoretical physics (<code class="text-sm">hep-th</code>) over the same period are flat or barely growing. Conference acceptance distributions, PhD-granting distributions, faculty hiring distributions — nearly all academic flows are aligned along the same direction.
+                        The arXiv monthly-submissions distribution paints the same picture. Of 24,226 new submissions in October 2024, the three categories <code class="text-sm">cs.LG</code>, <code class="text-sm">cs.CV</code>, and <code class="text-sm">cs.CL</code> (machine learning, computer vision, natural language processing) together exceed 6,000. Pure mathematics (<code class="text-sm">math.AG</code> and the like) and theoretical physics (<code class="text-sm">hep-th</code>) over the same period are flat or barely growing. Conference acceptances, PhD-granting distributions, faculty hiring distributions — nearly every academic flow points the same way.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>Fields Missing Even from the Analysis — Math, Theoretical Physics, Philosophy</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        The table below compares the fields Evans 2026 saw with those it did not see. "Did not see" is not the team's failure; it points to an asymmetry in the analyzable data itself.
+                        The table below compares the fields Evans 2026 saw with those it did not. "Did not see" is not the team's failure. It points to an asymmetry in the analyzable data itself.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -453,13 +456,13 @@
                         <p class="text-xs themeable-muted mt-2">Source: Hao et al. 2026 (analyzed fields); NIH FY2025 / NSF MPS FY2025 official budget announcements; arXiv stats (2024-10); DeepMind announcements.</p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>AlphaProof's Exceptionality — the Cost of a Frontal Breakthrough in Data-Poor Territory</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>AlphaProof's Exception — the Cost of Breakthrough in Data-Poor Territory</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        If AlphaFold 2 showed the apex of acceleration in the life sciences, DeepMind's AlphaProof and AlphaGeometry produced an interesting exception in mathematics. In 2024, the two systems combined to solve 4 of the 6 problems at the International Mathematical Olympiad (IMO), reaching a silver-medal score. The fact points to two things at once. One: AI can break through in data-poor fields too. Two: that breakthrough was made possible by generating a massive volume of <strong>synthetic proof data</strong> (over 100 million examples, in AlphaProof's case) — turning poverty into abundance by hand.
+                        If <a href="https://www.nature.com/articles/s41586-021-03819-2" target="_blank" rel="noopener" class="text-orange-500 hover:underline">AlphaFold 2</a> showed acceleration in the life sciences, DeepMind's AlphaProof and AlphaGeometry produced an interesting exception in mathematics. In 2024, the two systems combined to solve 4 of the 6 problems at the International Mathematical Olympiad (IMO), reaching a silver-medal score. The fact tells two things at once. One, AI can break through in data-poor fields too. Two, that breakthrough was made possible by generating a massive volume of <strong>synthetic proof data</strong> (over 100 million examples, in AlphaProof's case), turning scarcity into abundance by hand.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        In plain language — frontal breakthroughs in data-poor territory are possible, but the cost far exceeds the cost of simple application in data-rich fields. Academic labs without DeepMind-scale infrastructure cannot easily take the same path. The structural pressure toward data-rich concentration remains. Borrowing Kuhn's old term <strong>paradigm shift</strong>, in the AI era the paradigm-shift cycle is likely to accelerate in some data-rich fields and slow down in data-poor ones. The flow of time between fields becomes asymmetric.
+                        In other words, breakthroughs in data-poor territory are possible, but the cost far exceeds the cost of simply using AI in data-rich fields. Academic labs without DeepMind-scale infrastructure cannot easily walk the same path. The structural pressure toward data-rich concentration remains. Borrowing Kuhn's old term <strong>paradigm shift</strong>, in the AI era the paradigm-shift cycle is likely to accelerate in some data-rich fields and slow down in data-poor ones. The flow of time between fields becomes asymmetric.
                     </p>
 
                     <!-- Image: AlphaFold protein structure — AI for Science exemplar -->
@@ -476,7 +479,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>The shape of science is deepening in six data-rich fields and thinning in mathematics, theoretical physics, and philosophy.</strong> The exclusion of the latter from Evans 2026's analysis is not a coincidence but a structural omission produced by the four-axis alignment of data, funding, tools, and evaluation. Exceptions like AlphaProof exist, but the cost curve of those exceptions is exactly what points — in the next section (§7) — to the place where Pebblous's synthetic-data and simulation infrastructure belongs.
+                            The shape of science is deepening in six data-rich fields and thinning in mathematics, theoretical physics, and philosophy. The exclusion of the latter from Evans 2026 is not a coincidence but a structural omission produced by the alignment of data, funding, tools, and evaluation. Exceptions like AlphaProof exist, but the cost curve of those exceptions points directly to the place where Pebblous's synthetic-data and simulation infrastructure belongs (§7).
                         </p>
                     </div>
                 </section>
@@ -489,7 +492,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Four pieces Pebblous published in sequence in May 2026 trace a series. This piece is the fifth coordinate. The evolution curve across the five is <strong>morality (principles) → scholarship (optimizer) → scholarship (lifecycle) → law (enforcement) → meta (the shape of science itself)</strong>. If 1–4 worked inside governance, the fifth sits one level above — a mirror that asks <strong>how AI governs science.</strong>
+                        Four pieces Pebblous published in May 2026 form a series. This is the fifth. The flow runs <strong>morality (principles) → scholarship (optimizer) → scholarship (lifecycle) → law (enforcement) → meta (the change in science itself)</strong>. If 1–4 worked inside governance, the fifth sits one level above, as a mirror that asks <strong>how AI is changing science</strong>.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -511,27 +514,27 @@
                         <p class="text-xs themeable-muted mt-2">Source: Pebblous Blog publication record.</p>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>The Three Axes the Nature Editorial Named — institutions · funders · publishers</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>The Three Actors the Nature Editorial Named — institutions, funders, publishers</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Two months after Evans 2026 was published, on <strong>March 25, 2026</strong>, <em>Nature</em> responded with an editorial — <em>"AI scientists are changing research — institutions, funders and publishers must respond"</em> (DOI: 10.1038/d41586-026-00934-w). This editorial is a rare event: one paper being elevated from a scholarly agenda to a policy agenda. The editorial distributes responsibility across three axes — <strong>institutions</strong> must redesign evaluation metrics, <strong>funders</strong> must create preservation tracks for data-poor fields, and <strong>publishers</strong> must establish transparency standards and meta-data conventions for AI use.
+                        Two months after Evans 2026 appeared, on <strong>March 25, 2026</strong>, <em>Nature</em> responded with an editorial: <em>"AI scientists are changing research — institutions, funders and publishers must respond"</em> (DOI: 10.1038/d41586-026-00934-w). One paper being elevated from a scholarly agenda to a policy agenda is a rare event. The editorial distributes responsibility across three actors. <strong>Institutions</strong> must redesign evaluation metrics, <strong>funders</strong> must create preservation tracks for data-poor fields, and <strong>publishers</strong> must establish transparency standards and metadata conventions for AI use.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        A subsequent editorial — <em>"AI grant flood must prioritize fairness as part of excellence"</em> — drove the point home: in funding allocation, excellence as a single criterion must be paired with fairness as a second dimension. Judged by excellence alone, all funding flows to the data-rich. Without fairness as a second dimension, the diversity retreat accelerates. The Evans proposition, translated into policy language.
+                        A follow-up editorial, <em>"AI grant flood must prioritize fairness as part of excellence,"</em> drove the point home. In funding allocation, excellence as a single criterion has to be paired with fairness as a second axis. Judged by excellence alone, all funding flows to the data-rich. Without fairness as a second axis, the diversity retreat accelerates. Evans's proposition, translated into policy language.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>What the Four-Part Series Drew Inside, and What the Fifth Draws Above</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.2</span>What the Four Drew Inside, What the Fifth Draws Above</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        One line for each of the four. <a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> asks about the principles of human dignity in the AI era. <a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline">SkillOpt</a> reads the scholarly design of a self-evolving optimizer for AI agents. <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> proposes a scholarly model of skill lifecycle. <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA</a> covers the four-Commissioner Canadian enforcement action on OpenAI training data. Morality asks; scholarship answers; law enforces.
+                        One line for each of the four. <a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> asks about the principles of human dignity in the AI era. <a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline">SkillOpt</a> reads the scholarly design of a self-evolving optimizer for AI agents. <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline">MUSE-Autoskill</a> proposes a scholarly model of skill lifecycle. <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA</a> covers the four-Commissioner Canadian enforcement action on OpenAI training data. Morality asks, scholarship answers, law enforces.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        This piece adds one more coordinate above that flow — the meta perspective of <strong>how AI is reshaping science itself</strong>. While morality, scholarship, and law work inside governance, the object of that governance — science itself — is narrowing. The quintet, taken together, looks both inside governance and at the transformation of what governance is meant to govern. That completes the series.
+                        This piece adds one more coordinate above that flow, the meta perspective of <strong>how AI is reshaping science itself</strong>. While morality, scholarship, and law work inside governance, the object of that governance — science — is narrowing. Taken together, the quintet looks both inside governance and at the transformation of what governance is meant to govern. That completes the series.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>The governance landscape the quintet completes.</strong> Morality (principles) · scholarship (optimizer) · scholarship (lifecycle) · law (enforcement) · meta (the shape of science). Any one of these alone is partial; together, a picture emerges of how far AI governance must reach. The place from which Pebblous's next pieces begin becomes naturally visible inside that picture.
+                            Morality (principles), scholarship (optimizer), scholarship (lifecycle), law (enforcement), meta (the shape of science). Any one of these alone is partial. Taken together, they outline how far AI governance must reach. The place from which Pebblous's next pieces begin shows up naturally inside that outline.
                         </p>
                     </div>
                 </section>
@@ -544,7 +547,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        If Evans 2026 is one movement in a scholarly chord, Pebblous's coordinate is one infrastructure line to add to it. Evans himself left a single sentence as the policy implication. We quote.
+                        If Evans 2026 is one strand of a shared scholarly diagnosis, what Pebblous wants to add is one infrastructure line on top of it. Evans himself left a single sentence as the policy implication.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -553,16 +556,16 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Pebblous takes that sentence as a direct scholarly justification. <strong>DataGreenhouse</strong> is the expansion of sensory capacity — synthetic data supply for data-poor fields. <strong>PebbloSim</strong> is the expansion of experimental capacity — simulation to cover experiment costs and blind spots. Evans's policy implication points squarely at the scholarly coordinate of Pebblous's product line.
+                        Pebblous takes that sentence as the direct scholarly grounding for its product line. <strong>DataGreenhouse</strong> is the expansion of sensory capacity — synthetic data supply for data-poor fields. <strong>PebbloSim</strong> is the expansion of experimental capacity — simulation to cover experiment costs and blind spots. Evans's policy implication points directly at the coordinate Pebblous's product line already occupies.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>The Seventh DataClinic Signal — "Knowledge Diversity"</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>DataClinic's Seventh Signal — "Knowledge Diversity"</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        DataClinic has, to date, diagnosed dataset-internal quality through six signals — <strong>completeness · accuracy · consistency · timeliness · uniqueness · legality</strong>. The sixth, legality, was added in our <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA piece (Part 4 of the series)</a>. This piece proposes one more — a seventh signal, <strong>Knowledge Diversity</strong>.
+                        DataClinic has, to date, diagnosed dataset-internal quality through six signals: <strong>completeness, accuracy, consistency, timeliness, uniqueness, legality</strong>. The sixth, legality, was added in our <a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline">PIPEDA piece (Part 4 of the series)</a>. This piece proposes a seventh: <strong>Knowledge Diversity</strong>.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The first six look <strong>inside</strong> a dataset. The seventh looks <strong>outside</strong> — at <strong>which fields are absent</strong>. The box below is the first sketch of its operational definition.
+                        The first six look <strong>inside</strong> a dataset. The seventh looks <strong>outside</strong>, at which fields are absent.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -587,16 +590,16 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Unpack the seventh signal's operational definition. <strong>Measurement</strong>: compute the training-corpus coverage distribution in field-embedding space, and measure distance and evenness with respect to adjacent data-poor regions. <strong>Signal</strong>: Gini thresholds (e.g., a warning above 0.7), field omission rates (against the NSF / NIH classification), and a "lonely cluster" score (connection strength to adjacent clusters). <strong>Application</strong>: insert before AI-model training as a corpus-diagnostic step, with a recommendation to augment data-poor regions via synthetic data. DataGreenhouse becomes the augmentation tool.
+                        The seventh signal's operational definition can be set this way. <strong>Measurement</strong>: compute the training-corpus coverage distribution in field-embedding space, and measure distance and evenness with respect to adjacent data-poor regions. <strong>Signal</strong>: Gini thresholds (for example, a warning above 0.7), field-omission rates (against the NSF and NIH classification), and a "lonely cluster" score (connection strength to adjacent clusters). <strong>Application</strong>: insert before AI-model training as a corpus-diagnostic step, with a recommendation to augment data-poor regions via synthetic data. The augmentation itself is DataGreenhouse's job.
                     </p>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>Korea's AI4Science Policy and Its Missing Diversity Mechanism</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>The Missing Diversity Mechanism in Korea's AI4Science Policy</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Korea's AI4Science policy is fast and ambitious. The diversity mechanism, however, is absent. The 2026 government R&amp;D budget is KRW 35.5T (about $24.5B, +19.9% YoY), of which the AI budget is KRW 10.1T (~$7.0B); within that, the line item "AI-augmented S&amp;T R&amp;D innovation" is <strong>KRW 600B (~$414M)</strong>. The NRF AI+S&amp;T six priority fields — <strong>bio, materials chemistry, earth science, semiconductors, energy, secondary batteries</strong> — are all data-rich. The 2026 AI Co-Scientist Challenge Korea (KRW 1.9B / ~$1.3M prize pool) Track 1 includes mathematics — a small step forward — but no diversity indicator appears in the evaluation criteria.
+                        Korea's AI4Science policy is fast and ambitious. The piece that is missing is a mechanism to keep diversity. The 2026 government R&amp;D budget is KRW 35.5T (~$24.5B, +19.9% YoY), of which the AI budget is KRW 10.1T (~$7.0B), and within that the line item for "AI-augmented S&amp;T R&amp;D innovation" is <strong>KRW 600B (~$414M)</strong>. The NRF AI+S&amp;T six priority fields (bio, materials chemistry, earth science, semiconductors, energy, secondary batteries) are all data-rich. The 2026 AI Co-Scientist Challenge Korea (KRW 1.9B / ~$1.3M prize pool) Track 1 includes mathematics, which is a small step forward, but no diversity indicator appears in the evaluation criteria.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        The biggest variable is the <strong>InnoCORE postdoc program</strong> across four science-and-technology institutes, supporting 400 researchers at KRW 90M (~$62K) per year, with KAIST alone hosting 200. Where those 400 researchers flow over the next five to ten years will set the shape of Korean science. If the six fields remain all data-rich and the 400 cluster in the same place, the Korean version of the -4.63% / -22% Evans 2026 measured in the United States is likely to be measured here as well.
+                        The biggest variable is the <strong>InnoCORE postdoc program</strong> across four science-and-technology institutes, supporting 400 researchers at KRW 90M (~$62K) per year, with KAIST alone hosting 200. Where those 400 researchers flow over the next five to ten years will shape Korean science. If the six fields stay all data-rich and the 400 cluster in the same place, the Korean version of the −4.63% and −22% that Evans 2026 measured in the United States is likely to show up here as well.
                     </p>
 
                     <!-- Image: KAIST campus building — InnoCORE / Korea AI4Science visual -->
@@ -612,21 +615,21 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        On the industry side, LG AI Research's <strong>EXAONE Discovery</strong> is the peak case — an AI system that can screen 40 million substances per day, the Korean apex of new-materials and new-drug discovery automation. That EXAONE Discovery sits at the peak of data-rich-field automation is reason for applause. At the same time, the infrastructure for data-poor regions that this automation cannot reach — whose responsibility is it, and who will build it? That coordinate remains unfilled. Pebblous can stand in it.
+                        On the industry side, LG AI Research's <strong>EXAONE Discovery</strong> is the peak case. An AI system that screens 40 million substances per day, the Korean apex of new-materials and new-drug discovery automation. That EXAONE Discovery sits at the peak of data-rich-field automation is reason to applaud. At the same time, the infrastructure for data-poor regions that this automation cannot reach is the open question: whose responsibility is it, and who will build it? That place remains unfilled. Pebblous can stand in it.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.3</span>"Scientific Diversity Infrastructure" as a New Category</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        The identity this piece draws for Pebblous fits in one line — <strong>Scientific Diversity Infrastructure</strong>. The three-stage architecture of data diagnostics (DataClinic) · synthesis (DataGreenhouse) · simulation (PebbloSim) is no longer a product line alone; it is an infrastructure-operator identity that joins the scholarly chord written by Evans, Park, Messeri, and Kleinberg. We do not join the autonomous-research-agent race (Sakana AI Scientist v2, Google Co-Scientist, FutureHouse Crow / Falcon / Owl / Phoenix, LG EXAONE Discovery) on the same track. Pebblous's coordinate is <strong>one layer below</strong> — the infrastructure layer that supplies these agents with the data they will train on, especially in data-poor regions.
+                        The identity this piece draws for Pebblous fits in one line: <strong>Scientific Diversity Infrastructure</strong>. The three-stage architecture of data diagnostics (DataClinic), synthesis (DataGreenhouse), and simulation (PebbloSim) is no longer just a product line. It is an infrastructure-operator identity that joins the diagnosis Evans, Park, Messeri, and Kleinberg have been building. We do not enter the autonomous-research-agent race (Sakana AI Scientist v2, Google Co-Scientist, FutureHouse Crow/Falcon/Owl/Phoenix, LG EXAONE Discovery) on the same track. Pebblous sits <strong>one layer below</strong>, in the infrastructure layer that supplies those agents with data, especially in data-poor regions.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        We recommend reading one sister piece. <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a> drew the arrival of the new AI-for-Science era from an industry-and-policy perspective. If this piece traces the shadow of that era from a meta-and-sociology-of-science perspective, the sister piece looks at the light side. Two coordinates examining the same era from opposite sides settle naturally in the Pebblous series.
+                        We recommend reading one sister piece. <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a> drew the arrival of the new AI-for-Science era from an industry-and-policy view. If this piece traces the shadow of that era from a meta-and-sociology-of-science view, the sister piece looks at the light. Two pieces, one era, two sides.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>Evans's one sentence pointed exactly at Pebblous's scholarly coordinate.</strong> "The expansion of sensory and experimental capacity" is the justification for DataGreenhouse and PebbloSim. DataClinic is diagnosis, DataGreenhouse is augmentation, PebbloSim is simulation — the three-stage architecture is one picture of Scientific Diversity Infrastructure. The seventh DataClinic signal, "Knowledge Diversity," is this piece's one concrete action item.
+                            Evans's one sentence pointed exactly at Pebblous's scholarly coordinate. The expansion of sensory and experimental capacity is the grounding for DataGreenhouse and PebbloSim. DataClinic is diagnosis, DataGreenhouse is augmentation, PebbloSim is simulation. The three-stage architecture is what Scientific Diversity Infrastructure looks like. The seventh DataClinic signal, "Knowledge Diversity," is this piece's one concrete action item.
                         </p>
                     </div>
                 </section>
@@ -639,24 +642,24 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        +3.02x and -4.63% appear on the same screen above a 41.3-million-paper sample — that is the place this piece needs to close on. Individual acceleration and collective narrowing are two faces of the same era. The choice is not to pick one. It is the recognition that <strong>both must be lived through together</strong>.
+                        +3.02x and −4.63% sit on the same screen above a 41.3-million-paper sample. That is where this piece needs to close. Individual acceleration and collective narrowing are two faces of the same era. The choice is not between them. <strong>Both have to be lived at once</strong>, and a new era begins on that recognition.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        One honest admission is required. The acceleration AlphaFold 2 brought to protein folding is real. GNoME's discovery of 380,000 stable inorganic crystals is a real chapter in the history of science. AlphaProof and AlphaGeometry's IMO silver-medal reasoning proved that frontal breakthroughs in data-poor territory are possible. The era of autonomous research agents is approaching fast. Acceleration does not need to be belittled. But a view that sees only acceleration misses -4.63% and -22%. A view is needed that holds both.
+                        One honest admission first. The acceleration AlphaFold 2 brought to protein folding is real. GNoME finding 380,000 stable inorganic crystals is a chapter in the history of science. AlphaProof and AlphaGeometry showing IMO silver-medal reasoning proved that frontal breakthroughs in data-poor territory are possible. The era of autonomous research agents is approaching fast. There is no reason to belittle acceleration. The trouble is that a view that sees only acceleration misses −4.63% and −22%. A view that holds both is what we need.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Read Evans's policy sentence once more — <em>"reimagine AI systems that expand not only cognitive capacity but also sensory and experimental capacity."</em> Not only the expansion of cognition, but also the expansion of sensing and experiment. That one line is a design principle for the next era. Enjoy the acceleration where AI can automate, and lay down infrastructure — synthetic data, simulation, diversity diagnostics — where AI does not yet do well. Both must move at once for the era of acceleration-and-narrowing to keep its balance.
+                        Read Evans's policy sentence once more. <em>"reimagine AI systems that expand not only cognitive capacity but also sensory and experimental capacity."</em> Not only the expansion of cognition, but the expansion of sensing and experiment. That one line is a design principle for the next era. Enjoy the acceleration where AI can automate, and lay down infrastructure — synthetic data, simulation, diversity diagnostics — where AI does not yet do well. Both have to move at once for the era of acceleration-and-narrowing to keep its balance.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Where this piece ends, more questions begin. <strong>How do we make the measurement tooling for the seventh DataClinic signal, "Knowledge Diversity," concrete? In what order should DataGreenhouse augment data-poor fields? How should the field distribution of the 400 InnoCORE postdocs be monitored along the diversity dimension? How might a data-poor track be added to the next round of NRF AI+S&amp;T's six priority fields?</strong> These exceed what one piece can answer. They mark the place from which Pebblous's next pieces will work, slowly.
+                        Where this piece ends, more questions begin. How do we measure the diversity of fields that are poor in data? Where do we start filling data in? Over the next five to ten years, how do we read the field distribution of 400 InnoCORE postdocs, or the next round of NRF AI+S&amp;T's six priority fields, along the diversity dimension? These exceed what one piece can answer, and they happen to be the questions Pebblous's "Agentic AI Data Scientist" project is already running into. The concrete answers will come in other pieces.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>One coordinate that four scholars drew above 41.3 million papers shows the grain of an era.</strong> Individuals get stronger; science gets narrower. The acceptance that both propositions are true at once is where this piece starts — and where Pebblous's next work begins. <strong>Scientific diversity is also subject to diagnosis — and on top of that diagnosis, infrastructure for augmentation and simulation will follow.</strong> One line that closes this piece and ties one knot in the quintet.
+                            What four scholars left above 41.3 million papers is a simple conclusion. <strong>Individuals get stronger, and science gets narrower.</strong> Both propositions are true at once. A view that enjoys the acceleration while still seeing the fields emptying out in its shadow is the most important homework this study leaves behind.
                         </p>
                     </div>
 
@@ -666,13 +669,13 @@
                         <p class="themeable-text leading-relaxed text-sm mb-4">
                             This piece is the fifth coordinate (meta · sociology of science) of the Pebblous AI Governance Quintet. Morality → scholarship → scholarship → law → meta — five coordinates that draw the full landscape of AI governance.
                         </p>
-                        <ul class="text-sm space-y-2">
-                            <li><a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline"><strong>① Magnifica Humanitas</strong></a> — Morality · Theology (2026-05-25)</li>
-                            <li><a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline"><strong>② SkillOpt</strong></a> — Scholarship · Optimizer (2026-05-27)</li>
-                            <li><a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline"><strong>③ MUSE-Autoskill</strong></a> — Scholarship · Lifecycle (2026-05-28)</li>
-                            <li><a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline"><strong>④ PIPEDA</strong></a> — Law · Regulatory enforcement (2026-05-29)</li>
-                            <li class="font-bold themeable-heading"><strong>⑤ This piece</strong> — Meta · Sociology of science (2026-05-31)</li>
-                        </ul>
+                        <ol class="list-decimal list-inside text-sm space-y-2">
+                            <li><a href="/report/pope-magnifica-humanitas/en/" class="text-orange-500 hover:underline"><strong>Magnifica Humanitas</strong></a> — Morality · Theology (2026-05-25)</li>
+                            <li><a href="/report/microsoft-skillopt-self-evolving-agents/en/" class="text-orange-500 hover:underline"><strong>SkillOpt</strong></a> — Scholarship · Optimizer (2026-05-27)</li>
+                            <li><a href="/report/muse-autoskill-self-evolving-skill-lifecycle/en/" class="text-orange-500 hover:underline"><strong>MUSE-Autoskill</strong></a> — Scholarship · Lifecycle (2026-05-28)</li>
+                            <li><a href="/report/openai-pipeda-ai-training-data-regulation/en/" class="text-orange-500 hover:underline"><strong>PIPEDA</strong></a> — Law · Regulatory enforcement (2026-05-29)</li>
+                            <li class="font-bold themeable-heading"><strong>This piece</strong> — Meta · Sociology of science (2026-05-31)</li>
+                        </ol>
                         <p class="themeable-text-secondary text-sm mt-4">
                             Sister piece — <a href="/report/ai-science-new-era/" class="text-orange-500 hover:underline">AI Science New Era</a> (AI for Science from the industry-and-policy perspective).
                         </p>


### PR DESCRIPTION
## Summary
KO에 적용된 JH 피드백 9개 패턴 + 산문 정제를 EN에 일관 적용. ko-prose-humanizer 스킬의 11 tell 점검(T1·T4·T11·T8·T9) 위주로 EN 산문 톤을 KO 동등 수준으로 끌어올림.

## Before / After

| 지표 | Before | After |
|---|---|---|
| 본문 글자 | 45,802 | 43,508 (-2,294) |
| em-dash | 143 | **70** (-73) |
| em-dash 빈도 | 1/320자 | **1/621자** (KO 1/494자보다 보수적) |
| AI 접속부사 | 0 | 0 (유지) |
| "We quote" 메타 예고문 | 1 | 0 |
| "category leader" 자사 점프 | 1 | 0 |
| "coordinate as" 자사 점프 | 1 | 0 |

## 적용된 변경 (KO와 동일 패턴)

### Exec Summary
- 1단락: Nature 논문 외부 링크 추가
- 2단락 명확화: "institutions, funders, publishers"가 무엇을 해야 하는지 풀이 + 6대 과학 분야 구체 명시 + KRW 10T (~$7B) USD 환산 + 데이터 풍부의 의미 (papers, experimental measurements, datasets)
- 3단락 명확화: 빈약 분야 예시(mathematics, theoretical physics, philosophy, parts of social sciences) 명시 + "moving fields with no data into a form that can be measured, and filling thin spots with synthetic data" 풀이
- 5부작 자기홍보 → Editor's Note로 이동
- 본문 마지막의 "category leader" 점프 제거

### §2 제목 정성화
- Before: "The Individual Victory — 3x · 4.8x · 1.4 Years"
- After: "The Individual Victory — A Leap in Productivity, Influence, and Leadership"
- TOC + H2 양쪽 교체

### §1~§8 산문
- em-dash 동격 재진술 패턴 마침표·접속어로 변환
- "We quote", "We quote — " 메타 예고문 제거
- §1 본문 + §5.3 AlphaFold 2 첫 두 등장에 Nature DOI 링크
- 자사 작위 점프 톤다운

### Editor's Note (신규)
- "Editor's Note." → **Editor's Note** (Italic Bold)
- 4부작 4편 인라인 링크 + "an attempt to answer the question of the diversity of knowledge"

### Stat Cards 위 "Key Metrics" h3
- 패러독스 문단 삭제 → 단순 제목

### §8 Series Notice
- ul + ①~⑤ 중복 → ol list-decimal 통일

## Test plan
- [ ] 머지 후 라이브 EN 페이지에서 Exec Summary 명료성·Editor's Note·Key Metrics 확인
- [ ] §2 제목 TOC + H2 일치
- [ ] §8 시리즈 안내 카드 — 자동 1·2·3·4·5 번호
- [ ] Evans Nature + AlphaFold 외부 링크 동작
- [ ] 모든 수치(47개), 이미지(5장), key-insight(9개) 보존

## 시리즈 사후 검수 진행 상황
- ✅ Evans KO (PR #248 머지) — em-dash 117 → 52
- 🔄 Evans EN (이 PR) — em-dash 143 → 70
- ⏳ SkillOpt KO (1/277자) — 다음
- ⏳ MUSE-Autoskill KO (1/238자)
- ⏳ PIPEDA KO (1/238자)

🤖 Generated with [Claude Code](https://claude.com/claude-code)