### PR TITLE
fix(og): EN 페이지 og:image ko→en 경로 정정

### DIFF
--- a/report/claude-code-workflows-enterprise-ai/en/index.html
+++ b/report/claude-code-workflows-enterprise-ai/en/index.html
@@ -24,7 +24,7 @@
     <meta property="og:title" content="Every Job Is an Algorithm — What Claude Code Workflows Just Proved">
     <meta property="og:description" content="From Miessler's 'graph of algorithms' thesis to Claude Code Dynamic Workflows. A structural analysis of SOP-based Enterprise AI transformation.">
     <meta property="og:url" content="https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/">
-    <meta property="og:image" content="https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/image/index.png">
+    <meta property="og:image" content="https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/image/index.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="Every Job Is an Algorithm — Claude Code Workflows Deep Analysis">
@@ -37,7 +37,7 @@
     <meta name="twitter:creator" content="@pebblous_ai">
     <meta name="twitter:title" content="Every Job Is an Algorithm — What Claude Code Workflows Just Proved">
     <meta name="twitter:description" content="1,000 subagents, 960K-line Bun port, SOP automation limits and data quality's role. Structural analysis of Enterprise AI transformation.">
-    <meta name="twitter:image" content="https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/image/index.png">
+    <meta name="twitter:image" content="https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/image/index.png">
     <meta name="twitter:image:alt" content="Claude Code Dynamic Workflows Deep Analysis Report">
 
     <!-- Google Scholar Citation Meta -->


### PR DESCRIPTION
## Summary
- `report/claude-code-workflows-enterprise-ai/en/index.html`의 `og:image`, `twitter:image`가 `/ko/image/index.png`를 잘못 가리키던 버그 수정
- EN OG 이미지 파일(`/en/image/index.png`, 256KB)은 이미 존재 — 경로만 수정

## 변경 파일
- `report/claude-code-workflows-enterprise-ai/en/index.html` — 2줄 (og:image, twitter:image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)