### PR TITLE
fix(gitnexus): 표준 준수 — 제목 간결화 + KO/EN 표준화

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -2502,7 +2502,7 @@
     },
     {
       "id": "gitnexus-code-knowledge-graph-2026-ko",
-      "title": "GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG, '브라우저 전용'은 과장",
+      "title": "GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG",
       "description": "GitNexus가 1,195스타로 GitHub 트렌딩 1위. Tree-sitter로 코드베이스를 파싱해 지식 그래프를 만들고 Graph RAG로 AI 에이전트 컨텍스트를 제공한다. '브라우저 전용'은 과장이다.",
       "category": "tech",
       "date": "2026-04-10",
@@ -2529,7 +2529,7 @@
     },
     {
       "id": "gitnexus-code-knowledge-graph-2026-en",
-      "title": "GitNexus Hits #1 on GitHub — Code Knowledge Graphs Are Here, But \"Browser-Only\" Is Oversold",
+      "title": "GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents",
       "description": "GitNexus reached 1,195 stars as GitHub's #1 trending repo today. It parses codebases with Tree-sitter into a knowledge graph, then serves Graph RAG context to AI agents via MCP. But you still need a local server.",
       "category": "tech",
       "date": "2026-04-10",

--- a/blog/gitnexus-code-knowledge-graph-2026/en/index.html
+++ b/blog/gitnexus-code-knowledge-graph-2026/en/index.html
@@ -11,8 +11,8 @@
     <meta name="copyright" content="(주)페블러스 데이터 커뮤니케이션">
     <meta name="robots" content="index, follow">
 
-    <title>GitNexus Hits #1 on GitHub — Code Knowledge Graphs and Graph RAG | Pebblous</title>
-    <meta name="description" content="GitNexus hit #1 on GitHub trending today with 1,195 stars. It builds a knowledge graph of your codebase using Tree-sitter and serves Graph RAG context to AI agents via MCP. But 'browser-only' is oversold.">
+    <title>GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents | Pebblous</title>
+    <meta name="description" content="GitNexus hit GitHub trending #1 with 1,195 stars. Tree-sitter builds a code knowledge graph; Graph RAG serves structural context to AI agents via MCP.">
     <meta name="keywords" content="GitNexus, Graph RAG, knowledge-graph, code-analysis, AI-agents, MCP, open-source, developer-tools, pebblous, Tree-sitter, LadybugDB, code-graph">
 
     <link rel="canonical" href="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/">
@@ -24,11 +24,12 @@
 
     <!-- OG -->
     <meta property="og:type" content="article">
-    <meta property="og:title" content="GitNexus Hits #1 on GitHub — Code Knowledge Graphs Are Here, But &quot;Browser-Only&quot; Is Oversold">
+    <meta property="og:title" content="GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents">
     <meta property="og:description" content="GitNexus reached 1,195 stars as GitHub's #1 trending repo today. It parses codebases with Tree-sitter into a knowledge graph, then serves Graph RAG context to AI agents. But you still need a local server — 'browser-only' is a myth.">
     <meta property="og:url" content="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/">
     <meta property="og:image" content="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/image/index.png">
     <meta property="og:locale" content="en_US">
+    <meta property="og:site_name" content="Pebblous Blog">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
@@ -78,7 +79,6 @@
             <main class="max-w-[800px] px-4 sm:px-6">
                 <header class="text-left mb-12">
                     <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
-                                    <div id="share-buttons-placeholder" class="flex justify-start"></div>
                 </header>
 
                 <!-- Executive Summary -->
@@ -218,15 +218,15 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>What it does well</strong>: Finding code that resembles a specific function name or logic pattern.</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>What it fails at</strong>: "Where is this function ultimately called from?", "Show me every subclass of this base class", "Walk me through the entire auth flow" — questions that require following structure.</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>Root cause</strong>: Splitting code into chunks destroys relational information. The fact that function A calls function B is structural knowledge — it cannot be recovered from text similarity alone.</span>
                         </li>
                     </ul>
@@ -336,19 +336,19 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">Large TypeScript/Python backend servers with tens of thousands of lines</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">Microservice architectures — when cross-service call relationships are hard to track</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">Legacy codebase onboarding — when you need to trace "where is this function called from" without reading every file</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">AI-assisted large-scale refactoring — when you need to structurally map the blast radius of a change</span>
                         </li>
                     </ul>
@@ -394,11 +394,11 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>Context explosion</strong>: Reading all related files quickly fills the context window — especially when call chains run deep.</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>Lost relational information</strong>: Even after reading a file, "where is this function called from elsewhere?" can only be guessed. There's no explicit data.</span>
                         </li>
                     </ul>
@@ -411,19 +411,19 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"Find all functions that call <code>processPayment()</code>"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"What are all the subclasses of <code>UserService</code>?"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"List all external libraries the <code>auth</code> module depends on"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"Trace the full execution flow starting from <code>handleLogin()</code>"</span>
                         </li>
                     </ul>
@@ -470,15 +470,15 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">How does a normalization function affect the downstream augmentation chain?</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">Which preprocessing steps does a validation function depend on?</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">At which point in the pipeline does a labeling error get amplified, and how?</span>
                         </li>
                     </ul>
@@ -523,9 +523,9 @@
     <script src="/scripts/common-utils.js?v=20260410"></script>
     <script>
         PebblousPage.init({
-            mainTitle: "GitNexus Hits #1 on GitHub — Code Knowledge Graphs Are Here, But \"Browser-Only\" Is Oversold",
-            subtitle: "Tree-sitter parses your codebase into a knowledge graph. Graph RAG serves structural context to AI agents via MCP. But you still need a local Node.js server.",
-            pageTitle: "GitNexus Hits #1 on GitHub — Code Knowledge Graphs and Graph RAG | Pebblous",
+            mainTitle: "GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents",
+            subtitle: "The tool that hit #1 on GitHub trending. Tree-sitter + Graph RAG + MCP — structural context for your codebase, served to AI agents.",
+            pageTitle: "GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents | Pebblous",
             category: "tech",
             publishDate: "2026-04-10",
             publisher: "Pebblous Research",

--- a/blog/gitnexus-code-knowledge-graph-2026/ko/index.html
+++ b/blog/gitnexus-code-knowledge-graph-2026/ko/index.html
@@ -11,8 +11,8 @@
     <meta name="copyright" content="(주)페블러스 데이터 커뮤니케이션">
     <meta name="robots" content="index, follow">
 
-    <title>GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG | 페블러스</title>
-    <meta name="description" content="GitNexus가 오늘 GitHub 트렌딩 1위를 기록했다. Tree-sitter로 코드베이스를 파싱해 지식 그래프를 구축하고 Graph RAG로 AI 에이전트 컨텍스트를 제공한다. '브라우저 전용'은 과장이다.">
+    <title>GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG | 페블러스</title>
+    <meta name="description" content="GitNexus가 GitHub 트렌딩 1위를 기록했다. Tree-sitter로 코드를 파싱해 지식 그래프를 구축하고 Graph RAG로 AI 에이전트에 구조적 컨텍스트를 제공한다. MCP 통합, 실전 한계, '브라우저 전용'이 과장인 이유.">
     <meta name="keywords" content="GitNexus, Graph RAG, 지식그래프, 코드분석, AI에이전트, MCP, 오픈소스, 개발도구, 페블러스, Tree-sitter, LadybugDB, 코드그래프">
 
     <link rel="canonical" href="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/">
@@ -24,11 +24,12 @@
 
     <!-- OG -->
     <meta property="og:type" content="article">
-    <meta property="og:title" content="GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG, '브라우저 전용'은 과장">
+    <meta property="og:title" content="GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG">
     <meta property="og:description" content="GitNexus가 1,195스타로 GitHub 트렌딩 1위. Tree-sitter로 코드베이스를 파싱해 지식 그래프를 만들고 Graph RAG로 AI 에이전트 컨텍스트를 제공한다. 하지만 '브라우저 전용'은 사실이 아니다.">
     <meta property="og:url" content="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/">
     <meta property="og:image" content="https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/image/index.png">
     <meta property="og:locale" content="ko_KR">
+    <meta property="og:site_name" content="페블러스 블로그">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
@@ -78,7 +79,6 @@
             <main class="max-w-[800px] px-4 sm:px-6">
                 <header class="text-left mb-12">
                     <h1 id="page-h1-title" class="text-4xl md:text-5xl font-bold themeable-heading mb-4 leading-tight"></h1>
-                                    <div id="share-buttons-placeholder" class="flex justify-start"></div>
                 </header>
 
                 <!-- Executive Summary -->
@@ -218,15 +218,15 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>잘 하는 것</strong>: 특정 함수 이름이나 로직과 유사한 코드를 찾기</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>못 하는 것</strong>: "이 함수가 최종적으로 어디서 호출되나?", "이 클래스를 상속받은 모든 서브클래스는?", "인증 흐름 전체를 보여줘" — 구조를 따라가는 질문</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>근본 이유</strong>: 청크를 분리하면서 함수 간 관계 정보가 사라진다. A가 B를 호출한다는 사실은 코드의 구조적 지식이지, 텍스트 유사도로는 파악할 수 없다.</span>
                         </li>
                     </ul>
@@ -336,19 +336,19 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">수만 줄의 TypeScript/Python 백엔드 서버</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">마이크로서비스 아키텍처 — 여러 서비스 간 호출 관계 파악이 어려운 경우</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">레거시 코드베이스 온보딩 — "이 함수가 어디서 불리는가"를 일일이 추적해야 하는 경우</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">AI 에이전트로 대규모 리팩토링을 할 때 — 변경의 영향 범위를 구조적으로 파악해야 하는 경우</span>
                         </li>
                     </ul>
@@ -394,11 +394,11 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>컨텍스트 폭발</strong>: 관련 파일을 모두 읽으면 컨텍스트 창이 금방 차버린다. 특히 호출 체인이 깊은 경우.</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed"><strong>관계 정보 손실</strong>: 파일을 읽어도 "이 함수가 어디서 호출되는가"는 추론으로만 알 수 있다. 명시적 데이터가 없다.</span>
                         </li>
                     </ul>
@@ -411,19 +411,19 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"<code>processPayment()</code>를 호출하는 모든 함수를 찾아줘"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"<code>UserService</code> 클래스를 상속받은 모든 서브클래스는?"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"<code>auth</code> 모듈이 의존하는 외부 라이브러리 목록"</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">"<code>handleLogin()</code>에서 시작해서 거치는 전체 실행 흐름"</span>
                         </li>
                     </ul>
@@ -470,15 +470,15 @@
 
                     <ul class="space-y-3 mb-6">
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">데이터 정규화 함수가 다운스트림 증강 체인에 어떻게 영향을 미치나?</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">검증 함수가 어떤 전처리 스텝에 의존하는가?</span>
                         </li>
                         <li class="flex items-start gap-3">
-                            <span class="text-teal-400 mt-1">•</span>
+                            <span class="text-orange-500 mt-1">•</span>
                             <span class="themeable-text leading-relaxed">레이블링 오류가 파이프라인 어느 지점에서 어떻게 증폭되는가?</span>
                         </li>
                     </ul>
@@ -523,9 +523,9 @@
     <script src="/scripts/common-utils.js?v=20260410"></script>
     <script>
         PebblousPage.init({
-            mainTitle: "GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG, '브라우저 전용'은 과장",
-            subtitle: "Tree-sitter 기반 코드 지식 그래프 + Graph RAG + MCP 통합. 하지만 진짜 쓰기 위해서는 로컬 Node.js 서버가 필요하다.",
-            pageTitle: "GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG | 페블러스",
+            mainTitle: "GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG",
+            subtitle: "GitHub 트렌딩 1위에 오른 코드 지식 그래프 도구. Tree-sitter + Graph RAG + MCP로 AI 에이전트에 구조적 컨텍스트를 제공한다.",
+            pageTitle: "GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG | 페블러스",
             category: "tech",
             publishDate: "2026-04-10",
             publisher: "Pebblous Research",


### PR DESCRIPTION
## Summary
- KO/EN 제목 간결화: "오늘 GitHub 1위…" 제거 → `GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG`
- `share-buttons-placeholder` 제거 (KO+EN hero section)
- `text-teal-400` → `text-orange-500` (브랜드 컬러 통일, KO 16개 + EN 17개)
- EN description 194 → 150자 (SEO 적정 범위)
- `og:site_name` KO+EN 추가
- articles.json 제목 동기화

## Test plan
- [ ] KO 페이지 렌더링 확인
- [ ] EN 페이지 렌더링 확인
- [ ] 오렌지 bullet 포인트 색상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)