### PR TITLE
voice(report): PIPEDA KO 사후 검수 — ko-prose-humanizer 세 번째 적용 (em-dash 114→69)

### DIFF
--- a/report/openai-pipeda-ai-training-data-regulation/ko/index.html
+++ b/report/openai-pipeda-ai-training-data-regulation/ko/index.html
@@ -114,21 +114,24 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Executive Summary</h2>
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            2026년 5월 6일, 캐나다의 4개 개인정보위원회가 OpenAI ChatGPT에 대한 3년 합동조사를 종결하며 <strong>PIPEDA Findings #2026-002</strong>를 공식 발표했다. 연방 OPC의 Philippe Dufresne, 퀘벡 CAI의 Naomi Ayotte, BC OIPC의 Michael Harvey, Alberta OIPC의 Diane McLeod — 네 명의 위원장이 한 자리에서 같은 사실관계에 도달했지만 결론은 넷으로 갈렸다. AI 훈련 데이터 수집 관행에 대한 글로벌 규제 동향의 변곡점이자 G7 첫 공식 판정이다. BC와 Alberta의 한 줄이 가장 결정적이다 — <em lang="en">"scraped data for which OpenAI has not obtained, and cannot obtain, consent."</em> <strong>사후 동의는 불가능하다</strong>는 선언.
+                            2026년 5월 6일, 캐나다의 4개 개인정보위원회가 OpenAI ChatGPT에 대한 3년 합동조사를 종결하며 <strong>PIPEDA Findings #2026-002</strong>를 공식 발표했다. 연방 OPC의 Philippe Dufresne, 퀘벡 CAI의 Naomi Ayotte, BC OIPC의 Michael Harvey, Alberta OIPC의 Diane McLeod. 네 명의 위원장이 한 자리에서 같은 사실관계에 도달했지만 결론은 넷으로 갈렸다. AI 훈련 데이터 수집 관행에 대한 글로벌 규제 동향의 변곡점이자 G7 첫 공식 판정이다. BC와 Alberta의 한 줄이 가장 결정적이다. <em lang="en">"scraped data for which OpenAI has not obtained, and cannot obtain, consent."</em> <strong>사후 동의는 불가능하다</strong>는 선언이다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            결정문은 다섯 개의 위반을 확정했다 — 개인정보 과다 수집(overcollection), 유효한 동의·투명성 결여(lack of valid consent and transparency), 개인정보 사실 부정확성(factual inaccuracies, 환각의 법적 재정의), 열람·정정·삭제 권리 침해(access·correct·delete issues), 관리 책임 결여(lack of accountability). 결정은 4중으로 분기되었다. 연방 OPC는 OpenAI의 시정 약속을 받아들여 <em lang="en">"well-founded and conditionally resolved"</em>로 종결했고, 퀘벡 CAI는 권고 조치로 처리했지만, BC와 Alberta는 시정 약속만으로는 불충분하다고 보고 <em lang="en">"well-founded but unresolved"</em>로 거부했다. Michael Harvey는 한 발 더 나아갔다 — <em lang="en">"ChatGPT, by design, cannot be compliant with the province's privacy law as currently written."</em> 동일한 사실관계가 네 개의 결론을 만들어냈고, 이는 <strong>가장 엄격한 관할이 점진적으로 글로벌 표준이 된다</strong>는 흐름의 첫 증거다.
+                            결정문은 다섯 개의 위반을 확정했다. 개인정보 과다 수집(overcollection), 유효한 동의·투명성 결여(lack of valid consent and transparency), 개인정보 사실 부정확성(factual inaccuracies, 환각의 법적 재정의), 열람·정정·삭제 권리 침해(access·correct·delete issues), 관리 책임 결여(lack of accountability). 결정은 4중으로 분기되었다. 연방 OPC는 OpenAI의 시정 약속을 받아들여 <em lang="en">"well-founded and conditionally resolved"</em>로 종결했고, 퀘벡 CAI는 권고 조치로 처리했지만, BC와 Alberta는 시정 약속만으로는 불충분하다고 보고 <em lang="en">"well-founded but unresolved"</em>로 거부했다. Michael Harvey는 한 발 더 나아갔다. <em lang="en">"ChatGPT, by design, cannot be compliant with the province's privacy law as currently written."</em> 동일한 사실관계가 네 개의 결론을 만들어냈고, 이는 <strong>가장 엄격한 관할이 점진적으로 글로벌 표준이 된다</strong>는 흐름의 첫 증거다.
                         </p>
                         <p class="themeable-text leading-relaxed mt-4">
-                            이 결정은 진공 상태에 떨어진 게 아니다. 2024년 12월 이탈리아 Garante가 OpenAI에 부과한 €15M(약 ₩225억) 과징금, 2026년 8월 2일 EU AI Act 고위험 시스템 전면 시행(최대 €35M 또는 매출 7%), 2026년 1월 22일 시행된 한국 AI 기본법, 그리고 2025년 매출 3%에서 10%로 강화된 한국 개인정보보호법 과징금 — 글로벌 규제 도미노의 정확한 변곡점에 캐나다가 섰다. 페블러스는 이 변곡점을 <strong>AI-Ready Data → AI-Ready Compliance</strong>의 등장으로 읽는다. DataClinic이 진단해 온 5신호(레이블·분포·신선도·결측·이상치) 위에 <strong>6번째 신호 "합법성"</strong>이 추가되는 순간이다. 본 보고서는 AI 거버넌스 4부작(Magnifica Humanitas · SkillOpt · MUSE-Autoskill · 본 글)의 마지막 좌표로, 도덕이 묻고 학술이 답하고 법이 강제하는 흐름의 법적 착륙점을 그린다.
+                            이 결정은 진공 상태에 떨어진 게 아니다. 2024년 12월 이탈리아 Garante가 OpenAI에 부과한 €15M(약 ₩225억) 과징금, 2026년 8월 2일 EU AI Act 고위험 시스템 전면 시행(최대 €35M 또는 매출 7%), 2026년 1월 22일 시행된 한국 AI 기본법, 그리고 2025년 매출 3%에서 10%로 강화된 한국 개인정보보호법 과징금. 글로벌 규제 도미노의 정확한 변곡점에 캐나다가 섰다. 페블러스는 이 변곡점을 <strong>AI-Ready Data → AI-Ready Compliance</strong>의 등장으로 읽는다. DataClinic이 진단해 온 5신호(레이블·분포·신선도·결측·이상치) 위에 <strong>6번째 신호 "합법성"</strong>이 추가되는 순간이다.
                         </p>
                     </div>
 
+                    <!-- Editor's Note -->
+                    <blockquote class="themeable-card rounded-xl p-5 my-6 themeable-text leading-relaxed">
+                        <p><strong><em>편집자의 노트.</em></strong> 데이터 진단을 해온 회사에게 합법성은 자연스럽게 따라오는 다음 신호다. 동의·출처·삭제권의 증명이 데이터 품질의 일부가 되는 시대가 열리고 있다. 이 글은 AI 거버넌스 4부작(<a href="/report/pope-magnifica-humanitas/ko/" class="text-orange-500 hover:underline">Magnifica Humanitas</a> · <a href="/report/microsoft-skillopt-self-evolving-agents/ko/" class="text-orange-500 hover:underline">SkillOpt</a> · <a href="/report/muse-autoskill-self-evolving-skill-lifecycle/ko/" class="text-orange-500 hover:underline">MUSE-Autoskill</a>)에 이어 법이 강제하는 좌표를 다루는 네 번째 글이다. 도덕이 묻고, 학술이 답하고, 법이 강제하는 흐름의 마지막 착륙점.</p>
+                    </blockquote>
+
                     <!-- Stat Cards -->
-                    <p class="themeable-text leading-relaxed mt-8 mb-6">
-                        한 결정문이 그은 좌표를 정량으로 풀어 두면 글로벌 규제 도미노의 결이 또렷해진다. 네 위원회가 한 사실관계 위에 도달했고, 다섯 위반이 한 사슬로 묶였고, 그 앞으로 이탈리아 €15M의 첫 GDPR 산식과 한국 기업의 4중 노출 추정이 이어진다. 다음 네 칸은 이 보고서가 천천히 풀어 갈 좌표의 정량 단서다.
-                    </p>
-                    <p class="themeable-text-secondary text-sm mb-3">출처: OPC News Release(2026-05-06), Garante Provvedimento 755/2024, EU Regulation 2024/1689, 한국 PIPA 개정(2025).</p>
+                    <h3 class="text-xl font-semibold themeable-heading mt-8 mb-3">주요 수치</h3>
+                    <p class="themeable-text-secondary text-sm mb-3">출처: <a href="https://www.priv.gc.ca/en/opc-news/news-and-announcements/2026/nr-c_260506/" target="_blank" rel="noopener" class="text-orange-500 hover:underline">OPC News Release</a>(2026-05-06), Garante Provvedimento 755/2024, EU Regulation 2024/1689, 한국 PIPA 개정(2025).</p>
                     <div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div class="themeable-card rounded-xl p-4 text-center">
                             <p class="text-2xl font-bold" style="color: #F86825;">4 위원회</p>
@@ -161,11 +164,11 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 문장으로 정리할 수 있는 사건은 드물다. <strong>2026년 5월 6일, 캐나다 4개 개인정보위원회가 OpenAI ChatGPT의 PIPEDA 위반을 공식 확정했다.</strong> 정식 번호는 <strong>PIPEDA Findings #2026-002</strong>. 2023년 5월에 4 위원회 공동 조사가 개시된 이후 정확히 3년이 흐른 시점이었다. 이날 발표가 무거운 까닭은 단순 결정문 한 건 이상이기 때문이다. 한 자리에서 네 가지 '첫'이 동시에 일어났다 — <strong>G7 첫 공식 판정, 첫 4 위원회 합동조사 종결, 첫 "사후 동의 불가능" 선언, 첫 AI 훈련 데이터 직접 판정</strong>. 어느 하나만 떼어 봐도 글로벌 규제 사적史的 좌표가 될 사건이 한꺼번에 겹쳤다.
+                        한 문장으로 정리할 수 있는 사건은 드물다. <strong>2026년 5월 6일, 캐나다 4개 개인정보위원회가 OpenAI ChatGPT의 PIPEDA 위반을 공식 확정했다.</strong> 정식 번호는 <strong>PIPEDA Findings #2026-002</strong>. 2023년 5월에 4 위원회 공동 조사가 개시된 이후 정확히 3년이 흐른 시점이었다. 이날 발표가 무거운 까닭은 단순 결정문 한 건 이상이기 때문이다. 한 자리에서 네 가지 '첫'이 동시에 일어났다. <strong>G7 첫 공식 판정, 첫 4 위원회 합동조사 종결, 첫 "사후 동의 불가능" 선언, 첫 AI 훈련 데이터 직접 판정.</strong> 어느 하나만 떼어 봐도 글로벌 규제 역사의 좌표가 될 사건이 한꺼번에 겹쳤다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        사용자의 첫 메시지가 이 사건을 짧고 정확히 요약했다 — "캐나다 개인정보위원회 ChatGPT 훈련, PIPEDA 위반 확정. AI 훈련 데이터 수집 관행에 대한 첫 주요 국가 공식 확정 판단으로 글로벌 규제 파장 예상." 본 보고서는 그 한 줄을 그대로 받아들이되, 그 안에 들어 있는 네 명의 위원장, 다섯 개의 위반, 네 가지로 갈린 결정의 결을 천천히 풀어 본다.
+                        사건의 윤곽은 짧다. 캐나다 개인정보위원회가 ChatGPT 훈련 관행에 대해 PIPEDA 위반을 확정했고, AI 훈련 데이터 수집에 대한 첫 주요 국가 공식 판단이라서 글로벌 규제 파장이 예상된다. 이 글은 그 윤곽을 따라가되, 그 안에 들어 있는 네 명의 위원장, 다섯 개의 위반, 네 가지로 갈린 결정의 결을 천천히 풀어 본다.
                     </p>
 
                     <!-- Image: Canadian Parliament Centre Block (Ottawa) — 연방 OPC 본부 도시 -->
@@ -219,7 +222,7 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 줄이 두 가지를 동시에 끊어 놓는다. 첫째 — OpenAI가 동의를 받지 <strong>않은</strong> 것이 아니라 <strong>받을 수 없는</strong> 것이라는 사실의 확인. 둘째 — 사후의 옵트아웃·정정·삭제로는 동의의 결여를 메울 수 <strong>없다</strong>는 법리의 선언. 두 문장 사이에 AI 산업의 표준 관행이 통째로 놓여 있다.
+                        한 줄이 두 가지를 동시에 끊어 놓는다. 첫째, OpenAI가 동의를 받지 <strong>않은</strong> 것이 아니라 <strong>받을 수 없는</strong> 것이라는 사실의 확인. 둘째, 사후의 옵트아웃·정정·삭제로는 동의의 결여를 메울 수 <strong>없다</strong>는 법리의 선언. 두 문장 사이에 AI 산업의 표준 관행이 통째로 놓여 있다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -232,20 +235,20 @@
                     </blockquote>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국어로 옮기면 — "ChatGPT는 그 설계 자체로, 현행 BC 개인정보 법과 양립할 수 없다." 운영의 결함이 아니라 <strong>설계의 결함</strong>이라는 진단. 시정 약속으로 메울 수 없는 종류의 문제라는 선언이다.
+                        한국어로 옮기면 "ChatGPT는 그 설계 자체로, 현행 BC 개인정보 법과 양립할 수 없다"는 진단이다. 운영의 결함이 아니라 <strong>설계의 결함</strong>이라는 선언. 시정 약속으로 메울 수 없는 종류의 문제다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        Alberta의 Diane McLeod 위원장도 무게 있는 한 문장을 남겼다 — <em lang="en">"OpenAI did not appear to <strong>turn its mind adequately</strong> to privacy compliance ... which is <strong>very troubling</strong>."</em> "개인정보 컴플라이언스를 적절히 숙고하지 않은 듯하다, 매우 우려스럽다." 법무 영어에서 <em lang="en">turn one's mind</em>는 의무자가 *진지하게 검토했는지*를 묻는 표현이다. 기술 회사가 그 의무를 그저 표면적으로 이행했다는 진단으로 읽힌다.
+                        Alberta의 Diane McLeod 위원장도 무게 있는 한 문장을 남겼다. <em lang="en">"OpenAI did not appear to <strong>turn its mind adequately</strong> to privacy compliance ... which is <strong>very troubling</strong>."</em> "개인정보 컴플라이언스를 적절히 숙고하지 않은 듯하다, 매우 우려스럽다." 법무 영어에서 <em lang="en">turn one's mind</em>는 의무자가 진지하게 검토했는지를 묻는 표현이다. 기술 회사가 그 의무를 그저 표면적으로 이행했다는 진단으로 읽힌다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        대조적으로, 연방 OPC의 Dufresne 위원장은 시정의 가능성에 무게를 실었다 — <em lang="en">"I've concluded that the measures that have been and that will be implemented by OpenAI <strong>will address the concerns identified</strong>."</em> 같은 사실관계에 대한 네 가지 결의 차이가 한 자리에 모인다. 누구의 입장이 맞느냐의 문제가 아니라, <strong>같은 데이터를 보고 네 가지 결론에 도달하는 법 체계의 다층성</strong>이 이번 결정의 진짜 메시지다.
+                        대조적으로, 연방 OPC의 Dufresne 위원장은 시정의 가능성에 무게를 실었다. <em lang="en">"I've concluded that the measures that have been and that will be implemented by OpenAI <strong>will address the concerns identified</strong>."</em> 같은 사실관계에 대한 네 가지 결의 차이가 한 자리에 모인다. 누구의 입장이 맞느냐의 문제가 아니라, <strong>같은 데이터를 보고 네 가지 결론에 도달하는 법 체계의 다층성</strong>이 이번 결정의 진짜 메시지다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>한 시점, 한 발표가 만들어 낸 네 가지 첫.</strong> G7 첫 공식 판정. 첫 4 위원회 합동조사 종결. 첫 "사후 동의 불가능" 선언. 첫 AI 훈련 데이터 직접 판정. 어느 하나만으로도 글로벌 규제의 좌표가 될 사건이 한 자리에 겹쳤다. 본 보고서가 이 사건을 풀어 가는 이유다.
+                            한 시점, 한 발표가 만들어 낸 네 가지 첫. G7 첫 공식 판정, 첫 4 위원회 합동조사 종결, 첫 "사후 동의 불가능" 선언, 첫 AI 훈련 데이터 직접 판정. 어느 하나만으로도 글로벌 규제의 좌표가 될 사건이 한 자리에 겹쳤다.
                         </p>
                     </div>
                 </section>
@@ -258,7 +261,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        결정문은 다섯 가지 위반을 확정했다. 다섯 항목은 서로 떨어진 별개의 결함이 아니다. 따로 보면 각자 깔끔한 법 조문 위반이지만, 묶어 보면 <strong>한 사슬</strong>이 보인다 — 과다 수집이 동의 부재를 부르고, 동의 부재가 정확성 결여로 이어지고, 정확성 결여가 권리 행사를 불가능하게 만들고, 결국 책임 회피로 마무리되는 인과의 사슬. 다섯 항목을 사슬로 읽으면 결정문이 무엇을 끊으려 했는지가 또렷해진다.
+                        결정문은 다섯 가지 위반을 확정했다. 다섯 항목은 서로 떨어진 별개의 결함이 아니다. 따로 보면 각자 깔끔한 법 조문 위반이지만, 묶어 보면 <strong>한 사슬</strong>이 보인다. 과다 수집이 동의 부재를 부르고, 동의 부재가 정확성 결여로 이어지고, 정확성 결여가 권리 행사를 불가능하게 만들고, 결국 책임 회피로 마무리되는 인과의 사슬. 다섯 항목을 사슬로 읽으면 결정문이 무엇을 끊으려 했는지가 또렷해진다.
                     </p>
 
                     <!-- Image: ChatGPT logo — 조사 대상 제품 -->
@@ -294,20 +297,20 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.1</span>환각이 왜 개인정보 위반이 되는가</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        다섯 항목 중 가장 학술적으로 새로운 자리는 세 번째 — 개인정보 사실 부정확성이다. 결정문 Para 80은 짧게 단언한다 — <em lang="en">"OpenAI did not comply with the accuracy requirements under the Acts."</em> Para 95는 부정확성의 출처를 적시한다 — <em lang="en">"personal information contained in sources such as social media and discussion forums — which may often be inaccurate."</em>
+                        다섯 항목 중 가장 학술적으로 새로운 자리는 세 번째, 개인정보 사실 부정확성이다. 결정문 Para 80은 짧게 단언한다. <em lang="en">"OpenAI did not comply with the accuracy requirements under the Acts."</em> Para 95는 부정확성의 출처를 적시한다. <em lang="en">"personal information contained in sources such as social media and discussion forums — which may often be inaccurate."</em>
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        지금까지 환각은 모델의 *품질* 문제로 다뤄졌다. 답이 틀리면 사용자가 손해를 보고, 회사는 보강 학습으로 정확도를 높였다. PIPEDA #2026-002는 그 프레임을 바꾼다 — <strong>특정 개인에 관해 모델이 부정확한 사실을 생성·반복하는 행위가 PIPEDA Principle 4.6(Accuracy) 위반</strong>이라는 첫 공식 판단이다. 학술적으로는 Wachter & Mittelstadt(2019)가 제안한 <em lang="en">"A Right to Reasonable Inferences"</em> — *추론에 대한 권리* — 가 부분적으로 실현된 셈이다. 모델이 한 사람에 관해 잘못된 추론을 내놓는 일은 그 사람의 개인정보 권리에 대한 침해다, 라는 학술적 직관이 법 결정으로 착륙했다.
+                        지금까지 환각은 모델의 품질 문제로 다뤄졌다. 답이 틀리면 사용자가 손해를 보고, 회사는 보강 학습으로 정확도를 높였다. PIPEDA #2026-002는 그 프레임을 바꾼다. <strong>특정 개인에 관해 모델이 부정확한 사실을 생성·반복하는 행위가 PIPEDA Principle 4.6(Accuracy) 위반</strong>이라는 첫 공식 판단이다. 학술적으로는 Wachter & Mittelstadt(2019)가 제안한 <em lang="en">"A Right to Reasonable Inferences"</em>, 즉 추론에 대한 권리가 부분적으로 실현된 셈이다. 모델이 한 사람에 관해 잘못된 추론을 내놓는 일은 그 사람의 개인정보 권리에 대한 침해다, 라는 학술적 직관이 법 결정으로 착륙했다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        학술적 보조 논거도 있다. Carlini et al.(2021)의 <em lang="en">"Extracting Training Data from Large Language Models"</em>는 LLM이 학습 데이터를 <strong>memorize(기억)</strong>할 수 있고 그 일부를 출력으로 노출할 수 있음을 실증했다. 모델의 가중치 안에 개인정보가 *살아 있다*는 학술적 근거다. 결정문이 다섯 번째 위반(관리 책임 결여)을 짚는 자리도 정확히 여기다. 학습 가중치가 곧 개인정보 저장소라는 관점이 받아들여지면, 그 저장소의 관리 책임을 누군가는 져야 한다.
+                        학술적 보조 논거도 있다. Carlini et al.(2021)의 <em lang="en">"Extracting Training Data from Large Language Models"</em>는 LLM이 학습 데이터를 <strong>memorize(기억)</strong>할 수 있고 그 일부를 출력으로 노출할 수 있음을 실증했다. 모델의 가중치 안에 개인정보가 살아 있다는 학술적 근거다. 결정문이 다섯 번째 위반(관리 책임 결여)을 짚는 자리도 정확히 여기다. 학습 가중치가 곧 개인정보 저장소라는 관점이 받아들여지면, 그 저장소의 관리 책임을 누군가는 져야 한다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">2.2</span>학습 규모의 정량 — 13조 토큰의 압력</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        결정문의 무게를 가늠하려면 학습 규모를 한 번 보는 게 도움이 된다. <strong>GPT-4의 학습 토큰은 13조, 파라미터는 1.8조</strong>로 추정된다(SemiAnalysis 누설 보고, 비공식). OpenAI의 공식 수치는 비공개다. 13조 토큰이 어떤 규모인지 직관적으로 말하면 — 영어 위키피디아 전체가 약 50억 토큰이다. 위키피디아의 약 2,600배를 학습한 셈이다. Stanford CRFM의 <em lang="en">Foundation Model Transparency Index</em>(Bommasani et al., 2024)는 OpenAI를 포함한 주요 LLM 사업자가 학습 데이터 영역에서 가장 낮은 투명도 점수를 받았다고 보고했다. 13조 토큰 안에 무엇이 들어가 있는지를 외부에서 검증할 수 있는 길은 거의 없다.
+                        결정문의 무게를 가늠하려면 학습 규모를 한 번 보는 게 도움이 된다. <strong>GPT-4의 학습 토큰은 13조, 파라미터는 1.8조</strong>로 추정된다(SemiAnalysis 누설 보고, 비공식). OpenAI의 공식 수치는 비공개다. 13조 토큰이 어떤 규모인지 직관적으로 말하면, 영어 위키피디아 전체가 약 50억 토큰이고 위키피디아의 약 2,600배를 학습한 셈이다. Stanford CRFM의 <em lang="en">Foundation Model Transparency Index</em>(Bommasani et al., 2024)는 OpenAI를 포함한 주요 LLM 사업자가 학습 데이터 영역에서 가장 낮은 투명도 점수를 받았다고 보고했다. 13조 토큰 안에 무엇이 들어가 있는지를 외부에서 검증할 수 있는 길은 거의 없다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -357,7 +360,7 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.2</span>왜 BC와 Alberta가 거부했는가</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        분기의 법리적 뿌리는 캐나다 법률 사무소 MLT Aikins의 분석이 정확히 짚는다 — <em lang="en">"provincial statutes are more specific and explicit than PIPEDA regarding consent."</em> 주 법령(BC PIPA · Alberta PIPA)이 연방 PIPEDA보다 동의에 관해 더 구체적이고 명시적이라는 뜻이다. 두 주는 특히 <strong>전향적 동의(prospective consent, ex ante consent)</strong>를 명시적으로 요구한다. 처리 행위 *전에* 동의가 확보되어야 한다는 시간성 요건이 법문에 박혀 있다.
+                        분기의 법리적 뿌리는 캐나다 법률 사무소 MLT Aikins의 분석이 정확히 짚는다. <em lang="en">"provincial statutes are more specific and explicit than PIPEDA regarding consent."</em> 주 법령(BC PIPA · Alberta PIPA)이 연방 PIPEDA보다 동의에 관해 더 구체적이고 명시적이라는 뜻이다. 두 주는 특히 <strong>전향적 동의(prospective consent, ex ante consent)</strong>를 명시적으로 요구한다. 처리 행위 전에 동의가 확보되어야 한다는 시간성 요건이 법문에 박혀 있다.
                     </p>
 
                     <!-- Image: British Columbia Parliament Buildings (Victoria) — BC OIPC 본부 도시 -->
@@ -378,7 +381,7 @@
 
                     <blockquote class="border-l-4 pl-6 py-2 my-6 themeable-text leading-relaxed" style="border-color: #F86825; background: rgba(248, 104, 37, 0.04);">
                         <p>"OpenAI's models rely on scraped data for which OpenAI has not obtained, and cannot obtain, consent. <strong>Consent for scraped data simply cannot be obtained after the fact.</strong>"</p>
-                        <p class="text-xs themeable-muted mt-3">— BC OIPC + Alberta OIPC 공동 입장 (verbatim, 본 보고서 §1.2에서 옮김)</p>
+                        <p class="text-xs themeable-muted mt-3">— BC OIPC + Alberta OIPC 공동 입장 (verbatim, §1.2에서 옮김)</p>
                     </blockquote>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">3.3</span>"사후 동의 불가능"이 흔드는 것 — AI 산업의 표준 관행</h3>
@@ -387,16 +390,16 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        학술적으로 이 입장은 동의의 시간성에 대한 한 입장의 강한 채택이다. Daniel Solove(2013)의 <em lang="en">"Privacy Self-Management and the Consent Dilemma"</em>가 비판한 <em lang="en">notice-and-choice paradigm</em>의 한계 — 개인이 모든 정보 처리에 사전적으로 동의를 표명한다는 가정의 비현실성 — 가 학술적 공감대였다. EDPB Opinion 28/2024는 이 문제를 LLM 맥락에서 <em lang="en">"case by case"</em>로 유보했다. 캐나다 BC와 Alberta는 그 유보 자리에서 <strong>원칙적 입장</strong>을 채택한 것이다. 사후 동의는 동의가 아니다.
+                        학술적으로 이 입장은 동의의 시간성에 대한 한 입장의 강한 채택이다. Daniel Solove(2013)의 <em lang="en">"Privacy Self-Management and the Consent Dilemma"</em>가 비판한 <em lang="en">notice-and-choice paradigm</em>의 한계, 즉 개인이 모든 정보 처리에 사전적으로 동의를 표명한다는 가정의 비현실성이 학술적 공감대였다. EDPB Opinion 28/2024는 이 문제를 LLM 맥락에서 <em lang="en">"case by case"</em>로 유보했다. 캐나다 BC와 Alberta는 그 유보 자리에서 <strong>원칙적 입장</strong>을 채택한 것이다. 사후 동의는 동의가 아니다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지 결과가 따라온다. 글로벌 규제 동향의 동의 기준 스펙트럼에서 캐나다 BC와 Alberta가 <strong>세계 최강 엄격성</strong>의 자리에 선다는 점이다. 중국 PIPL의 사전 동의 원칙, EU GDPR의 6(1)(a) 동의 근거, 연방 PIPEDA, 미국 부문별 접근의 순서로 강도가 약해지는 스펙트럼에서, BC·Alberta는 그 모든 자리보다 한 발 더 강한 입장에 선다. 그리고 글로벌 규제의 역사적 흐름은 <strong>가장 엄격한 관할이 점진적으로 표준이 되는 경로</strong>를 따라왔다. GDPR이 그렇게 글로벌 표준이 되었듯, BC·Alberta의 입장이 다음 표준의 후보가 된다.
+                        한 가지 결과가 따라온다. 글로벌 규제 동향의 동의 기준 스펙트럼에서 캐나다 BC와 Alberta가 <strong>세계 최강 엄격성</strong>의 자리에 선다는 점이다. 중국 PIPL의 사전 동의 원칙, EU GDPR의 6(1)(a) 동의 근거, 연방 PIPEDA, 미국 부문별 접근의 순서로 강도가 약해지는 스펙트럼에서, BC·Alberta는 그 모든 자리보다 한 발 더 강한 입장에 선다. 글로벌 규제의 역사적 흐름은 <strong>가장 엄격한 관할이 점진적으로 표준이 되는 경로</strong>를 따라왔다. GDPR이 그렇게 글로벌 표준이 되었듯, BC·Alberta의 입장이 다음 표준의 후보가 된다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>"사후 동의는 불가능하다"는 일곱 글자가 AI 산업의 표준 관행을 흔든다.</strong> 크롤 → 학습 → 사후 옵트아웃의 그림이 법적으로 닫힌다면, 남는 길은 두 가지다. 학습 *전*의 동의를 확보하거나, 합법적으로 동의가 이미 확보된 데이터 소스만 사용하거나. 두 길 모두 합성 데이터·시뮬레이션 학습·라이선스 데이터 같은 대안의 시장 가치를 끌어올린다. BC와 Alberta가 던진 한 줄이 그 시장의 미래를 끌어당기는 자력이 된다.
+                            "사후 동의는 불가능하다"는 일곱 글자가 AI 산업의 표준 관행을 흔든다. 크롤 → 학습 → 사후 옵트아웃의 그림이 법적으로 닫힌다면, 남는 길은 두 가지다. 학습 전의 동의를 확보하거나, 합법적으로 동의가 이미 확보된 데이터 소스만 사용하거나. 두 길 모두 합성 데이터·시뮬레이션 학습·라이선스 데이터 같은 대안의 시장 가치를 끌어올린다. BC와 Alberta가 던진 한 줄이 그 시장의 미래를 끌어당기는 자력이 된다.
                         </p>
                     </div>
                 </section>
@@ -413,7 +416,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        규제는 한 번에 등장하지 않는다. 한 관할이 신호를 보내고, 다른 관할이 그 신호를 자기 법체계로 옮겨 적고, 또 다른 관할이 그것을 본격 산정의 기준으로 형식화한다. 그 사이의 시차가 곧 글로벌 규제 도미노의 결이다. 본 섹션은 그 결을 세 자리로 풀어 본다 — 3년의 시간순 흐름, 8개 관할의 동시점 비교, 그리고 이탈리아·한국이 만들어 둔 두 산식.
+                        규제는 한 번에 등장하지 않는다. 한 관할이 신호를 보내고, 다른 관할이 그 신호를 자기 법체계로 옮겨 적고, 또 다른 관할이 그것을 본격 산정의 기준으로 형식화한다. 그 사이의 시차가 곧 글로벌 규제 도미노의 결이다. 이 섹션은 그 결을 세 자리로 풀어 본다. 3년의 시간순 흐름, 8개 관할의 동시점 비교, 그리고 이탈리아·한국이 만들어 둔 두 산식이다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.1</span>2023~2026 — 3년의 흐름</h3>
@@ -479,7 +482,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        €15M은 GDPR 상한(€20M 또는 매출 4%)에 한참 못 미친다. 그러나 그 의미는 명확하다 — <strong>학습형 LLM에 대한 GDPR 적용이 가능하다는 사실의 확인</strong>. 이후 2026년 8월 2일 EU AI Act 고위험 시스템 전면 시행과 함께, AI Act의 최대 €35M / 매출 7% 상한이 GDPR 위로 한 층 더 얹힌다. 두 법령이 동시에 적용 가능한 시기가 본격적으로 열린다.
+                        €15M은 GDPR 상한(€20M 또는 매출 4%)에 한참 못 미친다. 그러나 그 의미는 명확하다. <strong>학습형 LLM에 대한 GDPR 적용이 가능하다는 사실의 확인이다.</strong> 이후 2026년 8월 2일 EU AI Act 고위험 시스템 전면 시행과 함께, AI Act의 최대 €35M / 매출 7% 상한이 GDPR 위로 한 층 더 얹힌다. 두 법령이 동시에 적용 가능한 시기가 본격적으로 열린다.
                     </p>
 
                     <!-- Image: Berlaymont building (Brussels) — EU Commission HQ -->
@@ -496,11 +499,11 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">4.4</span>한국의 자리 — 두 법, 두 시계</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국은 2026년 5월 시점에 두 개의 시계를 동시에 갖고 있다. 하나는 <strong>2025년에 강화된 개인정보보호법</strong> — 과징금 상한이 매출 3%에서 10%로 올라갔다. 다른 하나는 <strong>2026년 1월 22일 시행된 AI 기본법</strong> — 고영향 AI에 대한 영향평가 의무, 운영 중 위험 탐지·차단·전환 체계, 한국 내 사업자 등록·신고 의무를 도입한다. 두 법은 별개의 시계로 작동하지만, AI 학습 데이터의 합법성이라는 한 질문 앞에서는 같은 문장의 두 절처럼 결합된다. PIPA가 학습 데이터의 합법성 문턱을 정의하고, AI 기본법이 운영 단계의 audit trail 의무를 부과한다.
+                        한국은 2026년 5월 시점에 두 개의 시계를 동시에 갖고 있다. 하나는 <strong>2025년에 강화된 개인정보보호법</strong>. 과징금 상한이 매출 3%에서 10%로 올라갔다. 다른 하나는 <strong>2026년 1월 22일 시행된 AI 기본법</strong>. 고영향 AI에 대한 영향평가 의무, 운영 중 위험 탐지·차단·전환 체계, 한국 내 사업자 등록·신고 의무를 도입한다. 두 법은 별개의 시계로 작동하지만, AI 학습 데이터의 합법성이라는 한 질문 앞에서는 같은 문장의 두 절처럼 결합된다. PIPA가 학습 데이터의 합법성 문턱을 정의하고, AI 기본법이 운영 단계의 audit trail 의무를 부과한다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국 개인정보보호위원회(PIPC)는 2025년 8월 <strong>"생성형 AI 개인정보 처리 안내서"</strong>를 발표하면서 4단계 생애주기(수집·학습·서비스·종료)별 처리 기준을 제시했다. 캐나다 PIPEDA #2026-002의 다섯 위반 항목은 이 4단계 생애주기에 그대로 매핑된다 — 수집 단계의 과다 수집, 학습 단계의 동의 부재, 서비스 단계의 정확성·권리 행사, 종료 단계의 책임 귀속. 한국 PIPC의 안내서가 한국 기업의 실무 진입로를 정리했다면, 캐나다 결정문이 그 진입로의 글로벌 합의 가능성을 끌어올렸다고 읽을 수 있다.
+                        한국 개인정보보호위원회(PIPC)는 2025년 8월 <strong>"생성형 AI 개인정보 처리 안내서"</strong>를 발표하면서 4단계 생애주기(수집·학습·서비스·종료)별 처리 기준을 제시했다. 캐나다 PIPEDA #2026-002의 다섯 위반 항목은 이 4단계 생애주기에 그대로 매핑된다. 수집 단계의 과다 수집, 학습 단계의 동의 부재, 서비스 단계의 정확성·권리 행사, 종료 단계의 책임 귀속. 한국 PIPC의 안내서가 한국 기업의 실무 진입로를 정리했다면, 캐나다 결정문이 그 진입로의 글로벌 합의 가능성을 끌어올렸다고 읽을 수 있다.
                     </p>
                 </section>
 
@@ -512,7 +515,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국 기업이 글로벌 시장에 진출할 때 마주하는 컴플라이언스 풍경은 더 이상 단일 법체계의 그림이 아니다. 같은 학습 데이터에 대해 <strong>네 개의 법체계가 동시에 적용</strong>되는 시기가 시작되었다. PIPEDA(개인정보 보호), GDPR(EU 거주자 개인정보), EU AI Act(AI 시스템 직접 규제), 한국 AI 기본법(국내 AI 사업자) — 네 자리에서 네 가지 다른 기준이 한 학습 데이터셋을 동시에 평가한다.
+                        한국 기업이 글로벌 시장에 진출할 때 마주하는 컴플라이언스 풍경은 더 이상 단일 법체계의 그림이 아니다. 같은 학습 데이터에 대해 <strong>네 개의 법체계가 동시에 적용</strong>되는 시기가 시작되었다. PIPEDA(개인정보 보호), GDPR(EU 거주자 개인정보), EU AI Act(AI 시스템 직접 규제), 한국 AI 기본법(국내 AI 사업자). 네 자리에서 네 가지 다른 기준이 한 학습 데이터셋을 동시에 평가한다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.1</span>가상의 한국 LLM 기업 — 4중 노출 시뮬레이션</h3>
@@ -544,7 +547,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        네 자리의 합은 단순 산술로 묶기 어렵다. 같은 행위에 대해 네 관할이 동시에 최대치를 부과하는 시나리오는 현실적으로 드물기 때문이다. 그러나 각 관할이 독립적으로 자기 상한의 일부씩만 부과해도 누적 노출은 결코 작지 않다. 보수적 추정 합산으로 <strong>최대 약 US$140M(≈ ₩1,900억)</strong> 수준이며, 이는 글로벌 매출 US$1B 기준 14% 수준의 단일 위반 비용이 된다. PIPEDA 단독의 행정 권한은 작지만, 4중 동시 노출과 함께 다음 위험이 따라온다 — <strong>시장 접근 차단</strong>. BC와 Alberta가 보여 줬듯, 시정 약속으로 해소되지 않는 결정은 사실상의 시장 운영 제한으로 이어진다.
+                        네 자리의 합은 단순 산술로 묶기 어렵다. 같은 행위에 대해 네 관할이 동시에 최대치를 부과하는 시나리오는 현실적으로 드물기 때문이다. 그러나 각 관할이 독립적으로 자기 상한의 일부씩만 부과해도 누적 노출은 결코 작지 않다. 보수적 추정 합산으로 <strong>최대 약 US$140M(≈ ₩1,900억)</strong> 수준이며, 이는 글로벌 매출 US$1B 기준 14% 수준의 단일 위반 비용이 된다. PIPEDA 단독의 행정 권한은 작지만, 4중 동시 노출과 함께 다음 위험이 따라온다. <strong>시장 접근 차단.</strong> BC와 Alberta가 보여 줬듯, 시정 약속으로 해소되지 않는 결정은 사실상의 시장 운영 제한으로 이어진다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.2</span>PIPEDA-한국 매핑 — 같은 사슬, 다른 언어</h3>
@@ -572,11 +575,11 @@
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">5.3</span>왜 한국 기업이 BC/Alberta 기준을 봐야 하는가</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        한국 기업의 컴플라이언스 설계에서 한 가지 직관이 결정적이다 — <strong>4중 규제 시대의 안전한 설계는 가장 엄격한 관할에 맞춘 설계다.</strong> 4개 법체계의 기준이 다르더라도, 가장 엄격한 BC/Alberta 기준에 맞춰 데이터 sourcing과 동의 절차를 설계하면 나머지 세 자리도 자연스럽게 충족된다. 반대로 가장 느슨한 자리에 맞춘 설계는 가장 엄격한 자리에서 곧장 위반이 된다.
+                        한국 기업의 컴플라이언스 설계에서 한 가지 직관이 결정적이다. <strong>4중 규제 시대의 안전한 설계는 가장 엄격한 관할에 맞춘 설계다.</strong> 4개 법체계의 기준이 다르더라도, 가장 엄격한 BC/Alberta 기준에 맞춰 데이터 sourcing과 동의 절차를 설계하면 나머지 세 자리도 자연스럽게 충족된다. 반대로 가장 느슨한 자리에 맞춘 설계는 가장 엄격한 자리에서 곧장 위반이 된다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        이 직관이 글로벌 규제 역사의 일반 흐름과도 맞아떨어진다. GDPR이 발효된 2018년 이후 글로벌 사업자 대부분이 GDPR 기준에 맞춰 설계를 통일했고, 그 설계가 다른 관할에서도 사실상의 표준이 되었다. <strong>"Brussels Effect"</strong> — 가장 엄격한 관할의 기준이 글로벌 표준이 되는 흐름 — 가 캐나다 BC/Alberta 발 다음 라운드를 만들 수 있다는 가능성이 열린다.
+                        이 직관이 글로벌 규제 역사의 일반 흐름과도 맞아떨어진다. GDPR이 발효된 2018년 이후 글로벌 사업자 대부분이 GDPR 기준에 맞춰 설계를 통일했고, 그 설계가 다른 관할에서도 사실상의 표준이 되었다. <strong>"Brussels Effect"</strong>, 즉 가장 엄격한 관할의 기준이 글로벌 표준이 되는 흐름이 캐나다 BC/Alberta 발 다음 라운드를 만들 수 있다는 가능성이 열린다.
                     </p>
                 </section>
 
@@ -588,7 +591,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        본 보고서는 페블러스의 <strong>AI 거버넌스 4부작</strong>의 마지막 좌표다. 4부작은 한 가지 가정을 따라왔다 — AI 거버넌스는 도덕에서 시작해 학술을 거쳐 법으로 착륙한다. 도덕이 *왜* 인간 존엄을 지켜야 하는지를 묻고, 학술이 자기진화 학습의 *어떻게*를 설계하고, 법이 그 흐름을 *강제*한다. 네 글을 한 표로 늘어놓으면 그 가정이 자연스럽게 드러난다.
+                        이 글은 페블러스의 <strong>AI 거버넌스 4부작</strong>의 마지막 좌표다. 4부작은 한 가지 가정을 따라왔다. AI 거버넌스는 도덕에서 시작해 학술을 거쳐 법으로 착륙한다. 도덕이 왜 인간 존엄을 지켜야 하는지를 묻고, 학술이 자기진화 학습의 어떻게를 설계하고, 법이 그 흐름을 강제한다. 네 글을 한 표로 늘어놓으면 그 가정이 자연스럽게 드러난다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -606,7 +609,7 @@
                                 <tr class="border-b-2 themeable-border" style="background: rgba(248, 104, 37, 0.06);"><td class="p-3 themeable-text">2026-05-29</td><td class="p-3 font-bold themeable-heading">PIPEDA (본 글)</td><td class="p-3 themeable-text">법 · 규제</td><td class="p-3 themeable-text"><strong>법적 강제로의 착륙 — 사후 동의 불가능</strong></td></tr>
                             </tbody>
                         </table>
-                        <p class="text-xs themeable-muted mt-2">출처: 페블러스 AI 거버넌스 4부작 시리즈 — 본 보고서가 시리즈의 4편이자 마지막 좌표.</p>
+                        <p class="text-xs themeable-muted mt-2">출처: 페블러스 AI 거버넌스 4부작 시리즈 — 이 글이 시리즈의 4편이자 마지막 좌표.</p>
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -619,7 +622,7 @@
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>도덕이 묻고, 학술이 답하고, 법이 강제한다.</strong> 네 글의 시간차는 닷새다. 그 닷새 사이에 한 가지 시각이 또렷해졌다 — AI 거버넌스는 세 차원의 일이고, 그중 한 차원만 다루는 작업은 미완성이다. 본 보고서가 시리즈의 마지막 좌표인 까닭은, 법이 다른 둘을 강제로 묶는 마지막 매듭이기 때문이다.
+                            도덕이 묻고, 학술이 답하고, 법이 강제한다. 네 글의 시간차는 닷새다. 그 닷새 사이에 한 가지 시각이 또렷해졌다. AI 거버넌스는 세 차원의 일이고, 그중 한 차원만 다루는 작업은 미완성이다. 이 글이 시리즈의 마지막 좌표인 까닭은, 법이 다른 둘을 강제로 묶는 마지막 매듭이기 때문이다.
                         </p>
                     </div>
                 </section>
@@ -632,17 +635,17 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스는 지난 몇 해 동안 한 가지 명제를 따라 움직였다 — <strong>"데이터를 진단 가능한 상태로 만든다."</strong> DataClinic이 학습 데이터의 다섯 신호(레이블 무결성·분포 균형·신선도·결측·이상치)를 진단했고, AI-Ready Data가 그 진단의 출력 카테고리였으며, DataGreenhouse와 PebbloSim이 진단된 데이터의 운영 환경을 제공해 왔다. PIPEDA Findings #2026-002가 던진 명제는 이 흐름의 자연스러운 다음 단계다 — <strong>데이터의 *법적 품질*도 진단 대상이 된다.</strong>
+                        페블러스는 지난 몇 해 동안 한 가지 명제를 따라 움직였다. <strong>데이터를 진단 가능한 상태로 만든다.</strong> DataClinic이 학습 데이터의 다섯 신호(레이블 무결성·분포 균형·신선도·결측·이상치)를 진단했고, AI-Ready Data가 그 진단의 출력 카테고리였으며, DataGreenhouse와 PebbloSim이 진단된 데이터의 운영 환경을 제공해 왔다. PIPEDA Findings #2026-002가 던진 명제는 이 흐름의 자연스러운 다음 단계다. <strong>데이터의 법적 품질도 진단 대상이 된다.</strong>
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.1</span>AI-Ready Data에서 AI-Ready Compliance로</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        명제는 한 칸 확장된다. 학습 데이터의 <strong>기술적 품질</strong>을 진단해 온 회사가, 그 위에 <strong>법적 품질</strong>의 진단 층을 자연스럽게 얹을 수 있다. 새 제품을 만드는 일이 아니라 <strong>기존 자산의 의미가 확장</strong>되는 일이다 — DataClinic은 이미 데이터의 무결성·균형·신선도를 신호로 다뤄왔고, 거기에 "합법성"이라는 6번째 신호만 추가하면 된다. DataGreenhouse는 이미 원본 의존도를 낮춰왔고, 그 구조 자체가 PIPEDA의 사후 대응 인프라가 된다. PebbloSim의 시뮬레이션 학습은 실세계 개인정보 없이도 학습이 가능한 구조적 우회로다. 세 축이 PIPEDA #2026-002의 합법성 요건과 정확히 맞물린다.
+                        명제는 한 칸 확장된다. 학습 데이터의 <strong>기술적 품질</strong>을 진단해 온 회사가, 그 위에 <strong>법적 품질</strong>의 진단 층을 자연스럽게 얹을 수 있다. 새 제품을 만드는 일이 아니라 <strong>기존 자산의 의미가 확장</strong>되는 일이다. DataClinic은 이미 데이터의 무결성·균형·신선도를 신호로 다뤄왔고, 거기에 "합법성"이라는 6번째 신호만 추가하면 된다. DataGreenhouse는 이미 원본 의존도를 낮춰왔고, 그 구조 자체가 PIPEDA의 사후 대응 인프라가 된다. PebbloSim의 시뮬레이션 학습은 실세계 개인정보 없이도 학습이 가능한 구조적 우회로다. 세 축이 PIPEDA #2026-002의 합법성 요건과 정확히 맞물린다.
                     </p>
 
                     <h3 class="text-xl font-semibold themeable-heading mb-4"><span class="sub-number-badge">7.2</span>DataClinic 5신호 + 1 — 6차원 진단</h3>
                     <p class="themeable-text leading-relaxed mb-6">
-                        5신호 위에 6번째 신호 "합법성"이 어떻게 얹히는지를 한 표로 정리하면, 진단 체계의 확장이 또렷해진다. 합법성 신호는 다시 다섯 개의 세부 진단 항목으로 갈라진다 — PIPEDA #2026-002가 다섯 위반 항목으로 나뉜 것과 정확히 같은 구조다.
+                        5신호 위에 6번째 신호 "합법성"이 어떻게 얹히는지를 한 표로 정리하면, 진단 체계의 확장이 또렷해진다. 합법성 신호는 다시 다섯 개의 세부 진단 항목으로 갈라진다. PIPEDA #2026-002가 다섯 위반 항목으로 나뉜 것과 정확히 같은 구조다.
                     </p>
 
                     <div class="overflow-x-auto mb-6">
@@ -679,7 +682,7 @@
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-text">Source provenance<br><span class="text-xs themeable-muted">(출처 기록)</span></td><td class="p-3">데이터가 어디서 왔는가, 그 출처가 합법적인가</td><td class="p-3">Gebru et al. (2021) Datasheets for Datasets</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-text">Consent validity<br><span class="text-xs themeable-muted">(동의 유효성)</span></td><td class="p-3">동의의 시점·범위·갱신성이 유효한가</td><td class="p-3">Solove (2013), BC/AB OIPC ex ante 요건</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-text">RTBF readiness<br><span class="text-xs themeable-muted">(삭제 가능성)</span></td><td class="p-3">잊혀질 권리가 기술적으로 충족 가능한가</td><td class="p-3">Bourtoule et al. (2021) SISA, Yao et al. (2024)</td></tr>
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-text">Cross-jurisdictional<br><span class="text-xs themeable-muted">(다관할 적합성)</span></td><td class="p-3">PIPEDA·GDPR·AI Act·한국 4중 충족 여부</td><td class="p-3">본 보고서 §4·§5</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-text">Cross-jurisdictional<br><span class="text-xs themeable-muted">(다관할 적합성)</span></td><td class="p-3">PIPEDA·GDPR·AI Act·한국 4중 충족 여부</td><td class="p-3">§4·§5</td></tr>
                                 <tr class="border-b-2 themeable-border"><td class="p-3 font-bold themeable-text">Inaccuracy correction<br><span class="text-xs themeable-muted">(정정 루프)</span></td><td class="p-3">개인정보 부정확성을 모니터·정정하는 루프가 있는가</td><td class="p-3">Wachter & Mittelstadt (2019), PIPEDA Principle 4.6</td></tr>
                             </tbody>
                         </table>
@@ -744,7 +747,7 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        페블러스의 자리가 그 빈 칸 위에 자연스럽게 놓인다. DataClinic = 데이터 *품질* 진단, AI-Ready Data = 명제의 기술 축, 거기에 *합법성 신호*를 한 칸 더하면 AI-Ready Compliance로 확장된다. DataGreenhouse + PebbloSim = 합법적 대안 데이터 인프라. 세 축의 통합이 곧 빈 칸 위의 진입로다. 새로 만드는 일이 아니라 5년간 다듬어 온 자산이 PIPEDA 결정과 정확히 맞물리는 자리. 광고의 형태가 아니라 통찰의 형태로 그 자리를 적어 둔다 — AI-Ready Compliance라는 시대가 왔고, 우리는 그 인접 영역을 오래 다듬어 왔다.
+                        페블러스의 자리가 그 빈 칸 위에 자연스럽게 놓인다. DataClinic은 데이터 품질 진단, AI-Ready Data는 그 진단의 출력 카테고리. 거기에 합법성 신호를 한 칸 더하면 AI-Ready Compliance로 확장된다. DataGreenhouse와 PebbloSim은 합법적 대안 데이터 인프라. 세 축의 통합이 곧 빈 칸 위의 진입로다. 5년간 다듬어 온 자산이 PIPEDA 결정과 정확히 맞물리는 자리. AI-Ready Compliance라는 시대가 왔고, 페블러스는 그 인접 영역을 오래 다듬어 왔다.
                     </p>
 
                     <div class="key-insight">
@@ -762,7 +765,7 @@
                     </div>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        결정문의 한 줄을 다시 읽어 본다 — "사후 동의는 불가능하다." 일곱 글자가 끊는 것은 한 회사의 한 제품이 아니다. <strong>한 시대의 표준 관행</strong>이다. 크롤하고, 학습하고, 그 다음에 사용자에게 옵트아웃을 제공하는 그림이 더 이상 법적으로 닫힌 그림이라는 사실의 확정. 그 자리에서 한 가지 질문이 따라 나온다 — 학습 *전*에 동의를 확보한다는 게 기술적으로 어떻게 가능한가, 또는 동의가 이미 확보된 합법적 데이터 소스만으로 학습이 가능한가.
+                        결정문의 한 줄을 다시 읽어 본다. "사후 동의는 불가능하다." 일곱 글자가 끊는 것은 한 회사의 한 제품이 아니다. <strong>한 시대의 표준 관행</strong>이다. 크롤하고, 학습하고, 그 다음에 사용자에게 옵트아웃을 제공하는 그림이 더 이상 법적으로 닫힌 그림이라는 사실의 확정. 그 자리에서 한 가지 질문이 따라 나온다. 학습 전에 동의를 확보한다는 게 기술적으로 어떻게 가능한가, 또는 동의가 이미 확보된 합법적 데이터 소스만으로 학습이 가능한가.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
@@ -770,16 +773,16 @@
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        한 가지 솔직한 인정이 필요하다. 합성 데이터 자체가 완벽한 해법은 아니다. 합성 데이터 생성에 쓰인 시드 데이터의 합법성, 멤버십 추론 공격(membership inference attack)에 대한 방어, 합성 분포의 편향 — 세 가지 새 검증 항목이 따라온다. 머신 언러닝도 단기적으로는 *good faith effort*로 인정될 수 있지만 학술적으로는 미완성이다. 어떤 단일 기술도 PIPEDA의 다섯 위반을 한꺼번에 해소하지 못한다. 그러나 <strong>여러 기술의 결합이 새 진입로를 연다</strong>는 직관은 분명하다. 합성 데이터·시뮬레이션 학습·차등 정보보호(differential privacy, DP-SGD)·머신 언러닝·데이터 sourcing 감사의 결합 위에 AI-Ready Compliance의 실무 청사진이 그려진다.
+                        한 가지 솔직한 인정이 필요하다. 합성 데이터 자체가 완벽한 해법은 아니다. 합성 데이터 생성에 쓰인 시드 데이터의 합법성, 멤버십 추론 공격(membership inference attack)에 대한 방어, 합성 분포의 편향. 세 가지 새 검증 항목이 따라온다. 머신 언러닝도 단기적으로는 good faith effort로 인정될 수 있지만 학술적으로는 미완성이다. 어떤 단일 기술도 PIPEDA의 다섯 위반을 한꺼번에 해소하지 못한다. 다만 <strong>여러 기술의 결합이 새 진입로를 연다</strong>는 직관은 분명하다. 합성 데이터·시뮬레이션 학습·차등 정보보호(differential privacy, DP-SGD)·머신 언러닝·데이터 sourcing 감사의 결합 위에 AI-Ready Compliance의 실무 청사진이 그려진다.
                     </p>
 
                     <p class="themeable-text leading-relaxed mb-6">
-                        결정문이 남긴 다음 질문들은 본 보고서가 끝나는 자리에서 시작된다. <strong>한국 기업은 BC/Alberta 기준에 맞춘 데이터 sourcing을 어떻게 6개월 안에 정렬할 것인가. 학습 가중치 안에 잠복한 개인정보를 어떤 비용으로 어떻게 다룰 것인가. 4중 거버넌스 보드는 누가 의장이 되고 어떤 의제로 분기 회의를 운영할 것인가.</strong> 이 질문들은 한 편의 보고서가 닫을 수 있는 종류가 아니다. 페블러스가 다음 글들에서 천천히 풀어 갈 자리.
+                        결정문이 남긴 다음 질문들은 이 글이 끝나는 자리에서 시작된다. 한국 기업은 BC/Alberta 기준에 맞춘 데이터 sourcing을 어떻게 6개월 안에 정렬할 것인가. 학습 가중치 안에 잠복한 개인정보를 어떤 비용으로 어떻게 다룰 것인가. 4중 거버넌스 보드는 누가 의장이 되고 어떤 의제로 분기 회의를 운영할 것인가. 이 질문들은 한 편의 글이 닫을 수 있는 종류가 아니다. 페블러스가 다음 글들에서 천천히 풀어 갈 자리다.
                     </p>
 
                     <div class="key-insight">
                         <p class="themeable-text leading-relaxed">
-                            <strong>네 명의 위원장이 한 자리에서 만든 결정 하나가 한 시대를 한 칸 옮겼다.</strong> 도덕이 묻고 학술이 답한 자리에 법이 강제로 매듭을 지었다. 그 매듭은 AI 학습 데이터의 합법성이라는 한 차원을 글로벌 표준의 자리로 끌어올렸고, 그 위에 페블러스의 다음 명제 — AI-Ready Compliance — 가 자연스럽게 그려진다. <strong>데이터의 법적 품질도 진단 대상이다.</strong> 그 한 줄이 이 보고서의 끝이자 다음 작업의 시작이다.
+                            네 명의 위원장이 한 자리에서 만든 결정 하나가 한 시대를 한 칸 옮겼다. 도덕이 묻고 학술이 답한 자리에 법이 강제로 매듭을 지었다. 그 매듭은 AI 학습 데이터의 합법성이라는 한 차원을 글로벌 표준의 자리로 끌어올렸고, 그 위에 페블러스의 다음 명제, AI-Ready Compliance가 자연스럽게 그려진다. <strong>데이터의 법적 품질도 진단 대상이다.</strong> 그 한 줄이 이 글의 끝이자 다음 작업의 시작이다.
                         </p>
                     </div>
                 </section>
@@ -791,7 +794,7 @@
                 <section id="references" class="mb-16 fade-in-card">
                     <h2 class="text-3xl font-bold themeable-heading mb-6">참고문헌</h2>
                     <p class="themeable-text leading-relaxed mb-6">
-                        본 보고서가 인용한 1차 결정문, GDPR·AI Act·한국 AI 기본법, 학술 논문, 법무 분석, 시장 보고서, 페블러스 시리즈 선행 글을 출처별로 묶었다. 1차 결정문은 OPC 공식 페이지에서 verbatim 인용을 확인할 수 있다.
+                        이 글이 인용한 1차 결정문, GDPR·AI Act·한국 AI 기본법, 학술 논문, 법무 분석, 시장 보고서, 페블러스 시리즈 선행 글을 출처별로 묶었다. 1차 결정문은 OPC 공식 페이지에서 verbatim 인용을 확인할 수 있다.
                     </p>
 
                     <div class="flex gap-2 mb-6">


### PR DESCRIPTION
## Summary
ko-prose-humanizer 도입 후 시리즈 4편 사후 검수의 마지막. Evans → SkillOpt → MUSE → **PIPEDA**.

PIPEDA는 시리즈 중 가장 길고(27,165자) em-dash 사용이 많았음(114개, 1/238자). T11 자사 점프는 §7의 "광고의 형태가 아니라 통찰의 형태로" 같은 메타 자기변호가 두드러짐.

## Before / After

| Tell | Before | After |
|------|--------|-------|
| T1 em-dash | 114개 (1/238자) | **69개 (1/389자)** |
| T7 위키체 '본 보고서' | 10 | **0** (전부 "이 글"로) |
| T4 메타 예고문 | 1 | 0 |
| T11 자사 점프 | 4곳 | 톤다운 (Editor's Note로 분리) |
| Editor's Note | 없음 | 추가 |

## 주요 변경

### Exec Summary 재구성
- OPC 공식 페이지 외부 링크 추가
- "—" 동격 재진술 4곳 → 마침표·접속어
- 3단락 "4부작의 마지막 좌표로, 도덕이 묻고..." 자사 점프 제거 → Editor's Note로
- Stat Cards 위 "주요 수치" h3

### §1~§8 산문
- "본 보고서" 위키체 10곳 모두 "이 글"로 치환
- "한국어로 옮기면 —" / "다시 읽어 본다 —" / "한 가지 질문이 따라 나온다 —" 메타 예고문 모두 마침표
- §7 자사 변호("광고의 형태가 아니라 통찰의 형태로") 제거
- key-insight 자사 점프 풀어쓰기

## 보존
- AI 거버넌스 4부작 흐름 (Magnifica → SkillOpt → MUSE → PIPEDA)
- PIPEDA 5위반 ↔ DataClinic 5신호 + 1 매핑 표
- BC/Alberta verbatim 인용 ("consent cannot be obtained after the fact")
- 4중 노출 시뮬레이션 ($140M), Stat Cards 4개, 한국 PIPA 매핑 표

## ko-prose-humanizer 시리즈 완주 (5건째)

| 글 | em-dash Before | After | 빈도 변화 |
|---|---|---|---|
| Evans KO | 117 | 52 | 1/237 → 1/494 |
| Evans EN | 143 | 70 | 1/320 → 1/621 |
| SkillOpt KO | 73 | 49 | 1/277 → 1/407 |
| MUSE KO | 98 | 51 | 1/238 → 1/451 |
| **PIPEDA KO** | **114** | **69** | **1/238 → 1/389** |

평균 45% em-dash 감소. 공통 신호: T1 동격 재진술 / T4 메타 예고문 / T11 자사 점프 / T7 위키체.

## 다음 작업
시리즈 5편의 누적 경험을 ko-prose-humanizer 스킬 v2 + voice-edit·blog-write 가이드에 반영. JH의 "스킬 재정렬" 약속 단계.

## Test plan
- [ ] Exec Summary Editor's Note + 주요 수치 h3
- [ ] OPC·EU·한국 외부 링크 동작
- [ ] AI 거버넌스 4부작 시리즈 링크 + DataClinic 6차원 매핑 표 보존
- [ ] $140M 4중 노출 시뮬레이션 stat cards 4개 유지
- [ ] 모든 수치, 이미지(4장), 시리즈 링크 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)