### PR TITLE
voice(report): SkillOpt KO 사후 검수 — ko-prose-humanizer 첫 적용 (em-dash 73→49)

### DIFF
--- a/report/microsoft-skillopt-self-evolving-agents/ko/index.html
+++ b/report/microsoft-skillopt-self-evolving-agents/ko/index.html
@@ -91,7 +91,7 @@
                     <li><a href="#section-1" class="block pl-4 themeable-toc-link transition-colors duration-200">1. 더 큰 모델의 환상</a></li>
                     <li><a href="#section-2" class="block pl-4 themeable-toc-link transition-colors duration-200">2. 스킬 문서가 던지는 질문</a></li>
                     <li><a href="#section-3" class="block pl-4 themeable-toc-link transition-colors duration-200">3. 텍스트 공간의 gradient descent</a></li>
-                    <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. +23.5, +24.8, +19.1</a></li>
+                    <li><a href="#section-4" class="block pl-4 themeable-toc-link transition-colors duration-200">4. 평균 뒤의 이야기 — +23.5, +24.8, +19.1</a></li>
                     <li><a href="#section-5" class="block pl-4 themeable-toc-link transition-colors duration-200">5. 옮겨다니는 스킬</a></li>
                     <li><a href="#section-6" class="block pl-4 themeable-toc-link transition-colors duration-200">6. 학습하는 조직, 진영의 분기</a></li>
                     <li><a href="#section-7" class="block pl-4 themeable-toc-link transition-colors duration-200">7. 진단된 스킬 문서 — 페블러스 관점</a></li>
@@ -114,19 +114,20 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            AI 업계에는 오래된 환상이 하나 있었다. 더 강력한 모델만 만들면 에이전트도 자연스럽게 똑똑해질 것이라는 믿음. 그래서 사람들은 GPU를 더 쌓고, 파라미터를 더 키우고, 프롬프트를 더 길게 늘어뜨렸다. 그러나 정작 현실의 에이전트는 여전히 불안정했다 — 같은 문제를 두 번 시키면 다른 결과를 내놓고, 환경이 조금만 바뀌어도 무너졌으며, 인간이 밤새 손으로 다듬은 스킬 문서는 몇 번의 업데이트만 지나면 낡은 유물처럼 변해버렸다. <strong>2026년 5월 22일 arXiv에 올라온 한 편의 논문(arXiv:2605.23904, <em lang="en">SkillOpt: Executive Strategy for Self-Evolving Agent Skills</em>)</strong>은 이 문제를 정면으로 마주했다. Microsoft Research의 제안은 단순하면서도 급진적이다 — <strong>모델을 계속 바꾸려 하지 말고, 에이전트의 스킬 자체를 학습 가능한 상태로 다뤄라.</strong>
+                            AI 업계에는 오래된 환상이 하나 있었다. 더 강력한 모델만 만들면 에이전트도 자연스럽게 똑똑해질 것이라는 믿음. 그래서 사람들은 GPU를 더 쌓고, 파라미터를 더 키우고, 프롬프트를 더 길게 늘어뜨렸다. 정작 현실의 에이전트는 여전히 불안정했다. 같은 문제를 두 번 시키면 다른 결과를 내놓고, 환경이 조금만 바뀌어도 무너졌으며, 인간이 밤새 손으로 다듬은 스킬 문서는 몇 번의 업데이트만 지나면 낡은 유물처럼 변했다. <strong>2026년 5월 22일 arXiv에 올라온 한 편의 논문(arXiv:2605.23904, <em lang="en">SkillOpt: Executive Strategy for Self-Evolving Agent Skills</em>)</strong>이 이 문제를 정면으로 마주했다. Microsoft Research의 제안은 단순하면서도 급진적이다. <strong>모델을 계속 바꾸려 하지 말고, 에이전트의 스킬 자체를 학습 가능한 상태로 다뤄라.</strong>
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            정량적 충격은 세 줄로 요약된다. 첫째, <strong>52/52 cells에서 best-or-tied</strong> — 6개 벤치마크 × 7개 모델 × 3개 실행 환경의 모든 조합에서 SkillOpt가 동등하거나 앞섰고, no-skill·human-skill·one-shot LLM-skill·TextGrad·GEPA·Trace2Skill·EvoSkill 등 7개 베이스라인을 모두 눌렀다. 둘째, <strong>GPT-5.5 direct chat +23.5pt, Codex agentic loop +24.8pt, Claude Code +19.1pt</strong>라는 향상폭은 거대 모델 한 세대 점프(GPT-3.5→GPT-4가 통상 +15~+20pt)와 같거나 더 크다 — 그것도 <strong>모델 학습 비용의 6~7 자릿수 아래</strong> 가격으로. 셋째, <strong>스킬은 모델 사이를 옮겨다닌다.</strong> Cross-model +15.2%, Cross-harness +31.8%, 그리고 Codex에서 학습된 SpreadsheetBench 스킬이 Claude Code 환경에서 22.1→81.8(+59.7pt)로 작동한다는 사실은 "스킬 = 모델 독립적 자산"이라는 명제를 더 이상 비유가 아니라 측정값으로 만든다.
+                            정량적 충격은 세 줄이다. 첫째, <strong>52/52 cells에서 best-or-tied</strong>. 6개 벤치마크 × 7개 모델 × 3개 실행 환경의 모든 조합에서 SkillOpt가 동등하거나 앞섰고, no-skill·human-skill·one-shot LLM-skill·TextGrad·GEPA·Trace2Skill·EvoSkill 등 7개 베이스라인을 모두 눌렀다. 둘째, <strong>GPT-5.5 direct chat +23.5pt, Codex agentic loop +24.8pt, Claude Code +19.1pt</strong>라는 향상폭은 거대 모델 한 세대 점프(GPT-3.5→GPT-4가 통상 +15~+20pt)와 같거나 더 크다. 그것도 <strong>모델 학습 비용의 6~7 자릿수 아래</strong> 가격으로. 셋째, <strong>스킬은 모델 사이를 옮겨다닌다.</strong> Cross-model +15.2%, Cross-harness +31.8%, 그리고 Codex에서 학습된 SpreadsheetBench 스킬이 Claude Code 환경에서 22.1→81.8(+59.7pt)로 작동한다는 사실은 "스킬 = 모델 독립적 자산"이라는 명제를 더 이상 비유가 아니라 측정값으로 만든다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            이 흐름이 우리와 무관할 리 없다. <strong>2026년 5월 22일은 SkillOpt 논문이 발표된 바로 그 날이면서, 같은 날 한국에서는 한글과컴퓨터와 LG AI연구원이 ChatEXAONE 결합 협약을 체결</strong>한 날이기도 하다. 한국 AI 시장은 IITP 기준 2025년 3.44조원에서 2027년 4.46조원(CAGR 14.3%)으로 가고 있고, <strong>2026년 1월 22일 한국 AI 기본법</strong>이 시행되면서 "AI 에이전트의 오판 책임은 누구에게 귀속되는가"가 산업계의 최대 쟁점이 되었다. 페블러스는 지난 몇 해 "데이터를 진단 가능한 상태로 만든다"는 명제로 DataClinic·AI-Ready Data·DataGreenhouse·PebbloSim을 운영해 왔다. SkillOpt가 던진 명제는 우리의 명제를 <strong>행동(behavior) 차원으로 확장</strong>한 것이다. 데이터의 진단 가능성에서 행동의 진단 가능성으로 — <strong>AI-Ready Data → AI-Ready Behavior.</strong>
+                            이 흐름이 우리와 무관할 리 없다. <strong>SkillOpt 논문이 발표된 2026년 5월 22일, 같은 날 한국에서는 한글과컴퓨터와 LG AI연구원이 ChatEXAONE 결합 협약을 체결</strong>했다. 한국 AI 시장은 IITP 기준 2025년 3.44조원에서 2027년 4.46조원(CAGR 14.3%)으로 가고 있고, <strong>2026년 1월 22일 한국 AI 기본법</strong>이 시행되면서 "AI 에이전트의 오판 책임은 누구에게 귀속되는가"가 산업계의 최대 쟁점이 되었다. 페블러스는 지난 몇 해 "데이터를 진단 가능한 상태로 만든다"는 명제로 DataClinic·AI-Ready Data·DataGreenhouse·PebbloSim을 운영해 왔다. SkillOpt가 던진 명제는 우리의 명제를 <strong>행동(behavior) 차원으로 확장</strong>한 것이다. 데이터의 진단 가능성에서 행동의 진단 가능성으로, <strong>AI-Ready Data → AI-Ready Behavior</strong>의 도약이다.
                         </p>
                     </div>
 
                     <!-- Stat Cards -->
-                    <p class="themeable-text-secondary text-sm mt-8 mb-3">SkillOpt 논문이 보고한 핵심 수치를 한눈에 본다. 출처: arXiv:2605.23904 (Microsoft Research, 2026-05-22), Stanford HAI AI Index 2026, Epoch AI.</p>
-                    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+                    <h3 class="text-xl font-semibold themeable-heading mt-8 mb-3">주요 수치</h3>
+                    <p class="themeable-text-secondary text-sm mb-3">출처: <a href="https://arxiv.org/abs/2605.23904" target="_blank" rel="noopener" class="text-orange-500 hover:underline">arXiv:2605.23904</a> (Microsoft Research, 2026-05-22), Stanford HAI AI Index 2026, Epoch AI.</p>
+                    <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">+23.5pt</p>
                             <p class="text-sm themeable-text-secondary mt-1">GPT-5.5 direct chat</p>
@@ -147,11 +148,6 @@
                             <p class="text-sm themeable-text-secondary mt-1">비용 차이</p>
                             <p class="text-xs themeable-muted mt-1">Frontier 학습 vs SkillOpt 1회</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-4 text-center">
-                            <p class="text-2xl font-bold" style="color: #F86825;">2026-05-22</p>
-                            <p class="text-sm themeable-text-secondary mt-1">한미 동시일</p>
-                            <p class="text-xs themeable-muted mt-1">SkillOpt 발표 = 한컴·LG ChatEXAONE 협약</p>
-                        </div>
                     </div>
                 </section>
 
@@ -171,16 +167,16 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Microsoft의 SkillOpt 논문이 흥미로운 이유는 바로 이 문제를 정면으로 마주했기 때문이다. 논문은 <strong>"모델 자체를 계속 바꾸려 하지 말고, 에이전트의 스킬 자체를 학습 가능한 상태로 다뤄라"</strong>라는 급진적인 전환을 제안한다. 같은 모델 위에서, 같은 추론 비용으로, 그러나 다른 스킬 문서를 가지고 — 에이전트의 평균 정확도가 한 세대 분량 점프한다.
+                        Microsoft의 SkillOpt 논문은 이 문제를 정면으로 마주한다. <strong>"모델 자체를 계속 바꾸려 하지 말고, 에이전트의 스킬 자체를 학습 가능한 상태로 다뤄라"</strong>라는 급진적인 전환의 제안이다. 같은 모델 위에서, 같은 추론 비용으로, 그러나 다른 스킬 문서를 가지고 에이전트의 평균 정확도가 한 세대 분량 점프한다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        같은 2026년 봄, 빅테크의 전략이 두 갈래로 가시화되었다. <strong>진영 A</strong>는 모델을 계속 키운다 — OpenAI GPT-5/o3, Anthropic Opus 4.x, Google Gemini Ultra, Meta Llama 5, xAI Grok 4.3 Heavy. <strong>진영 B</strong>는 모델은 frozen으로 두고 그 위에 학습되는 행동 자산을 다듬는다 — Microsoft SkillOpt(2026-05-22), Anthropic Claude Skills와 Managed Agents Dreaming, NousResearch Hermes, Sentient EvoSkill, Stanford GEPA. 어느 쪽이 옳다고 단정할 시점은 아직 아니다. 그러나 진영 B의 등장은 "더 큰 모델"이 유일한 길이 아님을 보여준다 — 그 옆에 분명히 한 갈래의 길이 더 났다는 것.
+                        같은 2026년 봄, 빅테크의 전략이 두 갈래로 가시화되었다. <strong>진영 A</strong>는 모델을 계속 키운다. OpenAI GPT-5/o3, Anthropic Opus 4.x, Google Gemini Ultra, Meta Llama 5, xAI Grok 4.3 Heavy. <strong>진영 B</strong>는 모델은 frozen으로 두고 그 위에 학습되는 행동 자산을 다듬는다. Microsoft SkillOpt(2026-05-22), Anthropic Claude Skills와 Managed Agents Dreaming, NousResearch Hermes, Sentient EvoSkill, Stanford GEPA. 어느 쪽이 옳다고 단정할 시점은 아직 아니다. 다만 진영 B의 등장이 "더 큰 모델"만이 유일한 길은 아님을 분명히 보여준다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>이 보고서는 그 두 번째 길의 첫 번째 결정판 — SkillOpt — 을 해부한다.</strong> 알고리즘이 어떻게 작동하는지, 정량 데이터가 무엇을 말하는지, 산업적 함의는 무엇인지. 그리고 마지막으로 "데이터 진단을 해온 회사가 이 흐름을 어떻게 받아 안는가"라는 페블러스의 시각을 통해 — <strong>AI-Ready Data → AI-Ready Behavior</strong>라는 다음 카테고리의 윤곽을 그린다.
+                            이 글은 그 두 번째 길의 첫 번째 결정판인 SkillOpt를 해부한다. 알고리즘이 어떻게 작동하는지, 정량 데이터가 무엇을 말하는지, 산업적 함의는 무엇인지. 그리고 마지막으로 데이터 진단을 해온 회사가 이 흐름을 어떻게 받아 안는가라는 페블러스의 시각으로, <strong>AI-Ready Data → AI-Ready Behavior</strong>라는 다음 카테고리의 윤곽을 그린다.
                         </p>
                     </div>
                 </section>
@@ -193,11 +189,11 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        SkillOpt가 정확히 무엇을 학습시키는가. 모델은 frozen이다. 에이전트는 frozen이다. 학습되는 유일한 객체는 단 하나의 마크다운 파일 — <code>best_skill.md</code>. 이 파일에는 절차(procedures), 도메인 휴리스틱, 도구 사용 정책, 출력 제약, 실패 모드가 자연어로 적힌다. 옵티마이저 모델(별도의 LLM)은 타깃 모델의 실행 궤적을 보고 이 문서를 수정한다. 두 모델이 같이 돌지만 학습되는 것은 두 모델 사이의 텍스트 한 장이다.
+                        SkillOpt가 정확히 무엇을 학습시키는가. 모델은 frozen이다. 에이전트도 frozen이다. 학습되는 유일한 객체는 단 하나의 마크다운 파일, <code>best_skill.md</code>다. 이 파일에는 절차(procedures), 도메인 휴리스틱, 도구 사용 정책, 출력 제약, 실패 모드가 자연어로 적힌다. 옵티마이저 모델(별도의 LLM)은 타깃 모델의 실행 궤적을 보고 이 문서를 수정한다. 두 모델이 같이 돌지만 학습되는 것은 두 모델 사이의 텍스트 한 장이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        저자들의 자기 규정이 흥미롭다.
+                        저자들의 자기 규정은 다음과 같다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -206,7 +202,7 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 줄로 옮기면 이렇다 — <strong>"학습이란 외부 자연어 상태(external natural-language state)에 대한 최적화다."</strong> 가중치라는 수십억 차원 연속 공간을 떠나, 자연어 문서라는 이산·의미 공간으로 학습 대상의 위상이 옮겨졌다는 선언. 이 구조의 함의를 셋으로 풀어 보자.
+                        풀어 쓰면 <strong>"학습이란 외부 자연어 상태(external natural-language state)에 대한 최적화"</strong>라는 선언이다. 가중치라는 수십억 차원 연속 공간을 떠나, 자연어 문서라는 이산·의미 공간으로 학습 대상의 위상이 옮겨졌다. 이 구조의 함의는 세 가지로 나타난다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>학습 대상의 위상이 바뀌었다</h3>
@@ -216,7 +212,7 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>학습 결과물을 인간이 읽을 수 있다</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        GB짜리 모델 파일 대신 수 KB의 마크다운. 변경 이력을 git으로 추적할 수 있고, 회고할 수 있으며, 사람의 검토 게이트를 끼워 넣을 수 있다. AI 거버넌스와 책임 귀속의 관점에서 이 한 가지 사실만으로도 의미가 크다 — 학습된 결과물에 대해 "왜 이렇게 결정했는가"를 처음으로 텍스트로 묻고 답할 수 있게 된 것이다.
+                        GB짜리 모델 파일 대신 수 KB의 마크다운. 변경 이력을 git으로 추적할 수 있고, 회고할 수 있으며, 사람의 검토 게이트를 끼워 넣을 수 있다. AI 거버넌스와 책임 귀속의 관점에서 이 한 가지 사실만으로도 의미가 크다. 학습된 결과물을 두고 "왜 이렇게 결정했는가"를 처음으로 텍스트로 묻고 답하게 됐다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.3</span>학습 결과가 다른 모델로 옮겨갈 수 있다</h3>
@@ -247,7 +243,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>3자 구조의 명시화</strong> — SkillOpt는 모델·에이전트·옵티마이저를 명시적으로 분리한다. 학습되는 객체는 셋 다 아니다. 그것은 세 객체 사이를 매개하는 한 장의 마크다운. 학습이 모델에서 일어나지 않고 그 옆의 텍스트에서 일어난다는 발상의 전환이, "행동을 학습한다(learn to behave)"는 명제를 처음으로 실용 알고리즘으로 만들었다.
+                            SkillOpt는 모델·에이전트·옵티마이저를 명시적으로 분리한다. 학습되는 객체는 셋 다 아니다. 세 객체 사이를 매개하는 한 장의 마크다운이다. 학습이 모델에서 일어나지 않고 그 옆의 텍스트에서 일어난다는 발상의 전환이, "행동을 학습한다(learn to behave)"는 명제를 처음으로 실용 알고리즘으로 만들었다.
                         </p>
                     </div>
                 </section>
@@ -260,7 +256,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        SkillOpt 알고리즘의 한 epoch은 네 단계로 흐른다. 익숙한 deep-learning training discipline이 텍스트 공간으로 그대로 이식된다.
+                        SkillOpt 알고리즘의 한 epoch은 네 단계로 흐른다. 익숙한 딥러닝 학습 규율이 텍스트 공간으로 그대로 이식된다.
                     </p>
 
                     <div class="grid md:grid-cols-2 gap-6 mb-8">
@@ -327,7 +323,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 대응이 깔끔할수록 무서운 점이 있다 — <strong>"학습"이라는 행위가 더 이상 weight 위에서만 일어나지 않는다는 것</strong>이 알고리즘적으로 정당화된다는 사실. 한 번 모델이 잘 만들어졌다면, 그 위에 얹히는 자연어 문서를 다듬는 일만으로 우리는 "학습한다"고 말할 수 있게 됐다.
+                        이 대응이 깔끔할수록 한 가지가 무겁게 다가온다. <strong>"학습"이라는 행위가 더 이상 weight 위에서만 일어나지 않는다는 것</strong>이 알고리즘적으로 정당화된다는 사실이다. 모델이 한 번 잘 만들어졌다면, 그 위에 얹히는 자연어 문서를 다듬는 일만으로 우리는 "학습한다"고 말할 수 있게 됐다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>학술 계보 — 8년의 누적이 한 시스템에 모이다</h3>
@@ -388,11 +384,11 @@
                 <section id="section-4" class="mb-16 fade-in-card">
                     <div class="flex items-center gap-4 mb-8">
                         <span class="number-badge">4</span>
-                        <h2 class="text-3xl font-bold themeable-heading">+23.5, +24.8, +19.1 — 평균 뒤의 이야기</h2>
+                        <h2 class="text-3xl font-bold themeable-heading">평균 뒤의 이야기 — +23.5, +24.8, +19.1</h2>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        +23.5pt라는 평균 숫자가 추상적이라면, 그 안을 들여다 보자. GPT-5.5 direct chat 환경에서 6개 벤치마크의 baseline → after는 다음과 같다. 평균이 아닌 셀 단위 수치에서 진짜 이야기가 드러난다.
+                        +23.5pt라는 평균 숫자만 보면 추상적이다. GPT-5.5 direct chat 환경에서 6개 벤치마크의 baseline → after를 셀 단위로 풀면 진짜 이야기가 드러난다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -422,7 +418,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        그 폭발이 가장 도드라진 세 자리를 따로 떼어 본다. 엑셀과 오피스, 그리고 올림피아드 수학 — 사람이 오랜 시간 손과 머리로 다듬어 온 절차들이 모인 곳에서 향상폭이 가장 크게 터졌다. 모델의 한 세대 점프가 통상 +15~+20pt임을 떠올리면, 이 세 셀은 그 점프를 두 번 겹친 자리에 해당한다.
+                        가장 큰 폭발이 일어난 세 자리는 엑셀과 오피스, 그리고 올림피아드 수학이다. 사람이 오랜 시간 손과 머리로 다듬어 온 절차들이 모인 곳에서 향상폭이 가장 크게 터졌다. 모델의 한 세대 점프가 통상 +15~+20pt임을 떠올리면, 이 세 셀은 그 점프를 두 번 겹친 자리다.
                     </p>
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
                         <div class="themeable-card rounded-xl p-6 text-center">
@@ -443,7 +439,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        그리고 이 향상은 <strong>52개 셀 모두에서 동등 또는 우위</strong>다. 어떤 모델, 어떤 환경, 어떤 벤치마크를 골라도 SkillOpt가 깔린 직계 경쟁자(TextGrad, GEPA, Trace2Skill, EvoSkill)보다 떨어지지 않는다. 더 인상적인 것은 epoch이 진행되는 동안 학습 곡선이 어떻게 그려지는지다 — 단순 평균이 아니라 시간에 따른 학습 동학(training dynamics)의 형태가 직접 보인다.
+                        이 향상은 <strong>52개 셀 모두에서 동등 또는 우위</strong>로 나타난다. 어떤 모델, 어떤 환경, 어떤 벤치마크를 골라도 SkillOpt가 직계 경쟁자(TextGrad, GEPA, Trace2Skill, EvoSkill)보다 떨어지지 않는다. 더 인상적인 것은 epoch이 진행되는 동안 학습 곡선이 어떻게 그려지는지다. 단순 평균이 아니라 시간에 따른 학습 동학(training dynamics)의 형태가 직접 보인다.
                     </p>
 
                     <!-- Image: SkillOpt epoch-wise training trends across 3 benchmarks -->
@@ -482,7 +478,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        가중치는 그 모델을 위해 태어난다. GPT-5.5에 맞춰 fine-tune한 LoRA adapter는 Qwen3.5에 붙지 않는다. 모델이 바뀌면 처음부터 다시 학습해야 한다. 그러나 스킬 문서는 다르다. SkillOpt가 GPT-5.4에서 학습한 SpreadsheetBench 스킬을 GPT-5.4-mini에 그대로 옮겼을 때 +9.4pt가 나왔고, GPT-5.4-nano로 옮겼을 때도 +15.2pt가 측정되었다. 더 인상적인 것은 환경 간 전이 — Codex 안에서 학습된 스킬이 Claude Code 안에서 그대로 작동할 때 SpreadsheetBench가 22.1에서 81.8로 (+59.7pt) 뛰어올랐다. <strong>다른 회사의 모델, 다른 회사의 실행 환경, 그러나 같은 자연어 문서.</strong>
+                        가중치는 그 모델을 위해 태어난다. GPT-5.5에 맞춰 fine-tune한 LoRA adapter는 Qwen3.5에 붙지 않는다. 모델이 바뀌면 처음부터 다시 학습해야 한다. 스킬 문서는 다르다. SkillOpt가 GPT-5.4에서 학습한 SpreadsheetBench 스킬을 GPT-5.4-mini에 그대로 옮겼을 때 +9.4pt가 나왔고, GPT-5.4-nano로 옮겼을 때도 +15.2pt가 측정되었다. 환경 간 전이는 한 단계 더 인상적이다. Codex 안에서 학습된 스킬이 Claude Code 안에서 그대로 작동할 때 SpreadsheetBench가 22.1에서 81.8로 +59.7pt 뛰어올랐다. <strong>다른 회사의 모델, 다른 회사의 실행 환경, 그러나 같은 자연어 문서.</strong>
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>전이 실험 — 세 종류의 옮겨다님</h3>
@@ -506,7 +502,7 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>비용 자릿수 — 6~7개의 차이</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 사실의 경제학적 의미는 크다. Frontier 모델의 학습 비용은 GPT-4가 $78M, Gemini Ultra가 $191M, GPT-5가 비공식 추정 $200~$500M 수준이다(Stanford HAI AI Index 2025, Epoch AI). 그에 반해 SkillOpt 1회 최적화 비용은 논문이 "수십~수백 달러"로 정성적으로 보고한다. 같은 단위로 환산하면 자릿수가 어떻게 차이 나는지 보자.
+                        이 사실의 경제학적 의미는 크다. Frontier 모델의 학습 비용은 GPT-4가 $78M, Gemini Ultra가 $191M, GPT-5가 비공식 추정 $200~$500M 수준이다(Stanford HAI AI Index 2025, Epoch AI). SkillOpt 1회 최적화 비용은 논문이 "수십~수백 달러"로 정성적으로 보고한다. 같은 단위로 환산하면 자릿수 차이가 또렷이 드러난다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -646,12 +642,12 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>AI-Ready Data → AI-Ready Behavior.</strong> 데이터를 진단 가능한 상태로 만든 회사가 이제 행동을 진단 가능한 상태로 만들 차례라는 명제. <strong>"진단된 스킬 문서(diagnosed skill documents)"</strong>라는 이름의 시장이 막 태어나고 있고, 우리는 그 자리에 자연스럽게 서 있다. 자기 광고가 아니다. 데이터 진단을 해온 회사라면 이 흐름 앞에서 같은 결론에 도달할 수밖에 없다는 통찰의 형태로, 우리는 이 명제를 적는다.
+                            <strong>AI-Ready Data → AI-Ready Behavior.</strong> 데이터를 진단 가능한 상태로 만든 회사가 이제 행동을 진단 가능한 상태로 만들 차례라는 명제. <strong>"진단된 스킬 문서(diagnosed skill documents)"</strong>라는 이름의 시장이 막 태어나고 있다. 데이터 진단을 해온 회사라면 이 흐름 앞에서 같은 결론에 도달할 수밖에 없다는 통찰의 결과로 이 명제가 적힌다.
                         </p>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        구체적 제품 로드맵은 이 글에서 다루지 않는다. 다만 DataClinic의 5신호 체계가 그대로 SkillClinic의 5신호로 재맵핑된다는 점, 그리고 행동 데이터베이스(에이전트 성공/실패 로그, 실행 궤적, 도구 호출 패턴)가 페블러스의 기존 PebbloSim·DataGreenhouse 자산과 자연스럽게 결합된다는 점은 명확하다. 페블러스가 그동안 데이터에 대해 해온 일이, 그대로 행동 자산으로 옮겨갈 수 있다는 것 — 그것이 이 한 편의 논문이 우리에게 던진 다음 좌표다.
+                        구체적 제품 로드맵은 이 글의 몫이 아니다. 다만 DataClinic의 5신호 체계가 그대로 SkillClinic의 5신호로 재맵핑된다는 점, 그리고 행동 데이터베이스(에이전트 성공/실패 로그, 실행 궤적, 도구 호출 패턴)가 페블러스의 기존 PebbloSim·DataGreenhouse 자산과 자연스럽게 결합된다는 점은 명확하다. 페블러스가 그동안 데이터에 대해 해온 일이, 그대로 행동 자산으로 옮겨갈 수 있다는 것. 그것이 이 한 편의 논문이 던진 다음 좌표다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -667,19 +663,19 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 편의 논문이 시대 좌표를 다시 그렸다. 모델을 더 키우는 길은 여전히 열려 있다. 그러나 그 옆에 분명히 하나의 길이 더 났다 — <strong>모델을 그대로 두고 행동을 학습시키는 길.</strong> 옵티마이저가 짠 스킬 문서를 검증 게이트가 통과시키고, 그 문서가 다른 모델로 옮겨가 또 한 번의 향상을 만들어내는 흐름.
+                        한 편의 논문이 시대 좌표를 다시 그렸다. 모델을 더 키우는 길은 여전히 열려 있다. 다만 그 옆에 분명히 하나의 길이 더 났다. <strong>모델을 그대로 두고 행동을 학습시키는 길.</strong> 옵티마이저가 짠 스킬 문서를 검증 게이트가 통과시키고, 그 문서가 다른 모델로 옮겨가 또 한 번의 향상을 만들어내는 흐름이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 흐름은 단지 fine-tuning 비용의 회피가 아니다. 그것은 <strong>AI의 학습 가능한 객체의 위상이 가중치에서 자연어 문서로 확장</strong>되었음을 의미하며, 그 자연어 문서는 한 번 만들어 두면 다음 모델로 옮겨갈 수 있는 누적 자산임을 의미한다. 빅테크 두 곳이 같은 시기에 스킬 계층을 모두에게 개방했고, 한국 산업에는 AI 기본법이 책임 귀속이라는 묵직한 질문을 얹었다. 답해야 할 질문은 명확해졌다.
+                        이 흐름은 단지 fine-tuning 비용의 회피가 아니다. <strong>AI의 학습 가능한 객체의 위상이 가중치에서 자연어 문서로 확장</strong>되었다는 사건이고, 그 자연어 문서는 한 번 만들어 두면 다음 모델로 옮겨갈 수 있는 누적 자산이라는 사건이다. 빅테크 두 곳이 같은 시기에 스킬 계층을 모두에게 개방했고, 한국 산업에는 AI 기본법이 책임 귀속이라는 묵직한 질문을 얹었다. 답해야 할 질문은 명확해졌다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스의 시각은 한 줄이다 — <strong>AI-Ready Data → AI-Ready Behavior.</strong> 데이터를 진단 가능한 상태로 만든 회사가 이제 행동을 진단 가능한 상태로 만들 차례라는 명제. 학습된 결과물을 처음으로 사람이 읽을 수 있게 된 이 시대에, "왜 이 에이전트가 이렇게 행동했는가"라는 물음에 답할 수 있는 능력이 — 그것이 다음 데이터 품질의 정의가 된다.
+                        페블러스의 시각은 한 줄이다. <strong>AI-Ready Data → AI-Ready Behavior.</strong> 데이터를 진단 가능한 상태로 만든 회사가 이제 행동을 진단 가능한 상태로 만들 차례라는 명제다. 학습된 결과물을 처음으로 사람이 읽을 수 있게 된 이 시대에, "왜 이 에이전트가 이렇게 행동했는가"라는 물음에 답할 수 있는 능력. 그것이 다음 데이터 품질의 정의가 된다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 편의 논문이 신호탄이었다. 그 옆에 한국 산업의 같은 날 협약이 있었고, AI 기본법의 시행이 있다. 이 흐름의 한복판에 <strong>"진단된 스킬 문서"</strong>라는 신규 카테고리가 비어 있다. 우리는 그 자리에 서 있다 — 자기 광고가 아니라, 데이터를 진단해 온 회사가 자연스럽게 도달하는 다음 좌표로서.
+                        한 편의 논문이 신호탄이었다. 그 옆에 한국 산업의 같은 날 협약이 있었고, AI 기본법의 시행이 있다. 이 흐름의 한복판에 <strong>"진단된 스킬 문서"</strong>라는 신규 카테고리가 비어 있다. 데이터를 진단해 온 회사가 자연스럽게 도달하는 다음 좌표가 그 자리다.
                     </p>
                 </section>
 


### PR DESCRIPTION
## Summary
ko-prose-humanizer 스킬 도입(blog-service PR #28) 직후 시리즈 4편 사후 검수의 첫 번째. LLM 판단 위주(grep은 1차 신호)로 11 tell 진단·교정.

## 진단 결과 (총점 ~35/110, 0.32 — 온건 교정)

SkillOpt는 Evans보다 시작 톤이 양호. JH 보이스에 가까운 호흡이 이미 있어 본문 골격은 유지. 주된 문제는 부분적 T1·T4·T11.

| Tell | Before | After |
|------|--------|-------|
| T1 em-dash | 73개 (1/277자) | **49개 (1/407자)** |
| T4 메타 예고문 | 6+곳 | **0** |
| T7 수동태 | 7곳 | 일부 정제 (자연스러운 자리 보존) |
| T11 자사 점프 | 2곳 | 톤다운 |
| Stat-card 수 | 5개 (정책 위반) | 4개 ✓ |

## 주요 변경

### Exec Summary
- "—" 동격 재진술 3곳 마침표로
- Stat Cards 5개 → 4개 ("2026-05-22 한미 동시일" 카드 제거, §6에 풀어 넣음)
- "한눈에 본다" 도입문 → "주요 수치" h3 (Evans 패턴)
- arXiv 외부 링크 추가

### §1~§8 산문
- §4 제목 어순 변경 (정성 표현 앞): "+23.5, +24.8, +19.1 — 평균 뒤의 이야기" → "평균 뒤의 이야기 — +23.5, +24.8, +19.1" (TOC + H2)
- T4 메타 예고문 6곳 제거 ("들여다 보자", "풀어 보자", "따로 떼어 본다", "옮겨 적어 본다" 등)
- "—" 동격 재진술 패턴 마침표·접속어로 변환
- §7 key-insight 자사 광고체 정제 ("자기 광고가 아니다" 제거)
- §8 자사 점프 톤다운

## 보존
- 모든 수치 30개, 이미지 3장, key-insight 5, blockquote 6, 시리즈 링크
- §6 한국 AI 시장·AI 기본법 분석 (한국 맥락 핵심)
- 5부작 시리즈 흐름 (Voyager → Hermes → SkillOpt)

## ko-prose-humanizer 첫 실전 경험 (스킬 재정렬에 반영 예정)
- SkillOpt는 시작 톤이 양호해 Evans보다 가벼운 정제. 점수 0.5 미만이라 "교정 강권" 트리거 미적용. **0.3~0.5 구간 온건 교정**이 흔한 경우임을 학습
- em-dash 1/500자 목표는 일률 적용보다 글의 본래 호흡을 고려한 유연한 임계치 필요
- "한 X" 빈도("한 줄·한 가지")는 자연스러운 자리가 많아 grep 신호만으로 판단 위험

## 시리즈 사후 검수 진행
- [x] Evans KO (PR #248) — em-dash 117 → 52
- [x] Evans EN (PR #249) — 143 → 70
- [x] **SkillOpt KO (이 PR)** — 73 → 49
- [ ] MUSE-Autoskill KO (1/238자) — 다음
- [ ] PIPEDA KO (1/238자)

## Test plan
- [ ] §4 제목 정성 표현 앞으로 (TOC + H2 일치)
- [ ] Stat Cards 4개 (모바일·태블릿·데스크탑 grid 정상)
- [ ] arXiv 외부 링크 동작
- [ ] 모든 수치(30개), 이미지(3장), 시리즈 링크 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)