### PR TITLE
voice(report): MUSE-Autoskill KO 사후 검수 — ko-prose-humanizer 두 번째 적용 (em-dash 98→51)

### DIFF
--- a/report/muse-autoskill-self-evolving-skill-lifecycle/ko/index.html
+++ b/report/muse-autoskill-self-evolving-skill-lifecycle/ko/index.html
@@ -114,18 +114,24 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            기억 없는 AI는 매번 같은 자리에서 다시 시작한다. 어제 풀었던 문제도, 어제 만든 절차도, 어제 받은 피드백도 다음 세션이 열리면 흔적 없이 사라진다. 인간이 경험을 쌓아 능력이 되는 방식과 가장 다른 지점이다. <strong>2026년 5월 26일 arXiv에 올라온 한 편의 논문 — <span lang="en">MUSE-Autoskill</span>(arXiv:2605.27366, Lin et al., ByteDance Infra AI Lab 추정)</strong>은 이 한계를 정면으로 풀려는 시도다. MUSE는 <span lang="en">Memory-Utilizing Skill Evolution</span>의 약자이며, 핵심 명제는 짧다 — <strong>"스킬을 isolated and static artifacts가 아니라 long-lived, experience-aware, and testable assets로 다룬다."</strong> 한 번 쓰고 버리는 일회용 절차가 아니라, 자기 자신의 경험을 누적하며 검증받는 자산. 이 문장 하나가 자기진화 에이전트 연구의 다음 좌표를 그린다.
+                            기억 없는 AI는 매번 같은 자리에서 다시 시작한다. 어제 풀었던 문제도, 어제 만든 절차도, 어제 받은 피드백도 다음 세션이 열리면 흔적 없이 사라진다. 인간이 경험을 쌓아 능력이 되는 방식과 가장 다른 지점이다. <strong>2026년 5월 26일 arXiv에 올라온 한 편의 논문 <a href="https://arxiv.org/abs/2605.27366" target="_blank" rel="noopener" class="text-orange-500 hover:underline">MUSE-Autoskill</a>(arXiv:2605.27366, Lin et al., ByteDance Infra AI Lab 추정)</strong>이 이 한계를 정면으로 풀려는 시도다. MUSE는 Memory-Utilizing Skill Evolution(기억 활용 스킬 진화)의 약자이고, 핵심 명제는 짧다. <strong>스킬을 한 번 쓰고 버리는 일회용 절차가 아니라, 자기 자신의 경험을 누적하며 검증받는 자산으로 다룬다는 것.</strong> 이 문장 하나가 자기진화 에이전트 연구의 다음 좌표를 그린다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            MUSE는 스킬을 다섯 단계의 <strong>unified lifecycle (creation, memory, management, evaluation, and refinement)</strong> 안에서 다룬다. 태스크 도중 필요하면 스킬을 만들고(Creation), 호출될 때마다 그 스킬에 경험이 누적되며(Memory — <strong>skill-level memory</strong>, 학술적으로 새로운 층), 라이브러리를 조직·검색하고(Management), unit test와 runtime feedback으로 이중 검증하고(Evaluation), 그 신호로 갱신한다(Refinement). 같은 해 2월 발표된 SkillsBench(arXiv:2602.12670, 86 tasks × 11 domains × 7,308 trajectories)는 <strong>"self-generated Skills provide no benefit on average"</strong> — 모델이 스스로 만든 스킬은 평균적으로 도움이 되지 않는다 — 라는 충격적 진단을 내렸다. MUSE는 정확히 그 진단에 대한 <strong>처방</strong>이다. 생성만으로는 부족하다는 결론에 lifecycle 관리로 답한다. 4개월 사이 SkillsBench가 진단하고, SkillOpt가 단일 스킬 학습으로, MUSE가 lifecycle 관리로 동시에 응답한 구도다.
+                            MUSE는 스킬을 다섯 단계의 통합 lifecycle 안에서 다룬다. 생성(Creation), 기억(Memory), 관리(Management), 평가(Evaluation), 정제(Refinement). 태스크 도중 필요하면 스킬을 만들고, 호출될 때마다 그 스킬에 경험이 누적되며(skill-level memory, 학술적으로 새로운 층), 라이브러리를 조직·검색하고, unit test와 runtime feedback으로 이중 검증한 뒤 그 신호로 갱신한다. 같은 해 2월 발표된 SkillsBench(arXiv:2602.12670, 86 tasks × 11 domains × 7,308 trajectories)는 모델이 스스로 만든 스킬은 평균적으로 도움이 되지 않는다는 충격적 진단을 내렸다. MUSE는 정확히 그 진단에 대한 <strong>처방</strong>이다. 생성만으로는 부족하다는 결론에 lifecycle 관리로 답한다. 넉 달 사이 SkillsBench가 진단하고, SkillOpt가 단일 스킬 학습으로, MUSE가 lifecycle 관리로 동시에 응답한 구도다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            페블러스는 이 흐름을 <strong>Voyager(2023, 학술 원형) → Hermes Agent(2025, 산업 구현) → SkillOpt(2026-05-22, 학습 기법) → MUSE(2026-05-26, lifecycle 관리)</strong> 4부작으로 정리해 왔다. 추상화는 매번 한 칸씩 올라간다. "스킬 라이브러리"에서 "스킬 자산의 일생 관리"로. DataClinic이 "데이터를 살아 있는 자산으로 본다"는 명제였다면, 그 명제는 이제 <strong>AI-Ready Behavior</strong> — 행동 자산을 진단 가능한 상태로 만든다 — 로 자연스럽게 확장된다. 데이터 품질 5신호(레이블·분포·신선도·결측·이상치)는 lifecycle 5단계로 재맵핑되고, 한국 AI 기본법 시행(2026-01-22) 이후의 audit trail 요건은 unit test + runtime feedback + skill-level memory가 만드는 증거 체인과 정확히 맞물린다. 한컴-LG ChatEXAONE 전략 협약(2026-05-22)이 한국 첫 SkillOps 의제화의 출발점이라면, 그 닷새 후 발행되는 이 글은 <strong>"행동 자산의 진단"</strong> 카테고리를 한국어로 처음 선언하는 자산이 된다.
+                            페블러스는 이 흐름을 <strong>Voyager(2023, 학술 원형) → Hermes Agent(2025, 산업 구현) → SkillOpt(2026-05-22, 학습 기법) → MUSE(2026-05-26, lifecycle 관리)</strong> 4부작으로 정리해 왔다. 추상화는 매번 한 칸씩 올라간다. 스킬 라이브러리에서 스킬 자산의 일생 관리로. DataClinic이 데이터를 살아 있는 자산으로 본다는 명제였다면, 이 흐름은 그 명제를 행동 차원으로 자연스럽게 확장한다. 데이터의 진단 가능성에서 행동의 진단 가능성으로. 데이터 품질 5신호(레이블·분포·신선도·결측·이상치)가 lifecycle 5단계로 재맵핑되고, 한국 AI 기본법 시행(2026-01-22) 이후의 audit trail 요건은 unit test + runtime feedback + skill-level memory가 만드는 증거 체인과 정확히 맞물린다.
                         </p>
                     </div>
 
+                    <!-- Editor's Note -->
+                    <blockquote class="themeable-card rounded-xl p-5 my-6 themeable-text leading-relaxed">
+                        <p><strong><em>편집자의 노트.</em></strong> 에이전트의 행동 자산을 진단 가능한 상태로 만든다는 명제는 페블러스가 데이터에 대해 해온 일의 자연스러운 다음 단계다. 한컴·LG ChatEXAONE 협약(2026-05-22)이 한국 SkillOps 의제화의 출발점이라면, 이 글은 그 닷새 뒤에 행동 자산의 진단이라는 카테고리를 한국어로 정리하려는 시도다. 시리즈 흐름은 Voyager → Hermes → SkillOpt → MUSE로 이어지고, 이 글은 그 네 번째 좌표다.</p>
+                    </blockquote>
+
                     <!-- Stat Cards -->
-                    <p class="themeable-text-secondary text-sm mt-8 mb-3">MUSE-Autoskill 프레임의 핵심 좌표와 주변 정량 신호를 한눈에 본다. 출처: arXiv:2605.27366·arXiv:2602.12670, McKinsey State of AI 2026, LangChain State of AI Agents 2025(n=1,340), Mem0.ai.</p>
+                    <h3 class="text-xl font-semibold themeable-heading mt-8 mb-3">주요 수치</h3>
+                    <p class="themeable-text-secondary text-sm mb-3">출처: <a href="https://arxiv.org/abs/2605.27366" target="_blank" rel="noopener" class="text-orange-500 hover:underline">arXiv:2605.27366</a> · arXiv:2602.12670, McKinsey State of AI 2026, LangChain State of AI Agents 2025(n=1,340), Mem0.ai.</p>
                     <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">5단계</p>
@@ -158,24 +164,24 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        AI 에이전트와 한 시간 동안 깊이 있는 대화를 나누어 본 사람이라면 누구나 한 번쯤 느꼈을 것이다 — <strong>"내일이면 이 대화를 전혀 기억하지 못하겠지."</strong> 어제 사용자가 알려준 회사 규칙, 어제 함께 발견한 풀이 절차, 어제 받은 미묘한 피드백 — 다음 세션이 열리는 순간 모든 흔적이 깨끗하게 지워진다. 사람이라면 단 한 번의 실수에서도 배우는데, AI는 같은 자리에서 같은 실수를 백 번이라도 반복한다.
+                        AI 에이전트와 한 시간 동안 깊이 있는 대화를 나누어 본 사람이라면 누구나 한 번쯤 느꼈을 것이다. <strong>"내일이면 이 대화를 전혀 기억하지 못하겠지."</strong> 어제 사용자가 알려준 회사 규칙, 어제 함께 발견한 풀이 절차, 어제 받은 미묘한 피드백. 다음 세션이 열리는 순간 모든 흔적이 깨끗하게 지워진다. 사람이라면 단 한 번의 실수에서도 배우는데, AI는 같은 자리에서 같은 실수를 백 번이라도 반복한다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        2025년에는 이 한계를 "메모리 기능"으로 부분적으로 봉합하려는 시도가 빅테크 전반에서 가시화되었다. ChatGPT memory, Anthropic Memory, Google Gemini 개인화 — 모두 사용자/세션 단위에서 누적되는 메모리다. 그러나 깊이 들여다보면 한 가지 공통점이 보인다. <strong>지금까지의 메모리는 "누가 대화하고 있는가"의 단위로만 작동한다.</strong> 사용자 단위, 세션 단위, 잘해야 에이전트 단위. "어떤 일을 하는가" — <strong>스킬 그 자체</strong>가 자신의 경험을 갖는다는 발상은 학술적으로도 산업적으로도 비어 있는 자리였다.
+                        2025년에는 이 한계를 "메모리 기능"으로 부분적으로 봉합하려는 시도가 빅테크 전반에서 가시화되었다. ChatGPT memory, Anthropic Memory, Google Gemini 개인화. 모두 사용자나 세션 단위에서 누적되는 메모리다. 깊이 들여다보면 한 가지 공통점이 보인다. <strong>지금까지의 메모리는 "누가 대화하고 있는가"의 단위로만 작동한다.</strong> 사용자 단위, 세션 단위, 잘해야 에이전트 단위. "어떤 일을 하는가", 즉 <strong>스킬 그 자체</strong>가 자신의 경험을 갖는다는 발상은 학술적으로도 산업적으로도 비어 있는 자리였다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스는 닷새 전 <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:text-orange-400 underline">Microsoft SkillOpt 논문</a>을 다루면서 "<strong>스킬 문서를 학습 가능한 텍스트 자산으로 다룬다</strong>"는 명제를 소개했다. SkillOpt가 풀어낸 질문이 <strong>"한 개의 스킬을 어떻게 학습시킬 것인가"</strong>였다면, 그 다음 질문은 자연스럽게 따라온다 — <strong>학습된 스킬을 어떻게 기억하고, 누적하고, 검증하고, 갱신할 것인가.</strong> 한 번 잘 만들어진 절차가 매 호출마다 어제의 자신을 잊는다면, 그것은 학습되었다고 말할 수 있는가.
+                        페블러스는 닷새 전 <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:text-orange-400 underline">Microsoft SkillOpt 논문</a>을 다루면서 <strong>스킬 문서를 학습 가능한 텍스트 자산으로 다룬다</strong>는 명제를 소개했다. SkillOpt가 풀어낸 질문이 "한 개의 스킬을 어떻게 학습시킬 것인가"였다면, 다음 질문은 자연스럽게 따라온다. <strong>학습된 스킬을 어떻게 기억하고, 누적하고, 검증하고, 갱신할 것인가.</strong> 한 번 잘 만들어진 절차가 매 호출마다 어제의 자신을 잊는다면, 그것을 학습되었다고 말할 수 있는가.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        시장의 정량 신호도 이 질문이 막연한 추상이 아님을 보여준다. McKinsey의 <em lang="en">State of AI 2026</em>에 따르면 <strong>에이전트 파일럿 프로젝트의 88%가 production 도달에 실패</strong>했고, 실패 기업의 <strong>64%가 그 원인으로 "evaluation gap"</strong>을 꼽았다. LangChain의 2025년 말 설문(n=1,340)은 <strong>layered memory를 도입한 조직에서 task completion이 31%에서 79%로 뛰었고 비용은 62% 줄었다</strong>고 보고한다. 기억 없는 에이전트는 그저 답답한 정도가 아니라 <strong>운영 단계에서 무너진다</strong>는 현장 데이터.
+                        시장의 정량 신호도 이 질문이 막연한 추상이 아님을 보여준다. McKinsey의 <em lang="en">State of AI 2026</em>에 따르면 <strong>에이전트 파일럿 프로젝트의 88%가 production 도달에 실패</strong>했고, 실패 기업의 <strong>64%가 그 원인으로 "evaluation gap"</strong>을 꼽았다. LangChain의 2025년 말 설문(n=1,340)은 <strong>layered memory를 도입한 조직에서 task completion이 31%에서 79%로 뛰었고 비용은 62% 줄었다</strong>고 보고한다. 기억 없는 에이전트는 그저 답답한 정도가 아니라 <strong>운영 단계에서 무너진다</strong>는 현장 데이터다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>이 보고서는 그 빈자리를 처음 학술적으로 메우려는 시도 — MUSE-Autoskill — 을 해부한다.</strong> 무엇을 제안하는지, 어떻게 작동하는지, 그리고 무엇보다 — 데이터 진단을 해온 회사가 이 흐름을 어떻게 받아 안는가. <strong>AI-Ready Data에서 AI-Ready Behavior로</strong> 명제가 한 칸 확장되는 자리.
+                            이 글은 그 빈자리를 처음 학술적으로 메우려는 시도, MUSE-Autoskill을 해부한다. 무엇을 제안하는지, 어떻게 작동하는지, 그리고 데이터 진단을 해온 회사가 이 흐름을 어떻게 받아 안는가. <strong>AI-Ready Data에서 AI-Ready Behavior로</strong> 명제가 한 칸 확장되는 자리다.
                         </p>
                     </div>
                 </section>
@@ -197,7 +203,7 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 줄로 옮기면 이렇다 — <strong>지금까지의 스킬은 한 번 만들어 두면 그 자리에 박힌 채로 늙어 간다.</strong> Voyager가 만든 스킬 라이브러리도, Hermes가 5+ tool call 후에 자동으로 적어 둔 절차 문서도, SkillOpt가 텍스트 공간에서 다듬어 낸 <code>best_skill.md</code>도 — 일단 결정되고 나면 자기 자신의 경험을 누적하지 못했다. 같은 스킬이 100번 호출되어도 그 100번의 경험은 어디에도 남지 않는다. MUSE의 답은 다섯 단계의 통합 lifecycle이다.
+                        풀어 쓰면 <strong>지금까지의 스킬은 한 번 만들어 두면 그 자리에 박힌 채로 늙어 간다</strong>는 진단이다. Voyager가 만든 스킬 라이브러리도, Hermes가 5+ tool call 후에 자동으로 적어 둔 절차 문서도, SkillOpt가 텍스트 공간에서 다듬어 낸 <code>best_skill.md</code>도, 일단 결정되고 나면 자기 자신의 경험을 누적하지 못했다. 같은 스킬이 100번 호출되어도 그 100번의 경험은 어디에도 남지 않는다. MUSE의 답은 다섯 단계의 통합 lifecycle이다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -206,11 +212,11 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        다섯 단계가 모두 처음 등장한 단계는 아니다. Creation은 Voyager가, Memory는 MemGPT가, Management는 산업 AgentOps 도구들이, Evaluation은 Reflexion이, Refinement는 GEPA가 부분적으로 다뤘다. <strong>다섯을 하나의 통합 lifecycle로 묶어 "스킬이라는 자산"의 일생을 처음으로 그린 작업이 MUSE다.</strong> 단계별로 따로 일하던 흐름을 하나의 운영 모델로 묶었다는 점이 학술적 새로움이다.
+                        다섯 단계가 모두 처음 등장한 것은 아니다. Creation은 Voyager가, Memory는 MemGPT가, Management는 산업 AgentOps 도구들이, Evaluation은 Reflexion이, Refinement는 GEPA가 부분적으로 다뤘다. <strong>다섯을 하나의 통합 lifecycle로 묶어 "스킬이라는 자산"의 일생을 처음으로 그린 작업이 MUSE다.</strong> 단계별로 따로 일하던 흐름을 하나의 운영 모델로 묶었다는 점이 학술적 새로움이다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        다섯 단계를 한 줄로 늘여 놓으면 그 안에 한 자산의 일생이 들어 있다. <strong>태어나고(Creation), 경험을 누적하고(Memory), 도서관 안에서 정돈되고(Management), 검진을 받고(Evaluation), 필요할 때 갱신된다(Refinement).</strong> 사람이 한 직업을 평생 키워 가는 흐름과 닮았다 — 처음 배우고, 일하면서 익숙해지고, 동료들과 나누고, 평가받고, 더 나은 버전으로 다시 자란다. MUSE 논문은 이 다섯 단계를 하나의 그림으로 정리해 두었다.
+                        다섯 단계를 늘여 놓으면 그 안에 한 자산의 일생이 들어 있다. <strong>태어나고(Creation), 경험을 누적하고(Memory), 도서관 안에서 정돈되고(Management), 검진을 받고(Evaluation), 필요할 때 갱신된다(Refinement).</strong> 사람이 한 직업을 평생 키워 가는 흐름과 닮았다. 처음 배우고, 일하면서 익숙해지고, 동료들과 나누고, 평가받고, 더 나은 버전으로 다시 자란다. MUSE 논문은 이 다섯 단계를 하나의 그림으로 정리했다.
                     </p>
 
                     <!-- Image: MUSE-Autoskill framework overview (5-stage lifecycle) -->
@@ -262,11 +268,11 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        해석하면 — 모델이 스스로 만든 스킬을 다시 자신에게 먹였을 때 <strong>평균적으로는 도움이 되지 않았다.</strong> 같은 논문은 사람이 큐레이션한 스킬은 평균 +16.2pp 향상(도메인별 +4.5~+51.9pp 편차)을 보고했고, 84개 task 중 16개는 자가 생성 스킬을 먹였을 때 오히려 점수가 더 떨어졌다고 했다. <strong>"생성만으로는 안 된다"</strong>는 진단. 그리고 정확히 3개월 뒤, 같은 SkillsBench를 평가 도구로 사용한 MUSE 논문이 lifecycle 처방으로 답했다. <strong>SkillsBench가 진단했고, MUSE가 처방했다.</strong>
+                        해석하면 모델이 스스로 만든 스킬을 다시 자신에게 먹였을 때 <strong>평균적으로는 도움이 되지 않았다</strong>는 뜻이다. 같은 논문은 사람이 큐레이션한 스킬은 평균 +16.2pp 향상(도메인별 +4.5~+51.9pp 편차)을 보고했고, 84개 task 중 16개는 자가 생성 스킬을 먹였을 때 오히려 점수가 더 떨어졌다고 했다. 생성만으로는 안 된다는 진단이었다. 정확히 3개월 뒤, 같은 SkillsBench를 평가 도구로 사용한 MUSE 논문이 lifecycle 처방으로 답했다. <strong>SkillsBench가 진단했고, MUSE가 처방했다.</strong>
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지 주의가 필요하다. <strong>SkillsBench는 MUSE 팀이 만든 벤치마크가 아니다.</strong> 별개 연구진(Li et al.)의 독립 작업이며, MUSE는 이를 평가 도구로 채택했을 뿐. 또한 MUSE 자체의 SkillsBench 점수는 v1 단계에서 <span lang="en">"initial evidence that lifecycle-managed skills can improve task success, efficiency, reuse, and cross-agent transfer"</span>로만 표기되어 있다. 정확한 baseline 비교 수치는 아직 공개되지 않았다. 본 보고서는 MUSE의 정량 단정을 피하고, <strong>lifecycle 프레임 자체의 통합력</strong>에 가치를 둔다.
+                        한 가지 주의가 필요하다. <strong>SkillsBench는 MUSE 팀이 만든 벤치마크가 아니다.</strong> 별개 연구진(Li et al.)의 독립 작업이며, MUSE는 이를 평가 도구로 채택했을 뿐이다. MUSE 자체의 SkillsBench 점수는 v1 단계에서 <em lang="en">"lifecycle-managed skills can improve task success, efficiency, reuse, and cross-agent transfer"</em>라는 초기 증거 수준으로만 표기되어 있다. 정확한 baseline 비교 수치는 아직 공개되지 않았다. 이 글은 MUSE의 정량 단정을 피하고, <strong>lifecycle 프레임 자체의 통합력</strong>에 가치를 둔다.
                     </p>
                 </section>
 
@@ -309,7 +315,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        스킬은 어떻게 태어나는가 — Voyager가 "라이브러리에 등록한다"고 답했다면, Hermes는 "5번의 반복을 감지한다"고 답했고, MUSE는 <strong>"검증을 동반한 채로 lifecycle에 진입한다"</strong>고 답한다. 같은 질문에 매번 한 칸씩 정교해진 답.
+                        스킬은 어떻게 태어나는가. Voyager가 "라이브러리에 등록한다"고 답했다면, Hermes는 "5번의 반복을 감지한다"고 답했고, MUSE는 <strong>"검증을 동반한 채로 lifecycle에 진입한다"</strong>고 답한다. 같은 질문에 매번 한 칸씩 정교해진 답이다.
                     </p>
 
                     <div class="key-insight">
@@ -336,7 +342,7 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        지금까지의 에이전트 메모리 연구는 두 개의 단위로 발전해 왔다. <strong>세션/사용자 단위</strong>(MemGPT 2023, ChatGPT memory 2024, Anthropic Memory 2025)와 <strong>에이전트 단위</strong>(Generative Agents 2023, Reflexion 2023). 세션 메모리는 "내가 누구와 대화했는가"를, 에이전트 메모리는 "이 에이전트가 무엇을 겪었는가"를 기억한다. MUSE는 여기에 세 번째 층 — <strong>스킬 단위 메모리</strong> — 를 명시적으로 도입한다.
+                        지금까지의 에이전트 메모리 연구는 두 개의 단위로 발전해 왔다. <strong>세션/사용자 단위</strong>(MemGPT 2023, ChatGPT memory 2024, Anthropic Memory 2025)와 <strong>에이전트 단위</strong>(Generative Agents 2023, Reflexion 2023). 세션 메모리는 "내가 누구와 대화했는가"를, 에이전트 메모리는 "이 에이전트가 무엇을 겪었는가"를 기억한다. MUSE는 여기에 세 번째 층, <strong>스킬 단위 메모리</strong>를 명시적으로 도입한다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -361,7 +367,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 발상을 가장 직관적으로 설명하는 비유는 <strong>객체지향 프로그래밍의 instance/class 분리</strong>다. class는 메소드를 정의하지만, 그 메소드가 어떤 instance에서 어떻게 호출되었는지는 따로 기록되지 않는다. 그러나 만약 메소드 자신이 "내가 몇 번 호출되었는가, 그 중 몇 번이 성공했는가, 어떤 인자 패턴에서 자주 실패했는가"를 기억한다면 — 그것이 바로 MUSE가 말하는 skill-level memory다. 메소드가 instance처럼 자기 자신의 호출 이력을 갖는 새 차원.
+                        이 발상을 가장 직관적으로 설명하는 비유는 <strong>객체지향 프로그래밍의 instance/class 분리</strong>다. class는 메소드를 정의하지만, 그 메소드가 어떤 instance에서 어떻게 호출되었는지는 따로 기록되지 않는다. 만약 메소드 자신이 "내가 몇 번 호출되었는가, 그 중 몇 번이 성공했는가, 어떤 인자 패턴에서 자주 실패했는가"를 기억한다면, 그것이 바로 MUSE가 말하는 skill-level memory다. 메소드가 instance처럼 자기 자신의 호출 이력을 갖는 새 차원이다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>cross-task transfer — 같은 스킬, 다른 태스크</h3>
@@ -375,7 +381,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        MUSE 논문은 한 스킬 안에 무엇이 누적되는지를 구체적인 SKILL.md 분해도로 보여준다. <strong>SKILL.md 본문(median 326줄), 보조 스크립트(9%), unit test(9%), references(0%)</strong> — 한 스킬이 어떤 구성요소들로 자산화되는지의 정량 단면.
+                        MUSE 논문은 한 스킬 안에 무엇이 누적되는지를 구체적인 SKILL.md 분해도로 보여준다. <strong>SKILL.md 본문(median 326줄), 보조 스크립트(9%), unit test(9%), references(0%).</strong> 한 스킬이 어떤 구성요소로 자산화되는지의 정량 단면이다.
                     </p>
 
                     <!-- Image: MUSE skill content composition -->
@@ -405,7 +411,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        SkillsBench가 진단한 문제 — "self-generated Skills provide no benefit on average" — 의 핵심은 <strong>검증 없이 만들어진 스킬</strong>에 있다. MUSE의 Evaluation 단계는 정확히 이 진단의 처방이다.
+                        SkillsBench가 진단한 문제, "self-generated Skills provide no benefit on average"의 핵심은 <strong>검증 없이 만들어진 스킬</strong>에 있다. MUSE의 Evaluation 단계는 정확히 이 진단의 처방이다.
                     </p>
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
@@ -424,16 +430,16 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>runtime feedback — 운영 중 발견되는 결함</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        그러나 unit test가 모든 것을 잡지는 못한다. 분포가 미묘하게 다른 입력, 도구 환경의 사소한 변화, 시간이 흐르며 누적되는 의미적 표류 — 이런 결함은 운영 중에만 드러난다. Reflexion(2023)이 처음 제안한 verbal feedback 메커니즘이 MUSE의 두 번째 검증 축으로 들어와, 운영 중 발견되는 실패·이상 패턴을 자가 비판으로 잡아낸다. 정적 게이트가 막지 못한 동적 결함을 동적 게이트가 잡는 이중 안전망.
+                        unit test가 모든 것을 잡지는 못한다. 분포가 미묘하게 다른 입력, 도구 환경의 사소한 변화, 시간이 흐르며 누적되는 의미적 표류. 이런 결함은 운영 중에만 드러난다. Reflexion(2023)이 처음 제안한 verbal feedback 메커니즘이 MUSE의 두 번째 검증 축으로 들어와, 운영 중 발견되는 실패·이상 패턴을 자가 비판으로 잡아낸다. 정적 게이트가 막지 못한 동적 결함을 동적 게이트가 잡는 이중 안전망이다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>Refinement — 검증 신호의 폐쇄 루프</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        Evaluation 신호가 모이면 Refinement가 작동한다. unit test에서 잡힌 구조적 결함은 스킬 본문 수정으로, runtime feedback에서 잡힌 의미적 결함은 메모리·메타데이터 갱신으로 흡수된다. 그리고 갱신된 스킬은 다시 Memory에 누적되어 다음 호출의 시작점이 된다. <strong>Creation → Memory → Management → Evaluation → Refinement → Memory</strong>의 폐쇄 루프. 한 번 만들고 끝나는 게 아니라 lifecycle 그 자체가 학습의 주체가 되는 구조.
+                        Evaluation 신호가 모이면 Refinement가 작동한다. unit test에서 잡힌 구조적 결함은 스킬 본문 수정으로, runtime feedback에서 잡힌 의미적 결함은 메모리·메타데이터 갱신으로 흡수된다. 갱신된 스킬은 다시 Memory에 누적되어 다음 호출의 시작점이 된다. <strong>Creation → Memory → Management → Evaluation → Refinement → Memory</strong>의 폐쇄 루프. 한 번 만들고 끝나는 게 아니라 lifecycle 그 자체가 학습의 주체가 되는 구조다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        MUSE 논문 자체도 이 검증 + Refinement 결합의 효과를 한 그림에 응축해 두었다. 보상(품질)을 그대로 유지하면서 latency와 tokens가 줄어드는 — <strong>lifecycle 관리된 스킬은 더 싸고 더 빠르고 더 정확하다</strong>는 결과의 산점도.
+                        MUSE 논문 자체도 이 검증과 Refinement 결합의 효과를 한 그림에 응축해 두었다. 보상(품질)을 그대로 유지하면서 latency와 tokens가 줄어드는 결과. <strong>lifecycle 관리된 스킬은 더 싸고 더 빠르고 더 정확하다.</strong>
                     </p>
 
                     <!-- Image: MUSE reward vs latency/tokens comparison -->
@@ -449,7 +455,7 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        왜 지금 이 lifecycle이 산업적으로 절실해졌는가. 한 개의 정량 신호가 그 절실함을 가장 또렷이 보여준다. 다음 세 개의 숫자는 따로 떨어진 통계가 아니라 한 그림을 그린다 — <strong>현장은 무너지고 있고, 무너지는 이유의 절반 이상이 평가의 부재이며, lifecycle 한 층만 더해도 두 배 가까이 회복된다.</strong> McKinsey가 진단하고, LangChain이 응답한다.
+                        왜 지금 이 lifecycle이 산업적으로 절실해졌는가. 다음 세 개의 숫자가 한 그림을 그린다. <strong>현장은 무너지고 있고, 무너지는 이유의 절반 이상이 평가의 부재이며, lifecycle 한 층만 더해도 두 배 가까이 회복된다.</strong> McKinsey가 진단하고, LangChain이 응답한다.
                     </p>
 
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
@@ -471,7 +477,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        McKinsey의 88%·64%는 단순히 평균값이 아니다. <strong>현장의 거의 모든 파일럿이 무너지고 있고, 그 중 절반 이상이 "평가 시스템이 없어서"</strong> 무너진다는 신호다. SkillOpt가 텍스트 공간 학습으로 +23.5pt를 만든 결과 위에, MUSE의 lifecycle 평가가 그 84%의 진입로를 열어준다면 — 산업적 의의는 학술 점수 한두 자릿수 향상보다 훨씬 크다.
+                        McKinsey의 88%와 64%는 단순한 평균값이 아니다. <strong>현장의 거의 모든 파일럿이 무너지고 있고, 그 중 절반 이상이 "평가 시스템이 없어서"</strong> 무너진다는 신호다. SkillOpt가 텍스트 공간 학습으로 +23.5pt를 만든 결과 위에, MUSE의 lifecycle 평가가 그 84%의 진입로를 열어준다면, 산업적 의의는 학술 점수 한두 자릿수 향상보다 훨씬 크다.
                     </p>
 
                     <div class="key-insight">
@@ -489,7 +495,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스의 자기진화 에이전트 시리즈는 처음부터 한 가지 가정을 따라왔다 — <strong>학술의 직관이 산업으로 흐르고, 산업의 구현이 다시 학술의 정교화로 돌아온다.</strong> Voyager부터 MUSE까지 4년 사이의 좌표가 그 가정을 정확히 보여준다.
+                        페블러스의 자기진화 에이전트 시리즈는 처음부터 한 가지 가정을 따라왔다. <strong>학술의 직관이 산업으로 흐르고, 산업의 구현이 다시 학술의 정교화로 돌아온다.</strong> Voyager부터 MUSE까지 4년 사이의 좌표가 그 가정을 정확히 보여준다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -512,12 +518,12 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        시리즈를 통과해서 보면 추상화가 매번 한 칸씩 올라간다. Voyager는 <strong>"스킬이라는 객체가 존재한다"</strong>는 발상의 학술 원형이었다. Hermes는 그 객체를 <strong>"산업 코드 안에서 어떻게 자동 생성하는가"</strong>를 보였다. SkillOpt는 그 객체를 <strong>"어떻게 학습 가능한 상태로 다루는가"</strong>를 풀었다. MUSE는 마침내 그 객체를 <strong>"어떻게 살아 있는 자산으로 관리하는가"</strong>를 묻는다. 단일 스킬에서 스킬 도서관 전체로, 학습 기법에서 lifecycle 거버넌스로 — 다섯 해 사이의 사고가 단계적으로 깊어졌다.
+                        시리즈를 통과해서 보면 추상화가 매번 한 칸씩 올라간다. Voyager는 <strong>"스킬이라는 객체가 존재한다"</strong>는 발상의 학술 원형이었다. Hermes는 그 객체를 <strong>"산업 코드 안에서 어떻게 자동 생성하는가"</strong>로 보였다. SkillOpt는 그 객체를 <strong>"어떻게 학습 가능한 상태로 다루는가"</strong>로 풀었다. MUSE는 마침내 그 객체를 <strong>"어떻게 살아 있는 자산으로 관리하는가"</strong>로 묻는다. 단일 스킬에서 스킬 도서관 전체로, 학습 기법에서 lifecycle 거버넌스로. 다섯 해 사이의 사고가 단계적으로 깊어졌다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.1</span>AgentOps → SkillOps → MemoryOps — 카테고리 진화</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        IT 산업은 운영(operations) 카테고리를 통해 새로운 기술 패러다임을 흡수해 왔다. DevOps(2007), MLOps(2017), LLMOps(2023). 그리고 2024년 무렵부터 <strong>AgentOps</strong>가 안정화 단계에 진입했다 — Mem0(GitHub 48,000+ stars, Series A $24M, AWS Agent SDK 독점), Letta, Zep, LangMem 4강 체제. Anthropic의 <em lang="en">Agent Skills Open Standard</em>(2025-12)가 Claude·OpenAI Codex·Gemini CLI에 동시 채택된 것은 이 흐름의 결정적 시그널이었다.
+                        IT 산업은 운영(operations) 카테고리를 통해 새로운 기술 패러다임을 흡수해 왔다. DevOps(2007), MLOps(2017), LLMOps(2023). 2024년 무렵부터 <strong>AgentOps</strong>가 안정화 단계에 진입했다. Mem0(GitHub 48,000+ stars, Series A $24M, AWS Agent SDK 독점), Letta, Zep, LangMem 4강 체제. Anthropic의 <em lang="en">Agent Skills Open Standard</em>(2025-12)가 Claude·OpenAI Codex·Gemini CLI에 동시 채택된 것은 이 흐름의 결정적 시그널이었다.
                     </p>
 
                     <!-- Image: DevOps toolchain (lineage that SkillOps inherits) -->
@@ -533,7 +539,7 @@
                     </figure>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        그 위에 2026년 봄부터 새로운 sub-segment가 모습을 드러내고 있다 — <strong>SkillOps</strong>. SkillOpt와 MUSE가 학술 청사진을 그렸고, 산업 도구는 아직 표준화되지 않았다. 그리고 그 옆에는 더 큰 빈자리 — <strong>MemoryOps</strong> — 가 있다. skill-level memory가 본격화되면 메모리 그 자체의 lifecycle 관리(생성·진단·삭제·전이)가 별도 카테고리로 떨어져 나올 가능성이 크다.
+                        그 위에 2026년 봄부터 새로운 sub-segment가 모습을 드러내고 있다. <strong>SkillOps</strong>. SkillOpt와 MUSE가 학술 청사진을 그렸고, 산업 도구는 아직 표준화되지 않았다. 그 옆에는 더 큰 빈자리, <strong>MemoryOps</strong>가 있다. skill-level memory가 본격화되면 메모리 그 자체의 lifecycle 관리(생성·진단·삭제·전이)가 별도 카테고리로 떨어져 나올 가능성이 크다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -562,7 +568,7 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">6.3</span>혼동 주의 — 동명 인접 사례</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지 사실관계를 정리하고 넘어가자. 본 보고서가 다루는 <strong>MUSE-Autoskill(arXiv:2605.27366, Lin et al., 2026-05-26)</strong>과는 별개로, 비슷한 시기에 발표된 동명의 다른 프레임워크가 존재한다 — <em lang="en">"Learning on the Job"</em>(arXiv:2510.08002, Cheng Yang et al., 5기관 공동, 2025-10-09, GitHub KnowledgeXLab/MUSE). 같은 약자 "MUSE"를 쓰지만 저자·소속·접근이 다른 별개 연구다. 본 보고서는 사용자 link verbatim 검증을 거친 <strong>arXiv:2605.27366</strong>을 1차 출처로 명시한다.
+                        한 가지 사실관계를 정리하고 넘어간다. 이 글이 다루는 <strong>MUSE-Autoskill(arXiv:2605.27366, Lin et al., 2026-05-26)</strong>과는 별개로, 비슷한 시기에 발표된 동명의 다른 프레임워크가 존재한다. <em lang="en">"Learning on the Job"</em>(arXiv:2510.08002, Cheng Yang et al., 5기관 공동, 2025-10-09, GitHub KnowledgeXLab/MUSE). 같은 약자 "MUSE"를 쓰지만 저자·소속·접근이 다른 별개 연구다. 이 글은 사용자 link verbatim 검증을 거친 <strong>arXiv:2605.27366</strong>을 1차 출처로 명시한다.
                     </p>
                 </section>
 
@@ -574,17 +580,17 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스는 지난 몇 해 동안 한 가지 명제를 따라 움직였다 — <strong>"데이터를 진단 가능한 상태로 만든다."</strong> DataClinic이 학습 데이터의 다섯 신호를 진단했고, AI-Ready Data가 그 진단의 출력 카테고리였으며, DataGreenhouse와 PebbloSim이 진단된 데이터의 운영 환경을 제공해 왔다. MUSE-Autoskill이 던진 명제는 이 흐름의 자연스러운 다음 단계다 — <strong>행동(behavior) 자산도 진단 가능한 상태로 만들 수 있는가.</strong>
+                        페블러스는 지난 몇 해 동안 한 가지 명제를 따라 움직였다. <strong>데이터를 진단 가능한 상태로 만든다.</strong> DataClinic이 학습 데이터의 다섯 신호를 진단했고, AI-Ready Data가 그 진단의 출력 카테고리였으며, DataGreenhouse와 PebbloSim이 진단된 데이터의 운영 환경을 제공해 왔다. MUSE-Autoskill이 던진 명제는 이 흐름의 자연스러운 다음 단계다. <strong>행동(behavior) 자산도 진단 가능한 상태로 만들 수 있는가.</strong>
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>AI-Ready Data → AI-Ready Behavior</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        명제는 한 칸 확장된다. AI 학습용 데이터의 품질을 진단해 온 회사가, AI 에이전트의 행동 자산 품질을 진단하는 회사로 자연스럽게 옮겨간다. SkillOpt가 "스킬 문서를 학습 가능한 텍스트 자산으로 다룬다"를 보였다면, MUSE는 "그 텍스트 자산이 lifecycle을 가진 long-lived asset"임을 선언한다. 두 명제가 모이는 자리에 페블러스의 다음 카테고리가 있다 — <strong>AI-Ready Behavior</strong>. 데이터 진단의 명제를 행동 차원으로 확장한 명제.
+                        명제는 한 칸 확장된다. AI 학습용 데이터의 품질을 진단해 온 회사가, AI 에이전트의 행동 자산 품질을 진단하는 회사로 자연스럽게 옮겨간다. SkillOpt가 "스킬 문서를 학습 가능한 텍스트 자산으로 다룬다"를 보였다면, MUSE는 "그 텍스트 자산이 lifecycle을 가진 long-lived asset"임을 선언한다. 두 명제가 모이는 자리에 페블러스의 다음 카테고리가 있다. <strong>AI-Ready Behavior.</strong> 데이터 진단의 명제를 행동 차원으로 확장한 명제다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>DataClinic 5신호 → SkillClinic 5신호 재맵핑</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스 DataClinic은 학습 데이터를 다섯 가지 신호로 진단해 왔다 — 레이블 무결성, 분포 균형, 신선도, 결측, 이상치. 이 다섯 신호는 lifecycle 5단계로 1:1 재맵핑된다. <strong>같은 진단 철학이 데이터에서 행동으로 옮겨붙는 자리.</strong>
+                        페블러스 DataClinic은 학습 데이터를 다섯 가지 신호로 진단해 왔다. 레이블 무결성, 분포 균형, 신선도, 결측, 이상치. 이 다섯 신호는 lifecycle 5단계로 1:1 재맵핑된다. <strong>같은 진단 철학이 데이터에서 행동으로 옮겨붙는 자리다.</strong>
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -603,11 +609,11 @@
                                 <tr class="border-b-2 themeable-border" style="background: rgba(248, 104, 37, 0.06);"><td class="p-3 font-bold themeable-text">이상치</td><td class="p-3 text-center">→</td><td class="p-3 themeable-text font-bold">Refinement 트리거</td><td class="p-3">runtime feedback이 갑자기 악화된 스킬, anomalous 호출 패턴</td></tr>
                             </tbody>
                         </table>
-                        <p class="text-xs themeable-muted mt-2">출처: 페블러스 DataClinic 5신호 → MUSE-Autoskill lifecycle 5단계 1:1 재맵핑(본 보고서 자체 합성). 한국어로 정의된 첫 매핑.</p>
+                        <p class="text-xs themeable-muted mt-2">출처: 페블러스 DataClinic 5신호 → MUSE-Autoskill lifecycle 5단계 1:1 재맵핑(이 글의 자체 합성).</p>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 매핑은 페블러스의 한국어 자산이다. 영어권에서도 아직 DataClinic 5신호와 lifecycle 5단계의 1:1 매핑을 시도한 작업은 보이지 않는다. <strong>"행동 자산을 진단 가능한 상태로 본다"</strong>는 명제가 한국어 카테고리로 처음 선언되는 자리.
+                        이 매핑은 페블러스의 한국어 자산이다. 영어권에서도 아직 DataClinic 5신호와 lifecycle 5단계의 1:1 매핑을 시도한 작업은 보이지 않는다. <strong>행동 자산을 진단 가능한 상태로 본다</strong>는 명제가 한국어로 정리되는 한 자리다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.3</span>고객/파트너 실무 함의 — 네 가지 질문</h3>
@@ -635,7 +641,7 @@
                     </ul>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 모든 질문은 <strong>데이터 진단 회사의 일</strong>이다. 페블러스가 "행동 자산의 가시화·진단·관리" 도구를 한국어 환경에 맞춰 제공할 수 있다면, MLOps 너머 AgentOps · SkillOps 시장의 자연스러운 진입로가 된다.
+                        이 질문들은 <strong>데이터 진단 회사의 일</strong>이다. 페블러스가 행동 자산의 가시화·진단·관리 도구를 한국어 환경에 맞춰 제공할 수 있다면, MLOps 너머 AgentOps와 SkillOps 시장의 자연스러운 진입로가 열린다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.4</span>한국 동시일 — 5월 22일과 5월 27일 사이</h3>
@@ -644,7 +650,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        아래 timeline은 단순 연표가 아니다. <strong>규제(AI 기본법)가 audit trail의 문법을 먼저 깔았고, 산업(한컴·LG 협약)이 같은 날 한국형 SkillOps의 첫 깃발을 꽂았으며, 학술(SkillOpt·MUSE)이 그 위에 lifecycle의 도면을 그렸다.</strong> 닷새 안에 규제·산업·학술이 한 자리에서 만났고, 페블러스의 발행일은 그 만남을 한국어 카테고리로 묶어 두는 자리에 놓인다. 시점은 우연이 아니라, 카테고리가 형성될 때의 자연스러운 굴절점이다.
+                        아래 timeline은 단순 연표가 아니다. <strong>규제(AI 기본법)가 audit trail의 문법을 먼저 깔았고, 산업(한컴·LG 협약)이 같은 날 한국형 SkillOps의 첫 깃발을 꽂았으며, 학술(SkillOpt·MUSE)이 그 위에 lifecycle의 도면을 그렸다.</strong> 닷새 안에 규제·산업·학술이 한 자리에서 만났고, 페블러스의 발행일은 그 만남을 한국어로 정리하려는 자리에 놓인다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -659,14 +665,14 @@
                                 <tr class="border-b themeable-border"><td class="p-3 themeable-text">2026-05-22</td><td class="p-3 font-bold themeable-text">한컴 · LG AI연구원 ChatEXAONE 협약</td><td class="p-3">한국 첫 SkillOps 의제화 시그널</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 themeable-text">2026-05-22</td><td class="p-3 font-bold themeable-text">Microsoft SkillOpt arXiv (같은 날)</td><td class="p-3">단일 스킬 학습 +23.5pt 실증</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 themeable-text">2026-05-26</td><td class="p-3 font-bold themeable-text">MUSE-Autoskill arXiv</td><td class="p-3">5단계 lifecycle + skill-level memory 첫 통합</td></tr>
-                                <tr class="border-b-2 themeable-border" style="background: rgba(248, 104, 37, 0.06);"><td class="p-3 themeable-text">2026-05-27</td><td class="p-3 font-bold themeable-heading">페블러스 발행 (본 보고서)</td><td class="p-3 themeable-text">AI-Ready Behavior · SkillClinic 한국어 카테고리 선언</td></tr>
+                                <tr class="border-b-2 themeable-border" style="background: rgba(248, 104, 37, 0.06);"><td class="p-3 themeable-text">2026-05-27</td><td class="p-3 font-bold themeable-heading">페블러스 발행 (이 글)</td><td class="p-3 themeable-text">AI-Ready Behavior · SkillClinic 한국어 정리</td></tr>
                             </tbody>
                         </table>
                         <p class="text-xs themeable-muted mt-2">출처: 국가법령정보센터, ZDNet Korea(2026-05-22), arXiv 발표일, 페블러스 합성.</p>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        시점은 우연이 아니다. 한국 AI 기본법의 audit trail 요건이 시행되고 넉 달, 한컴·LG ChatEXAONE 협약으로 한국 첫 SkillOps 의제가 가시화되고 닷새 — 정확히 이 자리에서 학술이 lifecycle 프레임을 제시했고, 페블러스는 그 프레임을 한국어 진단 카테고리로 받아 적는다. <strong>AI-Ready Data → AI-Ready Behavior</strong>, <strong>DataClinic → SkillClinic</strong>, <strong>DataGreenhouse → BehaviorGreenhouse</strong>. 세 쌍의 명제가 한 줄로 늘어선다.
+                        시점은 우연이 아니다. 한국 AI 기본법의 audit trail 요건이 시행되고 넉 달, 한컴·LG ChatEXAONE 협약으로 한국 첫 SkillOps 의제가 가시화되고 닷새. 정확히 이 자리에서 학술이 lifecycle 프레임을 제시했고, 페블러스는 그 프레임을 한국어로 받아 적는다. <strong>AI-Ready Data → AI-Ready Behavior</strong>, <strong>DataClinic → SkillClinic</strong>, <strong>DataGreenhouse → BehaviorGreenhouse</strong>. 세 쌍의 명제가 한 줄로 늘어선다.
                     </p>
                 </section>
 
@@ -678,20 +684,20 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        AI 에이전트와 한 시간 동안 깊이 있는 대화를 나누어 본 사람이라면 누구나 한 번쯤 느꼈을 것이다 — 내일이면 이 대화를 기억하지 못한다는 사실이 묘하게 아쉽다는 것을. MUSE-Autoskill이 던진 발상은 그 아쉬움에 대한 첫 학술적 답에 가깝다. <strong>기억은 사용자에게도, 에이전트에게도, 마지막에는 스킬 자체에게도 산다.</strong> 한 절차가 자기 자신의 호출 이력을 갖는다. 한 스킬이 백 번의 경험을 자기 안에 누적한다. 어제의 자신을 기억하는 행동 자산이라는 카테고리가 학술 프레임으로 처음 그려진 자리.
+                        AI 에이전트와 한 시간 동안 깊이 있는 대화를 나누어 본 사람이라면 누구나 한 번쯤 느꼈을 것이다. 내일이면 이 대화를 기억하지 못한다는 사실이 묘하게 아쉽다는 것을. MUSE-Autoskill이 던진 발상은 그 아쉬움에 대한 첫 학술적 답에 가깝다. <strong>기억은 사용자에게도, 에이전트에게도, 마지막에는 스킬 자체에게도 산다.</strong> 한 절차가 자기 자신의 호출 이력을 갖는다. 한 스킬이 백 번의 경험을 자기 안에 누적한다. 어제의 자신을 기억하는 행동 자산이라는 카테고리가 학술 프레임으로 처음 그려진 자리다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        기억을 가진 AI는 단순히 더 똑똑한 AI가 아니다. <strong>더 인간적인 협력자가 된다.</strong> 어제 사용자가 알려준 회사 컨벤션을 오늘도 기억한다면, 어제 실패한 절차를 오늘은 살짝 다듬어 다시 시도한다면, 작은 운영 자산 하나하나가 자기 자신의 경험을 갖는다면 — 매번 같은 자리에서 같은 실수를 반복하는 도구가 아니라 함께 자라는 동료가 된다. 그 미래를 MUSE는 lifecycle이라는 다섯 단계 프레임으로 그렸고, 페블러스는 그 프레임을 한국어 진단 카테고리로 받아 적었다.
+                        기억을 가진 AI는 단순히 더 똑똑한 AI가 아니다. <strong>더 인간적인 협력자가 된다.</strong> 어제 사용자가 알려준 회사 컨벤션을 오늘도 기억한다면, 어제 실패한 절차를 오늘은 살짝 다듬어 다시 시도한다면, 작은 운영 자산 하나하나가 자기 자신의 경험을 갖는다면. 매번 같은 자리에서 같은 실수를 반복하는 도구가 아니라 함께 자라는 동료가 된다. 그 미래를 MUSE는 lifecycle이라는 다섯 단계 프레임으로 그렸고, 페블러스는 그 프레임을 한국어로 받아 적었다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지는 분명하다. MUSE의 정량 결정타는 아직 v1 단계라 비어 있다. 실제 비교 점수, baseline 대비 향상폭, 통계적 신뢰구간 — 모두 다음 버전을 기다린다. 그러나 그것이 본 보고서의 무게중심이 아니다. <strong>중요한 것은 프레임 자체의 통합력이다.</strong> 다섯 단계의 lifecycle, 세 층의 메모리, 두 갈래의 검증, 한 가지 새 카테고리. 정량 수치가 채워지기 전에 정성적 지도가 먼저 그려진다. 데이터 진단의 명제가 행동 진단의 명제로 한 칸 확장된, 그 첫 한국어 좌표.
+                        한 가지는 분명하다. MUSE의 정량 결정타는 아직 v1 단계라 비어 있다. 실제 비교 점수, baseline 대비 향상폭, 통계적 신뢰구간. 모두 다음 버전을 기다린다. 그러나 그것이 이 글의 무게중심이 아니다. <strong>중요한 것은 프레임 자체의 통합력이다.</strong> 다섯 단계의 lifecycle, 세 층의 메모리, 두 갈래의 검증, 한 가지 새 카테고리. 정량 수치가 채워지기 전에 정성적 지도가 먼저 그려진다. 데이터 진단의 명제가 행동 진단의 명제로 한 칸 확장된, 그 첫 한국어 좌표다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>다음 글들이 다룰 것 — pb가 기억을 갖는다면.</strong> 페블러스의 사내 AI 에이전트 pb가 skill-level memory를 갖춘다면 어떤 일들이 가능해질까. 어제 동료가 알려준 회사 톤을 오늘 글에 자연스럽게 녹이고, 지난주 실패한 배포 절차를 이번에는 한 단계 우회해 시도하며, 매 호출마다 자기 자신의 경험을 한 줄씩 누적하는 작은 자산이 된다면 — 그 미래는 학술의 정점을 산업의 따스함으로 옮겨 적는 일이다. 본 시리즈의 다음 글들이 천천히 그려 갈 자리.
+                            다음 글들이 다룰 것은 pb가 기억을 갖는다면 어떤 일들이 가능해질까다. 페블러스의 사내 AI 에이전트 pb가 skill-level memory를 갖춘다면. 어제 동료가 알려준 회사 톤을 오늘 글에 자연스럽게 녹이고, 지난주 실패한 배포 절차를 이번에는 한 단계 우회해 시도하며, 매 호출마다 자기 자신의 경험을 한 줄씩 누적하는 작은 자산이 된다면. 그 미래는 학술의 정점을 산업의 따스함으로 옮겨 적는 일이다. 시리즈의 다음 글들이 천천히 그려 갈 자리다.
                         </p>
                     </div>
                 </section>
@@ -703,7 +709,7 @@
                 <section id="references" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-6">참고문헌</h2>
                     <p class="themeable-text leading-relaxed mb-6">
-                        본 보고서가 인용한 학술 논문, 산업 표준, 시장 보고서, 정책 문헌을 출처별로 묶어 두었다. 1차 출처(arXiv 논문)는 직접 링크를 따라가 verbatim 인용을 확인할 수 있다.
+                        이 글이 인용한 학술 논문, 산업 표준, 시장 보고서, 정책 문헌을 출처별로 묶어 두었다. 1차 출처(arXiv 논문)는 직접 링크를 따라가 verbatim 인용을 확인할 수 있다.
                     </p>
 
                     <div class="flex gap-2 mb-6">
@@ -715,7 +721,7 @@
                         </button>
                     </div>
 
-                    <h3 class="text-xl font-semibold themeable-heading mb-4">1차 소스 — 본 보고서의 주제 논문</h3>
+                    <h3 class="text-xl font-semibold themeable-heading mb-4">1차 소스 — 이 글의 주제 논문</h3>
                     <ul class="reference-list mb-6">
                         <li><span class="ref-num">1.</span><span class="ref-body">Lin, H., Li, P., Song, J., Jiang, F., &amp; Zhang, T. (2026). <a href="https://arxiv.org/abs/2605.27366" target="_blank" rel="noopener"><strong>MUSE-Autoskill: Self-Evolving Agents via Skill Creation, Memory, Management, and Evaluation</strong></a>. arXiv:2605.27366. (ByteDance Infra AI Lab 추정), 2026-05-26.</span></li>
                         <li><span class="ref-num">2.</span><span class="ref-body">Li, X., Chen, W., Liu, Y., Zheng, S. et al. (2026). <a href="https://arxiv.org/abs/2602.12670" target="_blank" rel="noopener"><em>SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks</em></a>. arXiv:2602.12670. 2026-02-13.</span></li>


### PR DESCRIPTION
## Summary
ko-prose-humanizer 도입 후 시리즈 4편 사후 검수의 두 번째. Evans → SkillOpt → **MUSE** → PIPEDA 순서.

## 진단 결과 (총점 ~40/110, 0.36 — 온건 교정)

MUSE는 SkillOpt보다 자사 톤이 진했고 위키체("본 보고서") 8곳, 영어 병기 강박이 두드러졌음. 본문 호흡은 양호.

| Tell | Before | After |
|------|--------|-------|
| T1 em-dash | 98개 (1/238자) | **51개 (1/451자)** |
| T4 메타 예고문 | 4+곳 | **0** |
| T7 위키체 '본 보고서' | 8 | **1** (자기참조 references만 유지) |
| T11 자사 점프 | 5곳 | 톤다운 (Editor's Note로 분리) |

## 주요 변경

### Exec Summary 재구성
- arXiv 논문에 외부 링크
- 영어 병기(`<span lang="en">`) 정제
- "한국어로 처음 선언하는 자산" 자사 점프 제거
- **Editor's Note 추가** — 4부작 흐름 + 페블러스 동기
- Stat Cards 위 "주요 수치" h3

### §1~§6 산문
- T4 메타 예고문 모두 제거
- em-dash 동격 재진술 → 마침표·접속어
- §6.3 "동명 인접 사례" 부분의 "본 보고서" 정제

### §7 자사 톤 톤다운
- "한국어 카테고리로 처음 선언되는 자리" → "한국어로 정리되는 한 자리"
- "굴절점" 카피 톤 문장 제거
- timeline 표 "한국어 카테고리 선언" → "한국어 정리"

### §8 마무리 정제
- 자기검증 grep 통과 (em-dash 51, T4 모두 0)

## 보존
- 4부작 흐름 (Voyager → Hermes → SkillOpt → MUSE)
- 모든 수치, 이미지 5장, key-insight 6, blockquote 6
- 한국 AI 기본법·한컴LG·McKinsey·LangChain 데이터
- DataClinic 5신호 → SkillClinic 매핑 표

## ko-prose-humanizer 실전 학습 (3건째 사례)
| 글 | em-dash Before | After | 빈도 변화 |
|---|---|---|---|
| Evans KO | 117 | 52 | 1/237 → 1/494 |
| Evans EN | 143 | 70 | 1/320 → 1/621 |
| SkillOpt KO | 73 | 49 | 1/277 → 1/407 |
| **MUSE KO** | **98** | **51** | **1/238 → 1/451** |

공통 패턴 확인: em-dash 약 50% 감소, T4 메타 예고문 모두 제거, T11 자사 점프 톤다운. SkillOpt/MUSE는 영어 병기·위키체가 추가 신호.

## Test plan
- [ ] Exec Summary에 Editor's Note 자연스러운지 + 주요 수치 h3
- [ ] §7 자사 톤 약하게 들리는지 (이전엔 카피)
- [ ] 4부작 흐름 + DataClinic 매핑 표 보존
- [ ] arXiv 외부 링크 6곳 동작
- [ ] 모든 수치, 이미지(5장), 시리즈 링크 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)