### PR TITLE
auto-sync: 진본 blog-service@b67b9e1

### DIFF
--- a/.claude/skills/blog-publish/skill.md
+++ b/.claude/skills/blog-publish/skill.md
@@ -146,6 +146,22 @@ python3 tools/validate-articles.py --fix --id [new-article-id]
 
 검증 통과 후 다음 단계 진행.
 
+### 2.6. provenance → HTML init 주입 (byline 고지)
+
+`provenance` 가 있는 글이라면, articles.json 의 그 값을 **HTML 의 `PebblousPage.init({...})` config 에 동기화**한다. 본문 hero-meta 의 AI 고지 byline(`.ai-disclosure`)이 `config.provenance` 에서 derive 되기 때문이다(fetch 없음). 멱등.
+
+```bash
+node tools/inject-provenance.js --id [new-article-id-ko]
+node tools/inject-provenance.js --id [new-article-id-en]
+# 또는 전체 동기화: node tools/inject-provenance.js
+```
+
+- **런타임 = node** (의도적) — publish-prep 는 Engine 컨테이너(python3 부재, #33)에서 돌기 때문. precheck-gate.js 와 동형.
+- 기본 동작: init 에 `provenance` 가 없으면 삽입, 있으면 무변경(안전).
+- `publishReview` 를 나중에 추가/수정했다면 `--force` 로 재동기화.
+- `provenance` 없는 수동 글은 대상 아님(byline 미표시) — 실행해도 무영향.
+- 표준 근거·라벨 매핑: [`docs/blog-service/ai-disclosure.md`](../../../docs/blog-service/ai-disclosure.md).
+
 ### 3. SEO 검증
 
 HTML에서 확인:

--- a/docs/blog-service/ai-disclosure.md
+++ b/docs/blog-service/ai-disclosure.md
@@ -97,9 +97,10 @@ byline은 hero-meta 줄 끝에 1개 span으로 붙는다:
 ## 6. 구현 계획 (이슈 #39 다음 단계)
 
 1. ✅ 표준 웹 조사 → 본 문서 (2026-06-05).
-2. **byline 고지 컴포넌트** — 사본 `scripts/common-utils.js` hero-meta `parts[]`에 disclosure span 추가. **소스 = `config.provenance` 주입**(결정 2026-06-05, §7 참조): 엔진이 HTML 생성 시 `PebblousPage.init({ provenance })`에 주입, fetch 없이 즉시 렌더링. derive 함수 `PebblousProvenance.deriveDisclosure(provenance, isEn)`. 기존 글은 provenance 없으면 byline 미노출 → 필요 시 엔진 재생성/백필.
-3. **카드 `prov-badge` 축소/제거** — 사본 `scripts/card-renderer.js` + `css/card-styles.css`. `feat/badge-3state-reviewed` 브랜치는 머지하지 말 것(이 방향으로 대체).
-4. **(선택) 기계판독 메타 임베드** — `tools/generate-og-image.js` 또는 별도 단계에서 OG/hero 이미지에 IPTC DST 기록. C2PA는 후순위.
+2. ✅ **byline 고지 컴포넌트** — 사본 `scripts/common-utils.js` hero-meta `parts[]`에 disclosure span. `PebblousProvenance.deriveDisclosure(provenance, isEn)` 신규. 소스 = `config.provenance`(no-fetch). (사본 PR #276)
+3. ✅ **카드 `prov-badge` 축소** — 아이콘 전용. `card-renderer.js` + `css/card-styles.css`·`styles.css`. (사본 PR #276)
+4. ✅ **provenance → HTML init 주입 도구** — `tools/inject-provenance.js`(진본, **node** — publish-prep 가 Engine 컨테이너에서 돌고 python3 부재(#33)이므로). articles.json 의 `provenance` 를 글 HTML 의 `PebblousPage.init({...})` 에 동기화(멱등). `blog-publish` 스킬 Step 2.6 + 백필. *이게 있어야 byline 이 실제 라이브에 노출됨* — provenance 진실 소스는 articles.json, 도구가 HTML init 으로 sync.
+5. **(선택) 기계판독 메타 임베드** — `tools/generate-og-image.js` 또는 별도 단계에서 OG/hero 이미지에 IPTC DST 기록. C2PA는 후순위.
 
 ### 기존 작업과의 관계
 - ✅ **유지**: [PR #37](https://github.com/joohaeng-pbls/blog-service/pull/37) provenance.publishReview 검증 모델 — 상태 관리 층.
@@ -108,6 +109,6 @@ byline은 hero-meta 줄 끝에 1개 span으로 붙는다:
 
 ## 7. 열린 질문
 
-- ~~byline disclosure를 HTML init config로 주입할지 vs articles.json fetch할지~~ → **결정(2026-06-05): `config.provenance` 주입.** `no-fetch` 원칙 정합. 엔진이 HTML 생성 시 `PebblousPage.init` config에 주입하도록 `service/blog-service-engine` 측 변경 필요(진본). 기존 글은 provenance 미보유 시 byline 생략(또는 백필).
+- ~~byline disclosure를 HTML init config로 주입할지 vs articles.json fetch할지~~ → **결정(2026-06-05): `config.provenance` 주입.** `no-fetch` 원칙 정합. ~~엔진 측 변경~~ → **구현 = 결정적 도구 `tools/inject-provenance.js`**(node — #33 컨테이너 정합; LLM 편집 의존 대신): articles.json provenance 를 HTML init 으로 sync. `blog-publish` Step 2.6 에서 호출 + 기존 글 일괄 백필. 멱등.
 - 기계판독 임베드 범위 — OG 이미지만 vs hero 포함. §50(2) 기술 표준 확정(2026-08) 전까지는 OG부터.
 - §50(4) 면제 주장 여부 — 정책상 "항상 고지"이므로 면제에 의존하지 않으나, `publishReview.reviewedBy`에 **실질 검토**를 기록하는 운영 규칙은 별도로 정착시킬 것(엔진 게이트/스킬).

--- a/tools/inject-provenance.js
+++ b/tools/inject-provenance.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * inject-provenance.js — articles.json 의 provenance 를 각 글 HTML 의
+ * PebblousPage.init({...}) config 에 주입한다.
+ *
+ * 배경: 본문 byline 고지(.ai-disclosure)는 `config.provenance` 에서 derive 한다
+ * (fetch 없음 — hero-meta 렌더링 원칙). provenance 의 진실 소스는 articles.json
+ * (엔진이 프롬프트로 주입 → blog-publish 스킬이 기록). 이 도구는 그 값을 HTML init 에
+ * 동기화해 byline 이 실제 라이브에 노출되게 한다. 멱등(idempotent).
+ *
+ * ⚙️ 런타임: **node** (의도적). publish-prep 는 Engine 컨테이너(node:20-slim, python3
+ * 부재 — issue #33)에서 도므로, 이 경로 도구는 node 여야 한다(#25/#33 합의:
+ * 런타임 탈결합). precheck-gate.js 와 동형.
+ *
+ * 표준 근거·결정: docs/blog-service/ai-disclosure.md (이슈 #39)
+ * byline derive 로직: scripts/common-utils.js 의 PebblousProvenance.deriveDisclosure
+ *
+ * 동작:
+ *   - 기본    : init 에 provenance 가 없으면 삽입, 있으면 무변경(안전·멱등)
+ *   - --force : articles.json 값으로 항상 덮어쓰기(재동기화)
+ *   - --check : provenance 보유 글인데 HTML init 에 없으면 exit 1 (CI 게이트)
+ *   - --dry-run : 변경 미리보기(쓰기 없음)
+ *   - --id <article-id> : 특정 글만
+ *
+ * Usage:
+ *   node tools/inject-provenance.js
+ *   node tools/inject-provenance.js --dry-run
+ *   node tools/inject-provenance.js --check
+ *   node tools/inject-provenance.js --force --id data-freshness-checklist-ko
+ *
+ * 경로: BLOG_CONTENT_REPO env (없으면 repo root). scan-articles-meta.py 와 동일 규약.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.env.BLOG_CONTENT_REPO || path.resolve(__dirname, '..');
+const ARTICLES_JSON = path.join(ROOT, 'articles.json');
+
+// ── HTML init 파싱/주입 (순수 함수 — 테스트 용이) ──────────────────────────────
+
+/** articles.json path → HTML 파일 경로 (scan-articles-meta.py 와 동일 규약). */
+function resolveHtml(pathVal) {
+  let p = pathVal.replace(/^\/+/, '');
+  if (p.endsWith('.html')) return path.join(ROOT, p);
+  if (!p.endsWith('/')) p += '/';
+  return path.join(ROOT, p + 'index.html');
+}
+
+/** s[openIdx]==='{' 일 때 매칭되는 '}' 인덱스. 문자열/이스케이프 인지. 실패 시 -1. */
+function balanceBraces(s, openIdx) {
+  let depth = 0;
+  let inStr = null;
+  let esc = false;
+  for (let i = openIdx; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === inStr) inStr = null;
+    } else if (c === "'" || c === '"' || c === '`') {
+      inStr = c;
+    } else if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** 첫 <script> 안 PebblousPage.init({...}) 객체의 [braceStart, braceEnd]. 없으면 null. */
+function findInitObject(html) {
+  const scriptRe = /<script\b[^>]*>([\s\S]*?)<\/script>/gi;
+  let sm;
+  while ((sm = scriptRe.exec(html)) !== null) {
+    const inner = sm[1];
+    const m = /PebblousPage\.init\(\s*\{/.exec(inner);
+    if (!m) continue;
+    // inner(group1) 의 절대 시작 = 매치 시작 + 여는태그 길이
+    const groupStart = sm.index + (sm[0].length - inner.length - '</script>'.length);
+    const braceStart = groupStart + m.index + m[0].length - 1;
+    const braceEnd = balanceBraces(html, braceStart);
+    return braceEnd !== -1 ? [braceStart, braceEnd] : null;
+  }
+  return null;
+}
+
+/** init 범위 내 top-level `provenance: {...}` 의 [keyStart, valueEnd]. 없으면 null. */
+function findProvenanceSpan(html, braceStart, braceEnd) {
+  const region = html.slice(braceStart, braceEnd + 1);
+  const m = /\bprovenance\s*:\s*\{/.exec(region);
+  if (!m) return null;
+  const objOpen = braceStart + m.index + m[0].length - 1;
+  const valueEnd = balanceBraces(html, objOpen);
+  if (valueEnd === -1) return null;
+  return [braceStart + m.index, valueEnd];
+}
+
+/** init '{' 다음 첫 키 줄의 들여쓰기 칸 수(기존 키와 정합). 기본 4. */
+function detectIndent(html, braceStart) {
+  const nl = html.indexOf('\n', braceStart);
+  if (nl === -1) return 4;
+  const m = /^[ \t]*/.exec(html.slice(nl + 1));
+  const indent = m ? m[0].length : 0;
+  return indent > 0 ? indent : 4;
+}
+
+/** init 안에 넣을 `provenance: {...},` 스니펫. articles.json 과 동일 JSON(따옴표 키). */
+function formatProvenance(prov, baseIndent = 4) {
+  const pad = ' '.repeat(baseIndent);
+  const lines = JSON.stringify(prov, null, 2).split('\n');
+  const out = [pad + 'provenance: ' + lines[0]];
+  for (let i = 1; i < lines.length; i++) out.push(pad + lines[i]);
+  return out.join('\n') + ',';
+}
+
+/** 기존 `provenance: {...}` + 뒤따르는 콤마/공백/개행 제거한 html. */
+function removeSpan(html, span) {
+  const [keyStart, valueEnd] = span;
+  let tail = valueEnd + 1;
+  const m = /^[ \t]*,?[ \t]*\n?/.exec(html.slice(tail));
+  tail += m ? m[0].length : 0;
+  const pre = html.slice(0, keyStart).replace(/\n[ \t]*$/, '\n');
+  return pre + html.slice(tail);
+}
+
+/** 반환: [newHtml, status]. status ∈ inserted|replaced|present|missing-init. */
+function inject(html, prov, force = false) {
+  let loc = findInitObject(html);
+  if (!loc) return [html, 'missing-init'];
+  let [braceStart, braceEnd] = loc;
+  const span = findProvenanceSpan(html, braceStart, braceEnd);
+
+  if (span && !force) return [html, 'present'];
+
+  if (span && force) {
+    html = removeSpan(html, span);
+    [braceStart, braceEnd] = findInitObject(html);
+  }
+
+  const snippet = formatProvenance(prov, detectIndent(html, braceStart));
+  const newHtml = html.slice(0, braceStart + 1) + '\n' + snippet + html.slice(braceStart + 1);
+  return [newHtml, span && force ? 'replaced' : 'inserted'];
+}
+
+// ── 메인 ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const check = args.includes('--check');
+  const force = args.includes('--force');
+  let filterId = null;
+  const idIdx = args.indexOf('--id');
+  if (idIdx !== -1 && idIdx + 1 < args.length) filterId = args[idIdx + 1];
+
+  if (!fs.existsSync(ARTICLES_JSON)) {
+    console.error(`❌ articles.json 없음: ${ARTICLES_JSON}`);
+    process.exit(2);
+  }
+
+  const data = JSON.parse(fs.readFileSync(ARTICLES_JSON, 'utf8'));
+  const articles = data.articles || [];
+
+  let targets = articles.filter((a) => a.provenance && typeof a.provenance === 'object' && !Array.isArray(a.provenance));
+  if (filterId) targets = targets.filter((a) => a.id === filterId);
+
+  const mode = check ? '검사(--check)' : dryRun ? '미리보기(--dry-run)' : force ? '재동기화(--force)' : '주입';
+  console.log(`\n🔖 inject-provenance [${mode}] — provenance 보유 ${targets.length}글\n`);
+
+  let inserted = 0;
+  let replaced = 0;
+  let present = 0;
+  let missingHtml = 0;
+  let missingInit = 0;
+  let checkFail = 0;
+
+  for (const a of targets) {
+    const aid = a.id || '?';
+    const htmlFile = resolveHtml(a.path || '');
+    if (!fs.existsSync(htmlFile)) {
+      console.log(`  ⚠️  [${aid}] HTML 없음: ${path.relative(ROOT, htmlFile)}`);
+      missingHtml++;
+      continue;
+    }
+
+    const html = fs.readFileSync(htmlFile, 'utf8');
+
+    if (check) {
+      const loc = findInitObject(html);
+      const has = loc && findProvenanceSpan(html, loc[0], loc[1]);
+      if (!has) {
+        console.log(`  ❌ [${aid}] init 에 provenance 없음`);
+        checkFail++;
+      }
+      continue;
+    }
+
+    const [newHtml, status] = inject(html, a.provenance, force);
+    if (status === 'missing-init') {
+      console.log(`  ⚠️  [${aid}] PebblousPage.init 블록 없음 — 건너뜀`);
+      missingInit++;
+      continue;
+    }
+    if (status === 'present') {
+      present++;
+      continue;
+    }
+
+    const verb = status === 'inserted' ? '삽입' : '덮어씀';
+    console.log(`  ${dryRun ? '·' : '🔧'} [${aid}] provenance ${verb} → ${a.path}`);
+    if (status === 'inserted') inserted++;
+    else replaced++;
+    if (!dryRun) fs.writeFileSync(htmlFile, newHtml);
+  }
+
+  console.log();
+  if (check) {
+    console.log(`요약: 누락 ${checkFail} / 검사 대상 ${targets.length}`);
+    if (checkFail) console.log('→ `node tools/inject-provenance.js` 로 주입 필요');
+    process.exit(checkFail ? 1 : 0);
+  }
+
+  const parts = [];
+  if (inserted) parts.push(`삽입 ${inserted}`);
+  if (replaced) parts.push(`덮어씀 ${replaced}`);
+  if (present) parts.push(`이미존재 ${present}`);
+  if (missingHtml) parts.push(`HTML없음 ${missingHtml}`);
+  if (missingInit) parts.push(`init없음 ${missingInit}`);
+  console.log('요약: ' + (parts.length ? parts.join(', ') : '변경 없음') + (dryRun ? ' (dry-run, 미저장)' : ''));
+  process.exit(0);
+}
+
+module.exports = {
+  resolveHtml,
+  balanceBraces,
+  findInitObject,
+  findProvenanceSpan,
+  detectIndent,
+  formatProvenance,
+  removeSpan,
+  inject,
+};
+
+if (require.main === module) main();

--- a/tools/inject-provenance.test.js
+++ b/tools/inject-provenance.test.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * inject-provenance.js 단위 테스트 — 삽입/멱등/force/init없음/들여쓰기 정합.
+ * 실행: node tools/inject-provenance.test.js
+ */
+const { test } = require('node:test');
+const assert = require('node:assert');
+const ip = require('./inject-provenance.js');
+
+const PROV = {
+  mode: 'unattended',
+  humanReviewed: false,
+  trigger: { source: 'api', actor: 'e2e', at: '2026-06-05T00:00:00Z' },
+  gates: [{ phase: 'write-ko', resolution: 'auto_passed', by: 'engine' }],
+  engine: { runId: 'run-x', version: '0.1.0' },
+  recordedAt: '2026-06-05T00:00:00Z',
+  publishReview: { reviewed: true, reviewedAt: '2026-06-05', reviewedBy: 'JH (사실·논지 검토)' },
+};
+
+const HTML_BASE = `<!DOCTYPE html><html lang="ko"><head><title>T</title></head><body>
+<h1 id="page-h1-title"></h1>
+<script src="/scripts/common-utils.js"></script>
+<script>
+        PebblousPage.init({
+        mainTitle: "제목",
+        subtitle: "부제 \\"인용\\" 포함",
+        category: "tech",
+        publishDate: "2026-06-05",
+        tags: ["a", "b"],
+        faqs: [
+            { question: "Q1?", answer: "A1." },
+            { question: "Q2?", answer: "A2." }
+        ]
+    });
+</script>
+</body></html>`;
+
+function provObj(html) {
+  const loc = ip.findInitObject(html);
+  const sp = ip.findProvenanceSpan(html, loc[0], loc[1]);
+  const open = html.indexOf('{', sp[0]);
+  return JSON.parse(html.slice(open, sp[1] + 1));
+}
+
+test('삽입: status=inserted, 키 존재, 기존 키·FAQ 보존', () => {
+  const [out, status] = ip.inject(HTML_BASE, PROV, false);
+  assert.strictEqual(status, 'inserted');
+  assert.ok(ip.findProvenanceSpan(out, ...ip.findInitObject(out)));
+  assert.ok(out.includes('mainTitle: "제목"'));
+  assert.strictEqual((out.match(/question:/g) || []).length, 2);
+  assert.ok(out.includes('사실·논지 검토'));
+});
+
+test('주입된 provenance 가 유효 JSON 이고 원본과 동일', () => {
+  const [out] = ip.inject(HTML_BASE, PROV, false);
+  assert.deepStrictEqual(provObj(out), PROV);
+});
+
+test('들여쓰기 == init 키 들여쓰기 (8칸)', () => {
+  const [out] = ip.inject(HTML_BASE, PROV, false);
+  const provLine = out.split('\n').find((l) => /^\s*provenance\s*:/.test(l));
+  const mainLine = out.split('\n').find((l) => l.includes('mainTitle:'));
+  const ind = (l) => l.length - l.trimStart().length;
+  assert.strictEqual(ind(provLine), 8);
+  assert.strictEqual(ind(provLine), ind(mainLine));
+});
+
+test('멱등: 이미 있으면 present, 무변경', () => {
+  const [out] = ip.inject(HTML_BASE, PROV, false);
+  const [out2, status2] = ip.inject(out, PROV, false);
+  assert.strictEqual(status2, 'present');
+  assert.strictEqual(out2, out);
+});
+
+test('force: replaced, 중복 없음, 새 값 반영, 다른 키 보존', () => {
+  const [out] = ip.inject(HTML_BASE, PROV, false);
+  const PROV2 = { ...PROV, humanReviewed: true };
+  const [out3, status3] = ip.inject(out, PROV2, true);
+  assert.strictEqual(status3, 'replaced');
+  assert.strictEqual((out3.match(/\bprovenance\s*:/g) || []).length, 1);
+  assert.strictEqual(provObj(out3).humanReviewed, true);
+  assert.ok(out3.includes('mainTitle: "제목"'));
+  assert.strictEqual((out3.match(/question:/g) || []).length, 2);
+});
+
+test('init 블록 없음: missing-init', () => {
+  const [, status] = ip.inject('<html><body>no init</body></html>', PROV);
+  assert.strictEqual(status, 'missing-init');
+});
+
+test('주석 init 무시, 실제 script init 에 주입', () => {
+  const html = '<!-- PebblousPage.init({ faqs: [] }) -->\n' + HTML_BASE;
+  const [out, status] = ip.inject(html, PROV);
+  assert.strictEqual(status, 'inserted');
+  assert.ok(out.includes('mainTitle: "제목"'));
+});


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@b67b9e1

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
