### PR TITLE
feat(disclosure): AI 생성 고지 byline + 카드 배지 아이콘 축소 (#39)

### DIFF
--- a/css/card-styles.css
+++ b/css/card-styles.css
@@ -155,8 +155,10 @@
     opacity: 1;
 }
 
-/* Provenance(증적) badge — "사람 검토"(HITL) vs "완전 자동"(unattended).
-   Source: articles.json provenance.humanReviewed (Blog Service Engine). */
+/* Provenance(증적) badge — 카드 at-a-glance 신호(아이콘 전용으로 축소, 이슈 #39).
+   전체 고지는 본문 byline(.ai-disclosure). byline 과 색상 일치:
+   auto(순수 AI) → 오렌지 / human·reviewed(사람 개입) → 뉴트럴.
+   Source: articles.json provenance.humanReviewed (+ publishReview). */
 .prov-badge {
     display: inline-flex;
     align-items: center;
@@ -171,17 +173,24 @@
     line-height: 1.4;
 }
 
+/* 아이콘 전용 — 라벨 텍스트 제거(카드 공간 축소) */
+.prov-badge-icon {
+    padding: 3px;
+    gap: 0;
+}
+
 .prov-badge svg {
     flex-shrink: 0;
 }
 
-.prov-badge.human {
-    color: #16a34a;
-    background: rgba(34, 197, 94, 0.08);
-    border-color: rgba(34, 197, 94, 0.40);
+.prov-badge.auto {
+    color: #ea580c;
+    background: rgba(248, 104, 37, 0.10);
+    border-color: rgba(248, 104, 37, 0.40);
 }
 
-.prov-badge.auto {
+.prov-badge.human,
+.prov-badge.reviewed {
     color: #64748b;
     background: rgba(100, 116, 139, 0.10);
     border-color: rgba(100, 116, 139, 0.40);

--- a/css/styles.css
+++ b/css/styles.css
@@ -428,8 +428,10 @@ h1, h2, h3, h4, h5, h6 {
     opacity: 1;
 }
 
-/* Provenance(증적) badge — "사람 검토"(HITL) vs "완전 자동"(unattended).
-   Source: articles.json provenance.humanReviewed (Blog Service Engine). */
+/* Provenance(증적) badge — 카드 at-a-glance 신호(아이콘 전용으로 축소, 이슈 #39).
+   전체 고지는 본문 byline(.ai-disclosure). byline 과 색상 일치:
+   auto(순수 AI) → 오렌지 / human·reviewed(사람 개입) → 뉴트럴.
+   Source: articles.json provenance.humanReviewed (+ publishReview). */
 .prov-badge {
     display: inline-flex;
     align-items: center;
@@ -444,17 +446,24 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.4;
 }
 
+/* 아이콘 전용 — 라벨 텍스트 제거(카드 공간 축소) */
+.prov-badge-icon {
+    padding: 3px;
+    gap: 0;
+}
+
 .prov-badge svg {
     flex-shrink: 0;
 }
 
-.prov-badge.human {
-    color: #16a34a;
-    background: rgba(34, 197, 94, 0.08);
-    border-color: rgba(34, 197, 94, 0.40);
+.prov-badge.auto {
+    color: #ea580c;
+    background: rgba(248, 104, 37, 0.10);
+    border-color: rgba(248, 104, 37, 0.40);
 }
 
-.prov-badge.auto {
+.prov-badge.human,
+.prov-badge.reviewed {
     color: #64748b;
     background: rgba(100, 116, 139, 0.10);
     border-color: rgba(100, 116, 139, 0.40);

--- a/scripts/card-renderer.js
+++ b/scripts/card-renderer.js
@@ -217,31 +217,40 @@ window.PebblousCardRenderer = (function() {
                 + '</svg></span>'
             : '';
 
-        // Provenance(증적) badge — driven by articles.json `provenance.humanReviewed`,
-        // recorded by the Blog Service Engine at publish time:
-        //   true  → "사람 검토" (HITL — a human resumed at least one review gate)
-        //   false → "완전 자동" (unattended — every gate auto-passed, no human in the loop)
-        // Posts without a `provenance` block (legacy / manual publishes) get no badge.
+        // Provenance(증적) badge — 카드는 좁아 disclosure 에 부적합(이슈 #39).
+        // 전체 고지는 본문 byline(.ai-disclosure)으로 이전. 카드에는 라벨 텍스트 없이
+        // 아이콘만 남겨 at-a-glance 신호 + 툴팁으로 축소한다.
+        // 진실 소스: provenance.humanReviewed (+ publishReview). 라벨/표준 매핑:
+        // docs/blog-service/ai-disclosure.md. byline 과 vocab·색상 일치.
+        //   humanReviewed:true                           → 'human'    AI 작성·사람 편집
+        //   humanReviewed:false + publishReview.reviewed  → 'reviewed' AI 생성·사람 검수
+        //   humanReviewed:false + 검토 없음               → 'auto'     AI 자동 생성
         var prov = article.provenance;
         var provenanceBadge = '';
         if (prov && typeof prov.humanReviewed === 'boolean') {
             var isEn = (article.language === 'en');
-            var provLabel = prov.humanReviewed
-                ? (isEn ? 'Human-reviewed' : '사람 검토')
-                : (isEn ? 'Fully automated' : '완전 자동');
-            var provClass = prov.humanReviewed ? 'prov-badge human' : 'prov-badge auto';
+            var reviewedBeforePublish = !!(prov.publishReview && prov.publishReview.reviewed === true);
+            var provState = prov.humanReviewed ? 'human' : (reviewedBeforePublish ? 'reviewed' : 'auto');
+            var provLabel = provState === 'human'
+                ? (isEn ? 'AI-assisted, human-edited' : 'AI 작성·사람 편집')
+                : provState === 'reviewed'
+                    ? (isEn ? 'AI-generated, editor-reviewed' : 'AI 생성·사람 검수')
+                    : (isEn ? 'AI-generated' : 'AI 자동 생성');
+            var provReviewer = (provState !== 'auto' && prov.publishReview && prov.publishReview.reviewedBy)
+                ? String(prov.publishReview.reviewedBy) : '';
             var provSource = (prov.trigger && prov.trigger.source) ? prov.trigger.source : '';
             var provDate = prov.recordedAt ? String(prov.recordedAt).slice(0, 10) : '';
             var provTitle = (isEn ? 'Provenance: ' : '증적: ') + provLabel
-                + (provSource ? ' · ' + provSource : '')
+                + (provReviewer ? ' · ' + provReviewer : (provSource ? ' · ' + provSource : ''))
                 + (provDate ? ' · ' + provDate : '');
-            var provIcon = prov.humanReviewed
+            // icon-only (라벨 텍스트 없음): auto → bolt, human/reviewed → check
+            var provIcon = (provState === 'auto')
                 ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="12" height="12" aria-hidden="true">'
-                    + '<path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>'
+                    + '<path d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.4-.7C8.4 11.3 9.8 8.6 13 3h1l-1 7h3.5c.5 0 .56.33.47.51L11 21z"/></svg>'
                 : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="12" height="12" aria-hidden="true">'
-                    + '<path d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.4-.7C8.4 11.3 9.8 8.6 13 3h1l-1 7h3.5c.5 0 .56.33.47.51L11 21z"/></svg>';
-            provenanceBadge = '<span class="' + provClass + '" title="' + provTitle + '">'
-                + provIcon + '<span class="prov-badge-label">' + provLabel + '</span></span>';
+                    + '<path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>';
+            provenanceBadge = '<span class="prov-badge prov-badge-icon ' + provState + '" title="' + provTitle + '" aria-label="' + provTitle + '">'
+                + provIcon + '</span>';
         }
 
         // Append lock notice to description for locked posts

--- a/scripts/common-utils.js
+++ b/scripts/common-utils.js
@@ -604,6 +604,14 @@ const PebblousPage = {
                     if (publisher) parts.push(`<span>${publisher}</span>`);
                     if (readTime) parts.push(`<span>${readTime}</span>`);
 
+                    // AI 생성 콘텐츠 고지(disclosure) — provenance 에서 사람판독 라벨 derive.
+                    // 정책: 항상 고지(§50(4) 면제 충족 여부 무관). docs/blog-service/ai-disclosure.md
+                    const disclosure = PebblousProvenance.deriveDisclosure(config.provenance, isEn);
+                    if (disclosure) {
+                        const safeTitle = disclosure.title.replace(/"/g, '&quot;');
+                        parts.push(`<span class="ai-disclosure ai-disclosure-${disclosure.state}" title="${safeTitle}" data-iptc-source-type="${disclosure.iptcSourceType}">${disclosure.label}</span>`);
+                    }
+
                     // Language link with existence check
                     const langLink = document.createElement('a');
                     langLink.href = langPath;
@@ -2255,7 +2263,50 @@ const PebblousTabs = {
     }
 };
 
+// ===== PebblousProvenance — AI 생성 콘텐츠 고지(disclosure) =====
+// provenance(증적, articles.json/엔진 기록)에서 사람판독 byline 라벨 + 기계판독 IPTC
+// Digital Source Type 을 derive 한다. 2축 직교 모델:
+//   생성 방식(IPTC/C2PA) ⊥ 편집 책임(EU AI Act §50(4)).
+// 표준 근거·결정: docs/blog-service/ai-disclosure.md (이슈 #39)
+const PebblousProvenance = {
+    // provenance → { state, label, iptcSourceType, title } | null
+    //   state: 'human' | 'reviewed' | 'auto'
+    //   - humanReviewed:true                          → 'human'    AI 작성·사람 편집
+    //   - humanReviewed:false + publishReview.reviewed → 'reviewed' AI 생성·사람 검수
+    //   - humanReviewed:false + 검토 없음              → 'auto'     AI 자동 생성
+    // provenance 없거나 humanReviewed 불명 → null (수동·레거시: 고지 없음)
+    deriveDisclosure(prov, isEn) {
+        if (!prov || typeof prov.humanReviewed !== 'boolean') return null;
+        const reviewedBeforePublish = !!(prov.publishReview && prov.publishReview.reviewed === true);
+        const state = prov.humanReviewed ? 'human' : (reviewedBeforePublish ? 'reviewed' : 'auto');
+
+        let label, iptcSourceType;
+        if (state === 'human') {
+            label = isEn ? 'AI-assisted, human-edited' : 'AI 작성·사람 편집';
+            iptcSourceType = 'compositeWithTrainedAlgorithmicMedia';
+        } else if (state === 'reviewed') {
+            label = isEn ? 'AI-generated, editor-reviewed' : 'AI 생성·사람 검수';
+            iptcSourceType = 'trainedAlgorithmicMedia';
+        } else {
+            label = isEn ? 'AI-generated' : 'AI 자동 생성';
+            iptcSourceType = 'trainedAlgorithmicMedia';
+        }
+
+        // 툴팁: 증적 라벨 + 책임자(또는 trigger) + 기록일
+        const reviewer = (state !== 'auto' && prov.publishReview && prov.publishReview.reviewedBy)
+            ? String(prov.publishReview.reviewedBy) : '';
+        const source = (prov.trigger && prov.trigger.source) ? String(prov.trigger.source) : '';
+        const date = prov.recordedAt ? String(prov.recordedAt).slice(0, 10) : '';
+        const title = (isEn ? 'Provenance: ' : '증적: ') + label
+            + (reviewer ? ' · ' + reviewer : (source ? ' · ' + source : ''))
+            + (date ? ' · ' + date : '');
+
+        return { state, label, iptcSourceType, title };
+    }
+};
+
 // Export to global scope
+window.PebblousProvenance = PebblousProvenance;
 window.PebblousTheme = PebblousTheme;
 window.PebblousComponents = PebblousComponents;
 window.PebblousUI = PebblousUI;

--- a/styles/common-styles.css
+++ b/styles/common-styles.css
@@ -185,6 +185,34 @@ header > p.themeable-text {
     flex: none;
 }
 
+/* AI 생성 콘텐츠 고지(disclosure) byline — provenance 에서 derive.
+   정책: 항상 고지. 표준 근거: docs/blog-service/ai-disclosure.md (이슈 #39).
+   auto(순수 AI) → 오렌지 강조 / reviewed·human(사람 개입) → 뉴트럴. */
+.ai-disclosure {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 9px;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+    line-height: 1.6;
+    border: 1px solid;
+    cursor: help;
+}
+.ai-disclosure-auto {
+    color: #ea580c;
+    border-color: rgba(248, 104, 37, 0.45);
+    background: rgba(248, 104, 37, 0.10);
+}
+.ai-disclosure-reviewed,
+.ai-disclosure-human {
+    color: var(--text-muted, #64748b);
+    border-color: rgba(100, 116, 139, 0.40);
+    background: rgba(100, 116, 139, 0.10);
+}
+
 /* Breadcrumb pill — scales with title */
 .hero-breadcrumb-pill {
     font-size: 0.625rem;      /* mobile: 10px */


### PR DESCRIPTION
진본 이슈 [joohaeng-pbls/blog-service#39](https://github.com/joohaeng-pbls/blog-service/issues/39) 구현. 결정 문서: `docs/blog-service/ai-disclosure.md`(이미 머지됨, PR #274).

## 무엇

카드는 좁아 AI 고지(disclosure)에 부적합 → **전체 고지를 본문 hero-meta byline으로 이전**하고, 카드 `prov-badge`는 **아이콘 전용으로 축소**.

### 1. `PebblousProvenance.deriveDisclosure(provenance, isEn)` 신규 (`common-utils.js`)
provenance → `{ state, label, iptcSourceType, title }`. 2축 모델(생성 방식 ⊥ 편집 책임):

| provenance | state | byline (KO) | byline (EN) | IPTC DST |
|---|---|---|---|---|
| `humanReviewed:false`, 검토 없음 | auto | AI 자동 생성 | AI-generated | `trainedAlgorithmicMedia` |
| `humanReviewed:false` + `publishReview.reviewed` | reviewed | AI 생성·사람 검수 | AI-generated, editor-reviewed | `trainedAlgorithmicMedia` |
| `humanReviewed:true` | human | AI 작성·사람 편집 | AI-assisted, human-edited | `compositeWithTrainedAlgorithmicMedia` |
| provenance 없음(수동·레거시) | — | (고지 없음) | — | — |

### 2. hero-meta byline (`common-utils.js` + `styles/common-styles.css`)
`config.provenance`에서 derive한 `.ai-disclosure` 칩을 메타 줄에 추가. no-fetch(원칙 정합), **항상 고지** 정책. `auto`=오렌지 강조 / `reviewed`·`human`=뉴트럴. 툴팁에 책임자·기록일.

`2026-06-05 · 페블러스 데이터커뮤니케이션팀 · ~6분 · ENG · ` **`AI 생성·사람 검수`**

### 3. 카드 prov-badge 축소 (`card-renderer.js` + `css/card-styles.css`, `css/styles.css`)
라벨 텍스트 제거 → 아이콘 전용(`.prov-badge-icon`) + 툴팁. 3-state로 확장, byline과 vocab·색상 일치.

## 진실 소스 유지
`articles.json`의 `provenance`(mode·gates·humanReviewed·publishReview) 상태 관리는 그대로. 이 PR은 표시(disclosure) 층만 변경.

## 검증
- 실제 `deriveDisclosure` 함수 Node 추출·실행 — auto/reviewed/human/null 4+2 케이스 단언 통과
- 실제 `renderCard` 4 variant 렌더 — 아이콘 전용 마크업·3-state·수동글 배지없음 확인
- JS 문법 검사 통과
- ⚠️ 브라우저 시각 검증은 프리뷰 포트(8765)를 다른 세션이 점유 중이라 보류 — CSS는 기존 prov-badge 패턴·테마 변수 재사용

## 관계 / 후속
- ⏸ `feat/badge-3state-reviewed` 브랜치는 **머지 보류** — 이 byline 방향으로 대체.
- 후속(별도 PR): 엔진(진본)이 HTML 생성 시 `PebblousPage.init`에 `provenance` 주입 + 기존 글 백필 → byline이 실제 라이브 노출. 캐시버스팅 `?v=` 일괄 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)