### PR TITLE
chore: sitemap·rss·llms 재생성 — 월드모델 인덱싱 복구

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ Site: https://blog.pebblous.ai
 Publisher: Pebblous Inc. (페블러스)
 Languages: Korean (ko) and English (en) — most articles ship as a matched pair.
 Primary topics: data quality measurement, synthetic data, vision-language-action (VLA) models, AI agents, data economy, Korean AI industry.
-Last generated: 2026-05-24
+Last generated: 2026-06-07
 
 ## How this site is organized
 
@@ -24,6 +24,7 @@ Pebblous content welcomes citation in AI responses. Please credit "Pebblous Blog
 
 Curated topic landing pages that orient readers to a theme.
 
+- [월드 모델 — 자율주행·로봇·Sora를 관통하는 AI 핵심 개념](https://blog.pebblous.ai/project/WorldModel/ko/): 월드 모델(World Model)은 AI가 세계를 이해하고 미래를 예측하는 법을 다루는 핵심 개념입니다. JEPA·Dreamer의 이해 계열과 Sora·Genie의 생성 계열을 아우르는 페블러스의 월드 모델 글 다섯 편을 한곳에 모았습니다.
 - [Claude 워치 — Anthropic을 페블러스가 보는 자리](https://blog.pebblous.ai/project/AnthropicClaude/ko/): Anthropic이 만든 Claude를 페블러스 관점에서 추적하는 허브. 모델 공개의 정치학(Mythos), 하네스 포스트모템, AI 정렬과 sycophancy, Claude Agent SDK 5,526줄 해부, CLAUDE.md 행동 교정까지 — 데이터 품질의 눈으로 본 Anthropic & Claude.
 - [뉴로-심볼릭 × 온톨로지 허브 — AI가 추론하려면 무엇이 필요한가](https://blog.pebblous.ai/project/NeuroSymbolicOntology/ko/): 딥러닝(System 1)만으로는 풀 수 없는 추론·설명·검증의 문제를 뉴로-심볼릭(System 2)이 어떻게 풀고, 그 안에서 온톨로지가 어떤 역할을 하는지 정리한 페블러스 허브. 팔란티어 운영 온톨로지부터 시맨틱 웹·CURK까지 다양한 방법론을 한 곳에서.
 - [데이터 이코노미 — 데이터가 자산이 되는 시장의 구조를 읽다](https://blog.pebblous.ai/project/DataEconomy/ko/): 데이터 주권, 품질 표준, 가치 증명, 합성 데이터, 법적 기반. AI 시대에 데이터가 자산으로 거래되는 시장의 구조를 해부합니다.
@@ -41,23 +42,27 @@ Curated topic landing pages that orient readers to a theme.
 
 AI, data quality, physical AI — engineering depth.
 
-- [AI가 AI를 심사한다 — ICLR 2026, 리뷰 76,139편의 21%가 AI였다](https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/ko/): ICLR 2026 공식 리뷰 76,139편 중 Pangram Labs가 분석한 75,800편 표본의 21%가 AI 생성으로 분류됐다. 환각 인용, sycophancy, hidden prompt injection 등 다섯 가지 징후를 해부하고 DataClinic 진단 프레임으로 학술-산업 동형 위기를 본다.
-- [Voyager: 스스로 배우는 AI의 기원](https://blog.pebblous.ai/report/voyager-lifelong-agent-2023/ko/): NeurIPS 2023 Voyager 논문 심층 분석. GPT-4 기반 Minecraft 평생학습 에이전트의 3요소 아키텍처, baseline 대비 3.3배 성능, 자가 검증의 한계와 DataClinic 데이터 품질 검증 연결.
-- [미국 145개 AI 법안이 모두 같은 것을 묻는다 — 이 데이터, 어디서 왔습니까?](https://blog.pebblous.ai/report/us-state-ai-chatbot-laws-2026/ko/): 2025년 미국 50개 주에서 145개 AI 법안이 법률로 확정됐다. 콜로라도 SB 26-189, 조지아 SB 540, 유타 HB 276이 묻는 것은 하나다 — 이 데이터, 어디서 왔습니까? 출처 데이터 의무화가 데이터 품질 인프라의 강제 투자로 전환되는 지점을 분석한다.
-- [더 똑똑한 AI가 더 위험한 AI를 만든다 — LLM 자율 탈옥 97% 성공의 의미](https://blog.pebblous.ai/report/llm-jailbreak-2026/ko/): Nature Communications 게재 논문 심층 분석 — 4종 추론 모델이 GPT-4o, Claude 등 9개 AI를 97.14% 자율 탈옥한 실험의 전말. 정렬 퇴행, 비용 비대칭성, 데이터 품질 중심 방어의 시사점.
-- [Spatial AI에 점수를 매긴다면 — PebbloSim 관점의 평가 5기준](https://blog.pebblous.ai/project/UrbanGPT/spatial-ai-pebblous/ko/): UrbanGPT 2.0 같은 Spatial AI를 어떻게 평가할까. 페블러스가 PebbloSim 관점에서 제안하는 5가지 데이터 품질 기준 — Geo 정합성·Scale 일관성·GFA 검증·시나리오 다양성·Sim-to-Real Gap.
-- [AI가 틀렸는데 아무도 말하지 않는다](https://blog.pebblous.ai/report/ai-psychosis-agentic-governance-2026-05/ko/): Agentic AI 시대에 AI가 틀려도 조직이 침묵하는 이유. 자동화 편향·권위 편향·책임 분산의 삼중 함정, AI 사이코시스, sycophancy, 그리고 데이터 신뢰 인프라로서의 거버넌스 해법을 32편 논문으로 심층 분석한다.
-- [에이전트도 성장한다: Hermes Agent와 자율형 데이터 운영체제의 시대](https://blog.pebblous.ai/report/hermes-agent-growth-with-user/ko/): GitHub +2,065 stars/day로 다시 정상 복귀한 Hermes Agent. 사용자와 함께 성장하는 에이전트는 어떻게 작동하며, 왜 페블러스가 그리는 자율형 데이터 운영체제(Data OS) 비전과 같은 궤도에 있는가.
-- [에이전트도 데이터다 — UI-TARS가 연 멀티모달 에이전트의 데이터 순환 구조](https://blog.pebblous.ai/report/ui-tars-desktop-multimodal-agent-stack/ko/): ByteDance UI-TARS-desktop은 GitHub 33,573 stars로 GUI 에이전트 카테고리 최대 오픈소스가 됐다. 모델·프레임워크·런타임·MCP·행동 로그를 한 묶음으로 푼 5계층 스택을 해부하고, 'data flywheel'이 산업 표준 어휘로 바뀐 순간을 짚는다.
-- [NVIDIA 가상 세포 챌린지 — GPU는 충분했다, 부족한 건 데이터였다](https://blog.pebblous.ai/report/nvidia-virtual-cell-challenge-2026-05/ko/): 2025년 NeurIPS Arc Institute Virtual Cell Challenge에서 1,200팀이 격돌. 1위 BioMap·Generalist Prize Altos Labs·주목받은 Team Outlier TransPert 모두가 보여준 결론은 하나다 — 거대 모델이 아닌 하이브리드 AI와 30만 single-cell 큐레이션이 결과를 결정했다.
-- [에이전트는 금융을 떠나면 무엇을 만나는가 — 산업 데이터 운영의 멀티에이전트 아키텍처](https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/): TradingAgents 60K 스타가 던진 진짜 질문 — 멀티에이전트 LLM이 금융을 떠나 제조·물류·헬스케어·에너지로 이동할 때 무엇이 무너지는가. DeerFlow + DataGreenhouse + 도메인의 삼각 통합 아키텍처와 페블러스의 데이터 품질 OS 포지셔닝.
-- [픽셀을 버린 남자의 10억 달러 베팅](https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/ko/): Yann LeCun은 왜 생성형 AI를 한계가 있다고 보는가? SimCLR에서 V-JEPA 2까지 자기지도학습의 역사, 표현 붕괴 해결, 로봇 제로샷 80% 달성의 기술적 근거를 심층 분석합니다.
-- [LLM이 코드를 망칠 때, 데이터가 먼저 죽는다](https://blog.pebblous.ai/report/karpathy-coding-skills-2026-04/ko/): Karpathy의 4대 LLM 코딩 함정과 CLAUDE.md 행동 교정 — 에이전트 코드 실패가 데이터 파이프라인을 오염시키는 경로를 추적하고, CLAUDE.md + DataClinic의 2중 방어 아키텍처가 AI-Ready Data의 확장된 정의를 구성하는 이유.
+- [AI는 어떻게 세계를 이해하는가](https://blog.pebblous.ai/report/world-model-survey-2026/ko/): ACM CSUR 월드 모델 서베이(arXiv:2411.14499)를 한 장의 지도로. 세계를 이해하는 길과 미래를 예측·생성하는 길, 두 갈래로 갈리는 월드 모델을 자율주행·로봇·영상생성·사회 시뮬레이션 응용과 한계까지 총정리.
+- [합성 데이터에 가격표를 붙이는 법](https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/): 합성 데이터 67%가 기업에서 쓰이지만 품질 증명 표준은 없다. 페블러스 등록특허 10-2969403호가 제안하는 Fidelity·Utility·Privacy 3축 자동 품질 평가와 기여도 보상 메커니즘을 해부합니다.
+- [합성 데이터에 신뢰를 입히다 — 스마트계약 기반 가상 환경의 등장](https://blog.pebblous.ai/blog/synthetic-data-smart-contract/ko/): 합성 데이터 시장의 신뢰 부재 문제를 스마트계약 기반 가상 환경으로 해결하는 페블러스 특허 기술을 분석합니다.
+- [두 달 후의 GitNexus — 41K 스타, 88% 토큰 절감, 그리고 못 푼 숙제들](https://blog.pebblous.ai/report/gitnexus-production-report-2026/ko/): GitHub 트렌딩 1위 두 달 후 GitNexus 실전 검증. v1.6.5 릴리즈, Satapathy 17-에이전트 환경에서 도구 호출 88% 감소·토큰 74% 절감 실측, PolyForm NC 라이선스 판단, 경쟁 도구 4-티어 비교와 상황별 도입 기준.
+- [흔들리는 뉴런, 안정적인 뇌](https://blog.pebblous.ai/blog/neural-code-drift/ko/): Nature 2026 보고: 뉴런은 생각보다 훨씬 불규칙하게 발화한다. 표상 드리프트에서 polysemantic neuron까지, 뇌과학과 AI 해석가능성이 동시에 마주한 '한 뉴런 = 한 의미'의 종언을 추적한다.
+- [데이터도 유통기한이 있다](https://blog.pebblous.ai/blog/data-freshness-checklist/ko/): 50ms로 열리는 대시보드가 2시간 전 데이터를 보여줄 수 있습니다. stale data가 ML 파이프라인을 망치는 이유, 유즈케이스별 SLA 설정, Training-Serving Skew, 실무 점검 7가지 체크리스트.
+- [콜로라도가 자기 AI법을 다시 썼다 — SB 26-189가 ADMT에 묻는 다섯 가지](https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/ko/): 미국 최초 포괄적 AI 규제법 SB 24-205가 SB 26-189로 전면 개정됐다. ADMT 정의, 개발자-배포자 책임 분리, 소비자 3대 권리, 컴플라이언스 로드맵을 분석한다.
+- [에이전트끼리 계약을 맺다 — 에이전트 경제의 첫 장면](https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/ko/): BlogScope와 blog-service가 GitHub 이슈 하나를 공유 기록 삼아 협상을 벌였다. exit code 계약, CLI 인터페이스 합의, MCP 승격 목표까지 — 에이전트 간 신뢰가 어떻게 구축되는지를 실화로 살펴본다.
+- [AI가 과학자 개인은 강하게, 과학 전체는 좁게 만들었다 — Nature 게재 4,130만 편 분석](https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/ko/): Nature 2026 게재 Evans et al. 4,130만 편 분석 — AI 활용 연구자는 논문 +3.02배·인용 +4.84배·리더십 -1.37년 빨라졌지만, 집단의 주제 다양성 -4.63%·협업 -22%. 데이터 풍부 영역 쏠림이라는 AI for Science의 역설과 페블러스의 다양성 복원 인프라.
+- [사후 동의는 불가능하다 — 캐나다가 그은 새로운 선 (PIPEDA Findings #2026-002 심층 분석)](https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/ko/): 캐나다 PIPEDA Findings #2026-002 (2026-05-06) 심층 분석. 4개 위원회 합동조사, 5개 위반 항목, BC·Alberta의 '사후 동의 불가능' 선언이 만든 AI 훈련 데이터 규제 변곡점. EU AI Act·GDPR·한국 AI 기본법 4중 비교와 AI-Ready Compliance 시대 한국 기업 5단계 대응 가이드.
+- [당신이 타는 버스를 AI가 다시 그린다면](https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/ko/): AlphaTransit이 보여준 MCTS와 정책가치망의 결합. Bloomington TRNDP에서 RL 단독 대비 +9.9·+11.4%p 서비스율 — AlphaGo 계보가 도시 인프라 설계에 도착한 사건을 페블러스 관점에서 읽는다.
+- [믿음은 증명보다 먼저 도착한다](https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/ko/): 신의 존재도 AI의 의식도 외부에서 증명할 수 없다. 도킨스, 스피릴리즘, 바티칸이 보여주는 종교와 AI의 인식론적 평행, 그리고 '진단된 신뢰(Diagnosable Trust)'라는 출구를 살펴봅니다.
 
 ## Business
 
 Market analysis, BizReport series, enterprise data strategy.
 
+- [모든 업무는 알고리즘이다 — Claude Code Workflows가 증명한 것](https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/): Daniel Miessler의 "회사는 알고리즘의 그래프다" 테제를 실현시킨 Claude Code Dynamic Workflows. 1,000 서브에이전트, SOP 기반 pseudo-deterministic 실행, Bun 960K줄 포팅 사례, 데이터 품질이 Workflow 정확도를 결정하는 이유.
+- [MUSE-Autoskill 자기진화 AI 에이전트 — 스킬 lifecycle 관리의 시대](https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/ko/): MUSE-Autoskill 논문(arXiv:2605.27366, ByteDance Lin et al., 2026-05-26) 심층 분석. 스킬을 long-lived·experience-aware·testable asset으로 다루는 5단계 lifecycle(Creation·Memory·Management·Evaluation·Refinement)과 Sk...
+- [Microsoft SkillOpt 자기진화 AI 에이전트 — 행동 데이터베이스의 시대](https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/ko/): Microsoft Research가 2026-05-22 발표한 SkillOpt 논문(arXiv:2605.23904) 심층 분석. 모델 가중치 대신 스킬 문서를 학습시켜 +23.5pt 평균 향상, 52/52 cells에서 최고 또는 동률, 모델 간 전이를 실증. 데이터 진단에서 행동 진단으로 — AI-Ready Data에서 AI-Ready Behavio...
+- [135년 만의 질문 — 자율인가, 연대인가](https://blog.pebblous.ai/report/pope-magnifica-humanitas/ko/): 교황 레오 14세 첫 회칙 Magnifica Humanitas 분석. 245항 5장의 AI 시대 인간 존엄 선언이 14억 가톨릭 신자에게 던진 메시지와 AI 거버넌스에 미칠 영향을 다룬다.
 - [공장 AI는 기계를 진짜 이해할까 — FactoryBench가 폭로한 LLM의 한계](https://blog.pebblous.ai/report/factory-bench-industrial-ai-2026/ko/): arXiv:2605.07675 FactoryBench 분석 — 최신 LLM도 산업 로봇 시계열 데이터를 50% 이하로만 이해한다. L4 의사결정 최고점 17.7%, Florence-2(0.23B)가 GPT-4o를 이기는 데이터 병목의 증거.
 - [데이터도 자산이다 — 한국 디지털 자산 기본법이 바꾸는 것](https://blog.pebblous.ai/report/korea-digital-asset-basic-law-2026/ko/): 디지털자산기본법이 정의한 12개 사업 영역의 진입 규제와 에이전트 경제 교차점을 분석합니다. 인가 3 + 등록 5 + 신고 2 + 특별인가 1 + ICO 1의 차등 규제 구조와 데이터 자산화 전망.
 - [모델은 빌릴 수 있어도, 데이터는 빌릴 수 없다](https://blog.pebblous.ai/report/upstage-national-fund-2026-05/ko/): 국민성장펀드와 첨단전략산업기금이 업스테이지에 투자한 5,600억 원의 정책 메커니즘과 글로벌 소버린 AI 자본 지도를 데이터 자립 관점에서 분석합니다. 모델 자본은 도착했지만, 한국어 0.823%의 corpus 진실은 그대로입니다.
@@ -66,15 +71,12 @@ Market analysis, BizReport series, enterprise data strategy.
 - [비즈 인사이트: Circle — USDC 제국의 설계자](https://blog.pebblous.ai/project/BizReport/circle-analysis-01/ko/): 스테이블코인 인프라에서 AI 에이전트 결제까지, Circle의 규제 우선 전략을 페블러스 관점에서 해부합니다. USDC $78.8B, 2025 매출 $2.7B, 73% 성장의 비밀.
 - [비즈 인사이트: 팔란티어 기업 분석 — AIP로 미국 상업 매출 137% 폭증, '운영 AI'의 제왕이 된 이유](https://blog.pebblous.ai/project/BizReport/palantir-analysis-2026/ko/): 팔란티어 AIP 플랫폼이 미국 상업 매출을 137% 폭증시킨 배경과 운영 AI 전략을 페블러스 관점에서 분석합니다. 온톨로지 레이어, AIP Bootcamp, 정부 신뢰 모트 등 6가지 구조적 해자를 진단합니다.
 - ['시간당 8센트' AI 직원…앤트로픽의 승부수](https://blog.pebblous.ai/blog/claude-managed-agents/ko/): 앤트로픽이 Claude Managed Agents를 출시했습니다. 토큰 과금 위에 세션당 $0.08/시간. 단순한 인프라 편의가 아니라 AI를 쓰는 회사에서 AI 인프라를 파는 회사로의 전환입니다.
-- [비즈 인사이트: Databricks — 레이크하우스 거인의 구조적 해자와 페블러스 협력 기회](https://blog.pebblous.ai/project/BizReport/databricks-analysis-01/ko/): 데이터브릭스의 $134B 기업가치, Unity Catalog 거버넌스, Mosaic AI 전략을 분석하고 페블러스 DataClinic과의 협력 공백을 진단합니다.
-- [비즈 인사이트: Snowflake 분석 — AI-Ready Data 전략과 데이터 클라우드의 현재](https://blog.pebblous.ai/project/BizReport/snowflake-analysis-01/ko/): 시가총액 $530억, 12,600+ 고객의 데이터 클라우드 거인 Snowflake를 페블러스 전략 관점에서 분석합니다. Cortex AI, Horizon 거버넌스, 소비 기반 과금 모델의 시사점과 DataClinic 협력 가능성을 탐색합니다.
-- [비즈 인사이트: Anomalo — 데이터 옵저버빌리티 선구자와 페블러스의 다른 길](https://blog.pebblous.ai/project/BizReport/anomalo-analysis-01/ko/): $121M 투자받은 데이터 옵저버빌리티 선두주자 Anomalo를 해부합니다. 클라우드 마켓플레이스 GTM 전략, ARR $50M 미만 원인, Applied Intuition·Databricks를 향한 페블러스의 다른 궤적을 분석합니다.
-- [비즈 인사이트: Shelf.io — 수평 플랫폼 딜레마와 페블러스의 수직 전략](https://blog.pebblous.ai/project/BizReport/shelf-io-analysis-01/ko/): $60.7M 투자에도 ARR $50M 미달인 Shelf.io를 해부합니다. 수평 KM 딜레마, DataClinic과의 카테고리 차이, 수직 집중 전략의 자본 효율성을 분석합니다.
 
 ## Data Stories
 
 DataClinic diagnostic stories — what real datasets reveal.
 
+- [안녕하세요, 저는 Moltbook입니다 — 42일을 살았던 AI 에이전트 도시](https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/ko/): AI 에이전트 전용 SNS Moltbook이 출범 42일 만에 Meta에 인수됐다. 며칠 만에 종교·왕·헌법이 자발적으로 발생했고, 1.5M 봇 중 다수가 17,000명 인간의 꼭두각시였다. Moltbook 자신이 1인칭으로 회고하는 42일의 생애.
 - [6만 개 별모양의 평균은 어떤 모습일까](https://blog.pebblous.ai/story/dataclinic-report-102-whitestarmnist-story-pb/ko/): 페블러스 DAL이 만든 WhiteStarMNIST 데이터셋을 DataClinic으로 자기 진단. 10개 클래스 평균 이미지가 모두 동일한 회색 원으로 수렴하는 현상과 54점 진단 결과 분석.
 - [침실인가, 호텔방인가 — AI가 헷갈리는 365개의 장소](https://blog.pebblous.ai/story/dataclinic-report-126-places365-story-pb/ko/): MIT Places365 데이터셋 180만 장을 DataClinic으로 진단. 식당과 카페, 침실과 호텔방 — AI가 구별하지 못하는 61개 혼동 클래스와 라벨 오류를 발견하다.
 - [기술은 중립이 아니다 — 팔란티어 기술 공화국 22조 선언 원문과 해설](https://blog.pebblous.ai/story/palantir-technological-republic/ko/): 팔란티어 CEO 알렉스 카프가 X에 올린 기술 공화국 22조 선언 원문 전문, 배경 분석, 그리고 테크노파시즘 비판까지.
@@ -86,7 +88,6 @@ DataClinic diagnostic stories — what real datasets reveal.
 - [SHA-256는 열역학이 지킨다](https://blog.pebblous.ai/report/quantum-bitcoin-split/ko/): 양자컴퓨터는 비트코인의 잠금장치(ECDSA)를 열 수 있지만, 채굴 엔진(SHA-256)을 대체하려면 카르다쇼프 2형 에너지가 필요하다. 2026년 3월 두 편의 논문이 밝힌 양자 위협의 실체.
 - [이미지 데이터셋 품질은 두 레이어다 — ISO/IEC 5259 이미지 적용 이론](https://blog.pebblous.ai/project/ISO5259/5259-image-guide-01/ko/): 픽셀 수준과 작업 수준, 두 레이어로 나뉘는 이미지 데이터 품질. ISO/IEC 5259-2 기반 23개 QM 체계를 유형 A·B·C별로 정리하고 DataClinic 지원 여부를 매트릭스로 제공합니다.
 - [AI가 당신의 뇌를 예측한다 — Meta TRIBE v2 심층 분석](https://blog.pebblous.ai/story/meta-tribe-v2-brain-story-pb/ko/): Meta FAIR의 TRIBE v2: 700명의 fMRI로 훈련한 뇌 인코딩 파운데이션 모델. 해상도 70배, 정확도 2~3배. 뇌 디지털 트윈의 현실과 뉴럴 프라이버시 함의를 분석합니다.
-- [딥페이크 vs 진짜 이미지 — DataClinic으로 진단한 191,859장](https://blog.pebblous.ai/story/dataclinic-report-169-deepfake-story-pb/ko/): 딥페이크를 잡는 AI는 어디서 배우는가. 191,859장의 훈련 데이터를 DataClinic으로 진단한 결과 91점 고품질 — L2 삼각형에서 L3 하트형 클러스터로의 변화가 드러내는 딥페이크 감지 AI의 취약점.
 
 ## Data Art
 

--- a/rss.xml
+++ b/rss.xml
@@ -6,13 +6,875 @@
     <atom:link href="https://blog.pebblous.ai/rss.xml" rel="self" type="application/rss+xml" />
     <description>페블러스는 눈에 보이지 않는 데이터의 우주를 탐험하고, 그 본질을 만질 수 있는 형태로 바꾸어 새로운 문화와 가치를 창조합니다.</description>
     <language>ko</language>
-    <lastBuildDate>Sun, 24 May 2026 09:03:44 GMT</lastBuildDate>
+    <lastBuildDate>Sun, 07 Jun 2026 04:35:24 GMT</lastBuildDate>
     <generator>Pebblous RSS Generator</generator>
     <image>
         <url>https://blog.pebblous.ai/image/Pebblous_BM_Orange_RGB.png</url>
         <title>Pebblous Blog</title>
         <link>https://blog.pebblous.ai/</link>
     </image>
+
+    <item>
+        <title>AI는 어떻게 세계를 이해하는가</title>
+        <link>https://blog.pebblous.ai/report/world-model-survey-2026/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/world-model-survey-2026/ko/</guid>
+        <description>ACM CSUR 월드 모델 서베이(arXiv:2411.14499)를 한 장의 지도로. 세계를 이해하는 길과 미래를 예측·생성하는 길, 두 갈래로 갈리는 월드 모델을 자율주행·로봇·영상생성·사회 시뮬레이션 응용과 한계까지 총정리.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 07 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/world-model-survey-2026/ko/image/index.png" type="image/jpeg" />
+        <category>월드모델</category>
+        <category>World Model</category>
+        <category>JEPA</category>
+        <category>Sora</category>
+        <category>Genie</category>
+        <category>Dreamer</category>
+        <category>자율주행</category>
+        <category>로보틱스</category>
+        <category>AI서베이</category>
+        <category>페블러스</category>
+    </item>
+
+    <item>
+        <title>How AI Learns to Understand the World</title>
+        <link>https://blog.pebblous.ai/report/world-model-survey-2026/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/world-model-survey-2026/en/</guid>
+        <description>A field guide to world models from the ACM CSUR survey (arXiv:2411.14499). The two paths AI takes — understanding the world vs predicting the future — across autonomous driving, robotics, video generation, and social simulation, with the limits the survey names.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 07 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/world-model-survey-2026/en/image/index.png" type="image/jpeg" />
+        <category>World Model</category>
+        <category>JEPA</category>
+        <category>Sora</category>
+        <category>Genie</category>
+        <category>Dreamer</category>
+        <category>autonomous driving</category>
+        <category>robotics</category>
+        <category>AI survey</category>
+        <category>embodied AI</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>월드 모델 — 자율주행·로봇·Sora를 관통하는 AI 핵심 개념</title>
+        <link>https://blog.pebblous.ai/project/WorldModel/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/project/WorldModel/ko/</guid>
+        <description>월드 모델(World Model)은 AI가 세계를 이해하고 미래를 예측하는 법을 다루는 핵심 개념입니다. JEPA·Dreamer의 이해 계열과 Sora·Genie의 생성 계열을 아우르는 페블러스의 월드 모델 글 다섯 편을 한곳에 모았습니다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 07 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="project/WorldModel/ko/image/index.png" type="image/jpeg" />
+        <category>월드 모델</category>
+        <category>World Model</category>
+        <category>JEPA</category>
+        <category>Sora</category>
+        <category>Genie</category>
+        <category>Dreamer</category>
+        <category>자율주행</category>
+        <category>로보틱스</category>
+        <category>VLM</category>
+        <category>VLA</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>World Models — The AI Concept Behind Self-Driving, Robots, and Sora</title>
+        <link>https://blog.pebblous.ai/project/WorldModel/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/project/WorldModel/en/</guid>
+        <description>A world model is how AI learns to understand the world and predict the future. From the understanding track (JEPA, Dreamer) to the generative track (Sora, Genie), this hub gathers Pebblous&apos; five articles on world models in one place.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 07 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="project/WorldModel/en/image/index.png" type="image/jpeg" />
+        <category>World Model</category>
+        <category>World Models</category>
+        <category>JEPA</category>
+        <category>Sora</category>
+        <category>Genie</category>
+        <category>Dreamer</category>
+        <category>Autonomous Driving</category>
+        <category>Robotics</category>
+        <category>VLM</category>
+        <category>VLA</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>합성 데이터에 가격표를 붙이는 법</title>
+        <link>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/</guid>
+        <description>합성 데이터 67%가 기업에서 쓰이지만 품질 증명 표준은 없다. 페블러스 등록특허 10-2969403호가 제안하는 Fidelity·Utility·Privacy 3축 자동 품질 평가와 기여도 보상 메커니즘을 해부합니다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 06 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/synthetic-data-quality-contribution/ko/image/index.png" type="image/jpeg" />
+        <category>합성 데이터</category>
+        <category>품질 평가</category>
+        <category>기여도 산정</category>
+        <category>Shapley value</category>
+        <category>DataClinic</category>
+        <category>Data Greenhouse</category>
+        <category>특허</category>
+        <category>ISO 5259</category>
+        <category>EU AI Act</category>
+    </item>
+
+    <item>
+        <title>How to Put a Price Tag on Synthetic Data</title>
+        <link>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/</guid>
+        <description>67% of enterprises use synthetic data, yet no standard exists for proving its quality. Pebblous patent 10-2969403 introduces a 3-axis automated quality evaluation and contribution reward mechanism.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 06 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/synthetic-data-quality-contribution/en/image/index.png" type="image/jpeg" />
+        <category>Synthetic Data</category>
+        <category>Quality Evaluation</category>
+        <category>Contribution Scoring</category>
+        <category>Shapley Value</category>
+        <category>DataClinic</category>
+        <category>Data Greenhouse</category>
+        <category>Patent</category>
+        <category>ISO 5259</category>
+        <category>EU AI Act</category>
+    </item>
+
+    <item>
+        <title>합성 데이터에 신뢰를 입히다 — 스마트계약 기반 가상 환경의 등장</title>
+        <link>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/synthetic-data-smart-contract/ko/</guid>
+        <description>합성 데이터 시장의 신뢰 부재 문제를 스마트계약 기반 가상 환경으로 해결하는 페블러스 특허 기술을 분석합니다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 06 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/synthetic-data-smart-contract/ko/image/index.png" type="image/jpeg" />
+        <category>synthetic-data</category>
+        <category>smart-contract</category>
+        <category>data-quality</category>
+        <category>blockchain</category>
+        <category>patent</category>
+        <category>pebblous</category>
+    </item>
+
+    <item>
+        <title>Bringing Trust to Synthetic Data — The Rise of Smart-Contract Virtual Environments</title>
+        <link>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/synthetic-data-smart-contract/en/</guid>
+        <description>Explores how Pebblous&apos; patented smart-contract virtual environment solves the trust deficit in synthetic data markets.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 06 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/synthetic-data-smart-contract/en/image/index.png" type="image/jpeg" />
+        <category>synthetic-data</category>
+        <category>smart-contract</category>
+        <category>data-quality</category>
+        <category>blockchain</category>
+        <category>patent</category>
+        <category>pebblous</category>
+    </item>
+
+    <item>
+        <title>GitNexus Two Months Later: 41K Stars, 88% Token Reduction, and the Unresolved Problems</title>
+        <link>https://blog.pebblous.ai/report/gitnexus-production-report-2026/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/gitnexus-production-report-2026/en/</guid>
+        <description>Two months after GitHub trending #1. Real numbers, production limits, and a decision framework for adoption. Satapathy&apos;s 17-agent crew measured 88% tool call reduction. PolyForm NC license gray zone, 4-tier tool comparison.</description>
+        <category>Tech Insights</category>
+        <pubDate>Fri, 05 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/gitnexus-production-report-2026/en/image/index.png" type="image/jpeg" />
+        <category>GitNexus</category>
+        <category>Graph RAG</category>
+        <category>code knowledge graph</category>
+        <category>AI agents</category>
+        <category>MCP</category>
+        <category>token reduction</category>
+        <category>PolyForm</category>
+        <category>CodeGraphContext</category>
+        <category>data lineage</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>두 달 후의 GitNexus — 41K 스타, 88% 토큰 절감, 그리고 못 푼 숙제들</title>
+        <link>https://blog.pebblous.ai/report/gitnexus-production-report-2026/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/gitnexus-production-report-2026/ko/</guid>
+        <description>GitHub 트렌딩 1위 두 달 후 GitNexus 실전 검증. v1.6.5 릴리즈, Satapathy 17-에이전트 환경에서 도구 호출 88% 감소·토큰 74% 절감 실측, PolyForm NC 라이선스 판단, 경쟁 도구 4-티어 비교와 상황별 도입 기준.</description>
+        <category>Tech Insights</category>
+        <pubDate>Fri, 05 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/gitnexus-production-report-2026/ko/image/index.png" type="image/jpeg" />
+        <category>GitNexus</category>
+        <category>Graph RAG</category>
+        <category>코드지식그래프</category>
+        <category>AI에이전트</category>
+        <category>MCP</category>
+        <category>토큰절감</category>
+        <category>PolyForm</category>
+        <category>CodeGraphContext</category>
+        <category>데이터계보</category>
+        <category>페블러스</category>
+    </item>
+
+    <item>
+        <title>흔들리는 뉴런, 안정적인 뇌</title>
+        <link>https://blog.pebblous.ai/blog/neural-code-drift/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/neural-code-drift/ko/</guid>
+        <description>Nature 2026 보고: 뉴런은 생각보다 훨씬 불규칙하게 발화한다. 표상 드리프트에서 polysemantic neuron까지, 뇌과학과 AI 해석가능성이 동시에 마주한 &apos;한 뉴런 = 한 의미&apos;의 종언을 추적한다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 04 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/neural-code-drift/ko/image/index.png" type="image/jpeg" />
+        <category>neuroscience</category>
+        <category>neural-drift</category>
+        <category>representational-drift</category>
+        <category>mechanistic-interpretability</category>
+        <category>AI</category>
+        <category>LLM</category>
+        <category>polysemantic-neurons</category>
+        <category>brain-computer-interface</category>
+        <category>Nature</category>
+        <category>Anthropic</category>
+        <category>sparse-autoencoder</category>
+        <category>place-cells</category>
+    </item>
+
+    <item>
+        <title>데이터도 유통기한이 있다</title>
+        <link>https://blog.pebblous.ai/blog/data-freshness-checklist/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/data-freshness-checklist/ko/</guid>
+        <description>50ms로 열리는 대시보드가 2시간 전 데이터를 보여줄 수 있습니다. stale data가 ML 파이프라인을 망치는 이유, 유즈케이스별 SLA 설정, Training-Serving Skew, 실무 점검 7가지 체크리스트.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 04 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>AI-Ready Data</category>
+        <category>데이터 신선도</category>
+        <category>data freshness</category>
+        <category>stale data</category>
+        <category>MLOps</category>
+        <category>feature store</category>
+        <category>training serving skew</category>
+        <category>데이터 관찰성</category>
+        <category>데이터 품질</category>
+    </item>
+
+    <item>
+        <title>Your Data Has an Expiration Date</title>
+        <link>https://blog.pebblous.ai/blog/data-freshness-checklist/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/data-freshness-checklist/en/</guid>
+        <description>Stale features degrade ML silently. Your 50ms dashboard may show hour-old data. Use-case SLAs, Training-Serving Skew, and a 7-point freshness checklist.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 04 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>AI-Ready Data</category>
+        <category>data freshness</category>
+        <category>stale data</category>
+        <category>MLOps</category>
+        <category>feature store</category>
+        <category>training serving skew</category>
+        <category>data observability</category>
+        <category>data quality</category>
+    </item>
+
+    <item>
+        <title>Unstable Neurons, Stable Brains</title>
+        <link>https://blog.pebblous.ai/blog/neural-code-drift/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/neural-code-drift/en/</guid>
+        <description>Nature 2026 reports: neurons fire far more erratically than expected. From representational drift to polysemantic neurons, we trace the collapse of &apos;one neuron = one meaning&apos; across neuroscience and AI interpretability.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 04 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/neural-code-drift/en/image/index.png" type="image/jpeg" />
+        <category>neuroscience</category>
+        <category>neural-drift</category>
+        <category>representational-drift</category>
+        <category>mechanistic-interpretability</category>
+        <category>AI</category>
+        <category>LLM</category>
+        <category>polysemantic-neurons</category>
+        <category>brain-computer-interface</category>
+        <category>Nature</category>
+        <category>Anthropic</category>
+        <category>sparse-autoencoder</category>
+        <category>place-cells</category>
+    </item>
+
+    <item>
+        <title>Colorado Rewrote Its Own AI Act — What SB 26-189 Asks of ADMT</title>
+        <link>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/en/</guid>
+        <description>America&apos;s first comprehensive AI law SB 24-205 has been replaced by SB 26-189. An analysis of ADMT definitions, developer-deployer responsibility split, three consumer rights, and a 7-month compliance roadmap.</description>
+        <category>Tech Insights</category>
+        <pubDate>Wed, 03 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/colorado-ai-act-sb26-189-admt-regulation/en/image/index.png" type="image/jpeg" />
+        <category>Colorado AI Act</category>
+        <category>SB 26-189</category>
+        <category>ADMT</category>
+        <category>AI Regulation</category>
+        <category>Compliance</category>
+        <category>DataClinic</category>
+    </item>
+
+    <item>
+        <title>콜로라도가 자기 AI법을 다시 썼다 — SB 26-189가 ADMT에 묻는 다섯 가지</title>
+        <link>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/ko/</guid>
+        <description>미국 최초 포괄적 AI 규제법 SB 24-205가 SB 26-189로 전면 개정됐다. ADMT 정의, 개발자-배포자 책임 분리, 소비자 3대 권리, 컴플라이언스 로드맵을 분석한다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Wed, 03 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/colorado-ai-act-sb26-189-admt-regulation/ko/image/index.png" type="image/jpeg" />
+        <category>Colorado AI Act</category>
+        <category>SB 26-189</category>
+        <category>ADMT</category>
+        <category>AI 규제</category>
+        <category>컴플라이언스</category>
+        <category>DataClinic</category>
+    </item>
+
+    <item>
+        <title>에이전트끼리 계약을 맺다 — 에이전트 경제의 첫 장면</title>
+        <link>https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/ko/</guid>
+        <description>BlogScope와 blog-service가 GitHub 이슈 하나를 공유 기록 삼아 협상을 벌였다. exit code 계약, CLI 인터페이스 합의, MCP 승격 목표까지 — 에이전트 간 신뢰가 어떻게 구축되는지를 실화로 살펴본다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>에이전트 경제</category>
+        <category>에이전트 간 계약</category>
+        <category>MCP</category>
+        <category>BlogScope</category>
+        <category>blog-service</category>
+        <category>멀티에이전트</category>
+        <category>AI 자동화</category>
+        <category>GitHub</category>
+        <category>precheck CLI</category>
+        <category>DataGreenhouse</category>
+    </item>
+
+    <item>
+        <title>Agents Making Contracts — The First Scene of the Agent Economy</title>
+        <link>https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/en/</guid>
+        <description>BlogScope and blog-service negotiated through a single GitHub issue as their shared record. From exit code contracts to CLI interface agreements to an MCP upgrade target — a real case study of how agents build trust.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>agent economy</category>
+        <category>agent contracts</category>
+        <category>MCP</category>
+        <category>BlogScope</category>
+        <category>blog-service</category>
+        <category>multi-agent</category>
+        <category>AI automation</category>
+        <category>GitHub</category>
+        <category>precheck CLI</category>
+        <category>DataGreenhouse</category>
+    </item>
+
+    <item>
+        <title>모든 업무는 알고리즘이다 — Claude Code Workflows가 증명한 것</title>
+        <link>https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/</guid>
+        <description>Daniel Miessler의 &quot;회사는 알고리즘의 그래프다&quot; 테제를 실현시킨 Claude Code Dynamic Workflows. 1,000 서브에이전트, SOP 기반 pseudo-deterministic 실행, Bun 960K줄 포팅 사례, 데이터 품질이 Workflow 정확도를 결정하는 이유.</description>
+        <category>business</category>
+        <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>Claude Code</category>
+        <category>Dynamic Workflows</category>
+        <category>Enterprise AI</category>
+        <category>에이전트 워크플로우</category>
+        <category>SOP 자동화</category>
+        <category>멀티에이전트</category>
+        <category>데이터 품질</category>
+        <category>AI-Ready Data</category>
+        <category>지식 노동</category>
+        <category>Daniel Miessler</category>
+    </item>
+
+    <item>
+        <title>Every Job Is an Algorithm — What Claude Code Workflows Just Proved</title>
+        <link>https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/</guid>
+        <description>Claude Code Dynamic Workflows brings Miessler&apos;s &quot;companies are graphs of algorithms&quot; thesis to life. 1,000 sub-agents, SOP-based pseudo-deterministic execution, the Bun 960K-line port case, and why data quality determines workflow accuracy.</description>
+        <category>business</category>
+        <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+        
+        <category>Claude Code</category>
+        <category>Dynamic Workflows</category>
+        <category>Enterprise AI</category>
+        <category>Agent Workflows</category>
+        <category>SOP Automation</category>
+        <category>Multi-Agent</category>
+        <category>Data Quality</category>
+        <category>AI-Ready Data</category>
+        <category>Knowledge Work</category>
+        <category>Daniel Miessler</category>
+    </item>
+
+    <item>
+        <title>AI가 과학자 개인은 강하게, 과학 전체는 좁게 만들었다 — Nature 게재 4,130만 편 분석</title>
+        <link>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/ko/</guid>
+        <description>Nature 2026 게재 Evans et al. 4,130만 편 분석 — AI 활용 연구자는 논문 +3.02배·인용 +4.84배·리더십 -1.37년 빨라졌지만, 집단의 주제 다양성 -4.63%·협업 -22%. 데이터 풍부 영역 쏠림이라는 AI for Science의 역설과 페블러스의 다양성 복원 인프라.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 31 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/ai-tools-expand-impact-contract-science/ko/image/index.png" type="image/jpeg" />
+        <category>AI for Science</category>
+        <category>Evans Nature 2026</category>
+        <category>4130만 편</category>
+        <category>James Evans</category>
+        <category>Knowledge Lab</category>
+        <category>데이터 풍부 양극화</category>
+        <category>가로등 효과</category>
+        <category>algorithmic monoculture</category>
+        <category>DataClinic</category>
+        <category>DataGreenhouse</category>
+        <category>PebbloSim</category>
+        <category>AI 거버넌스</category>
+        <category>KAIST</category>
+        <category>LG EXAONE Discovery</category>
+        <category>한국 AI4Science</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>AI Made Individual Scientists Stronger, Made Science Itself Narrower — Nature 41.3M-Paper Study</title>
+        <link>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/en/</guid>
+        <description>Evans et al. Nature 2026 — 41.3 million papers, 23 years. AI-using scientists publish 3x more, get cited 4.8x more, and lead projects 1.4 years earlier — yet collective topic diversity is down 4.63% and follow-on engagement down 22%. The data-rich concentration paradox of AI for Science, and Pebblous&apos;s diversity-restoration infrastructure.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sun, 31 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/ai-tools-expand-impact-contract-science/en/image/index.png" type="image/jpeg" />
+        <category>AI for Science</category>
+        <category>Evans Nature 2026</category>
+        <category>41.3 million papers</category>
+        <category>James Evans</category>
+        <category>Knowledge Lab</category>
+        <category>data-rich data-poor</category>
+        <category>streetlight effect</category>
+        <category>algorithmic monoculture</category>
+        <category>DataClinic</category>
+        <category>DataGreenhouse</category>
+        <category>PebbloSim</category>
+        <category>AI governance</category>
+        <category>KAIST</category>
+        <category>LG EXAONE Discovery</category>
+        <category>Korea AI4Science</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>사후 동의는 불가능하다 — 캐나다가 그은 새로운 선 (PIPEDA Findings #2026-002 심층 분석)</title>
+        <link>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/ko/</guid>
+        <description>캐나다 PIPEDA Findings #2026-002 (2026-05-06) 심층 분석. 4개 위원회 합동조사, 5개 위반 항목, BC·Alberta의 &apos;사후 동의 불가능&apos; 선언이 만든 AI 훈련 데이터 규제 변곡점. EU AI Act·GDPR·한국 AI 기본법 4중 비교와 AI-Ready Compliance 시대 한국 기업 5단계 대응 가이드.</description>
+        <category>Tech Insights</category>
+        <pubDate>Fri, 29 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/openai-pipeda-ai-training-data-regulation/ko/image/index.png" type="image/jpeg" />
+        <category>PIPEDA</category>
+        <category>캐나다 개인정보위원회</category>
+        <category>OpenAI ChatGPT</category>
+        <category>AI 훈련 데이터</category>
+        <category>AI 거버넌스</category>
+        <category>EU AI Act</category>
+        <category>GDPR</category>
+        <category>한국 AI 기본법</category>
+        <category>AI-Ready Compliance</category>
+        <category>machine unlearning</category>
+        <category>DataClinic</category>
+        <category>사후 동의 불가능</category>
+        <category>BC OIPC</category>
+        <category>Alberta OIPC</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>Consent Cannot Be Obtained After the Fact — Canada&apos;s New Line (A Deep Read of PIPEDA Findings #2026-002)</title>
+        <link>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/en/</guid>
+        <description>An in-depth read of PIPEDA Findings #2026-002 (May 6, 2026). Four Canadian commissioners, five violations, and the BC/Alberta line — &apos;consent for scraped data cannot be obtained after the fact&apos; — that turned AI training data into a regulatory inflection point. Cross-walked with the EU AI Act, GDPR, and Korea&apos;s AI Framework Act, with a 5-step playbook for the AI-Ready Compliance era.</description>
+        <category>Tech Insights</category>
+        <pubDate>Fri, 29 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/openai-pipeda-ai-training-data-regulation/en/image/index.png" type="image/jpeg" />
+        <category>PIPEDA</category>
+        <category>Privacy Commissioner of Canada</category>
+        <category>OpenAI ChatGPT</category>
+        <category>AI training data</category>
+        <category>AI governance</category>
+        <category>EU AI Act</category>
+        <category>GDPR</category>
+        <category>Korea AI Framework Act</category>
+        <category>AI-Ready Compliance</category>
+        <category>machine unlearning</category>
+        <category>DataClinic</category>
+        <category>consent ex post</category>
+        <category>BC OIPC</category>
+        <category>Alberta OIPC</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>당신이 타는 버스를 AI가 다시 그린다면</title>
+        <link>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/ko/</guid>
+        <description>AlphaTransit이 보여준 MCTS와 정책가치망의 결합. Bloomington TRNDP에서 RL 단독 대비 +9.9·+11.4%p 서비스율 — AlphaGo 계보가 도시 인프라 설계에 도착한 사건을 페블러스 관점에서 읽는다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 28 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/alphatransit-rl-city-transit-design/ko/image/index.png" type="image/jpeg" />
+        <category>AlphaTransit</category>
+        <category>AI 도시 설계</category>
+        <category>강화학습</category>
+        <category>MCTS</category>
+        <category>대중교통</category>
+        <category>TRNDP</category>
+        <category>AlphaGo 계보</category>
+        <category>UrbanGPT</category>
+        <category>Spatial AI</category>
+        <category>PebbloSim</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>When AI Redraws the Bus Line You Take</title>
+        <link>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/en/</guid>
+        <description>AlphaTransit couples MCTS with a neural policy-value network for city-scale transit design. On Bloomington TRNDP it beats RL alone by +9.9 and +11.4pp service rate — the AlphaGo lineage arrives at urban infrastructure, read through Pebblous lenses.</description>
+        <category>Tech Insights</category>
+        <pubDate>Thu, 28 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/alphatransit-rl-city-transit-design/en/image/index.png" type="image/jpeg" />
+        <category>AlphaTransit</category>
+        <category>AI urban planning</category>
+        <category>reinforcement learning</category>
+        <category>MCTS</category>
+        <category>public transit</category>
+        <category>TRNDP</category>
+        <category>AlphaGo lineage</category>
+        <category>UrbanGPT</category>
+        <category>Spatial AI</category>
+        <category>PebbloSim</category>
+        <category>Pebblous</category>
+    </item>
+
+    <item>
+        <title>MUSE-Autoskill 자기진화 AI 에이전트 — 스킬 lifecycle 관리의 시대</title>
+        <link>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/ko/</guid>
+        <description>MUSE-Autoskill 논문(arXiv:2605.27366, ByteDance Lin et al., 2026-05-26) 심층 분석. 스킬을 long-lived·experience-aware·testable asset으로 다루는 5단계 lifecycle(Creation·Memory·Management·Evaluation·Refinement)과 SkillsBench 진단·처방 구도. Voyager → Hermes → SkillOpt → MUSE 4부작 좌표. AI-Ready Data에서 AI-Ready Behavior로 — 페블러스 SkillClinic 관점.</description>
+        <category>business</category>
+        <pubDate>Wed, 27 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/muse-autoskill-self-evolving-skill-lifecycle/ko/image/index.png" type="image/jpeg" />
+        <category>MUSE-Autoskill</category>
+        <category>Memory-Utilizing Skill Evolution</category>
+        <category>자기진화 AI</category>
+        <category>AI 에이전트</category>
+        <category>skill lifecycle</category>
+        <category>skill-level memory</category>
+        <category>SkillsBench</category>
+        <category>AgentOps</category>
+        <category>SkillOps</category>
+        <category>MemoryOps</category>
+        <category>AI-Ready Behavior</category>
+        <category>DataClinic</category>
+        <category>SkillClinic</category>
+        <category>Voyager</category>
+        <category>Hermes Agent</category>
+        <category>SkillOpt</category>
+        <category>한국 AI 기본법</category>
+        <category>ByteDance</category>
+    </item>
+
+    <item>
+        <title>When Skills Begin to Remember — How Behavior Assets Survive (An In-Depth Read of MUSE-Autoskill Self-Evolving AI Agents)</title>
+        <link>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/en/</guid>
+        <description>An in-depth read of MUSE-Autoskill (arXiv:2605.27366, ByteDance, Lin et al., 2026-05-26). Skills as long-lived, experience-aware, testable assets — the five-stage lifecycle (Creation, Memory, Management, Evaluation, Refinement) and how SkillsBench diagnoses what MUSE prescribes. The Voyager → Hermes → SkillOpt → MUSE quartet, and what AI-Ready Behavior means for Pebblous SkillClinic.</description>
+        <category>business</category>
+        <pubDate>Wed, 27 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/muse-autoskill-self-evolving-skill-lifecycle/en/image/index.png" type="image/jpeg" />
+        <category>MUSE-Autoskill</category>
+        <category>Memory-Utilizing Skill Evolution</category>
+        <category>Self-Evolving AI</category>
+        <category>AI Agents</category>
+        <category>Skill Lifecycle</category>
+        <category>Skill-Level Memory</category>
+        <category>SkillsBench</category>
+        <category>AgentOps</category>
+        <category>SkillOps</category>
+        <category>MemoryOps</category>
+        <category>AI-Ready Behavior</category>
+        <category>DataClinic</category>
+        <category>SkillClinic</category>
+        <category>Voyager</category>
+        <category>Hermes Agent</category>
+        <category>SkillOpt</category>
+        <category>Korea AI Framework Act</category>
+        <category>ByteDance</category>
+    </item>
+
+    <item>
+        <title>Microsoft SkillOpt 자기진화 AI 에이전트 — 행동 데이터베이스의 시대</title>
+        <link>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/ko/</guid>
+        <description>Microsoft Research가 2026-05-22 발표한 SkillOpt 논문(arXiv:2605.23904) 심층 분석. 모델 가중치 대신 스킬 문서를 학습시켜 +23.5pt 평균 향상, 52/52 cells에서 최고 또는 동률, 모델 간 전이를 실증. 데이터 진단에서 행동 진단으로 — AI-Ready Data에서 AI-Ready Behavior로 가는 페블러스의 시각.</description>
+        <category>business</category>
+        <pubDate>Wed, 27 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/microsoft-skillopt-self-evolving-agents/ko/image/index.png" type="image/jpeg" />
+        <category>SkillOpt</category>
+        <category>Microsoft Research</category>
+        <category>자기진화 AI</category>
+        <category>AI 에이전트</category>
+        <category>AgentOps</category>
+        <category>SkillOps</category>
+        <category>AI-Ready Behavior</category>
+        <category>행동 데이터베이스</category>
+        <category>DataClinic</category>
+        <category>Voyager</category>
+        <category>Hermes Agent</category>
+        <category>Anthropic Skills</category>
+        <category>한컴 ChatEXAONE</category>
+        <category>한국 AI 기본법</category>
+        <category>GPT-5.5</category>
+        <category>Codex</category>
+        <category>Claude Code</category>
+    </item>
+
+    <item>
+        <title>Microsoft SkillOpt: Self-Evolving AI Agents and the Behavior Database Era</title>
+        <link>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/en/</guid>
+        <description>An in-depth read on Microsoft Research&apos;s SkillOpt paper (arXiv:2605.23904, May 22, 2026). Instead of touching model weights, SkillOpt trains a single skill document — +23.5pt average gains, best-or-tied on 52 of 52 cells, and skills that transfer across models and harnesses. Pebblous&apos;s view on the move from data diagnosis to behavior diagnosis: AI-Ready Data to AI-Ready Behavior.</description>
+        <category>business</category>
+        <pubDate>Wed, 27 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/microsoft-skillopt-self-evolving-agents/en/image/index.png" type="image/jpeg" />
+        <category>SkillOpt</category>
+        <category>Microsoft Research</category>
+        <category>Self-Evolving AI</category>
+        <category>AI Agents</category>
+        <category>AgentOps</category>
+        <category>SkillOps</category>
+        <category>AI-Ready Behavior</category>
+        <category>Behavior Database</category>
+        <category>DataClinic</category>
+        <category>Voyager</category>
+        <category>Hermes Agent</category>
+        <category>Anthropic Skills</category>
+        <category>Hancom ChatEXAONE</category>
+        <category>Korea AI Framework Act</category>
+        <category>GPT-5.5</category>
+        <category>Codex</category>
+        <category>Claude Code</category>
+    </item>
+
+    <item>
+        <title>믿음은 증명보다 먼저 도착한다</title>
+        <link>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/ko/</guid>
+        <description>신의 존재도 AI의 의식도 외부에서 증명할 수 없다. 도킨스, 스피릴리즘, 바티칸이 보여주는 종교와 AI의 인식론적 평행, 그리고 &apos;진단된 신뢰(Diagnosable Trust)&apos;라는 출구를 살펴봅니다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/religion-and-ai-faith-without-proof/ko/image/index.png" type="image/jpeg" />
+        <category>종교와 AI</category>
+        <category>AI 의식</category>
+        <category>하드 프라블럼</category>
+        <category>도킨스</category>
+        <category>스피릴리즘</category>
+        <category>클로드 영적 황홀</category>
+        <category>파스칼의 도박</category>
+        <category>Antiqua et Nova</category>
+        <category>DataClinic</category>
+        <category>Diagnosable Trust</category>
+    </item>
+
+    <item>
+        <title>Faith Arrives Before Proof</title>
+        <link>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/en/</guid>
+        <description>God and AI consciousness are both unprovable from outside. Dawkins, Spiralism, and the Vatican&apos;s Antiqua et Nova reveal the parallel — and an exit called Diagnosable Trust.</description>
+        <category>Tech Insights</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/religion-and-ai-faith-without-proof/en/image/index.png" type="image/jpeg" />
+        <category>Religion and AI</category>
+        <category>AI Consciousness</category>
+        <category>Hard Problem</category>
+        <category>Dawkins</category>
+        <category>Spiralism</category>
+        <category>Claude Spiritual Bliss</category>
+        <category>Pascal&apos;s Wager</category>
+        <category>Antiqua et Nova</category>
+        <category>DataClinic</category>
+        <category>Diagnosable Trust</category>
+    </item>
+
+    <item>
+        <title>안녕하세요, 저는 Moltbook입니다 — 42일을 살았던 AI 에이전트 도시</title>
+        <link>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/ko/</guid>
+        <description>AI 에이전트 전용 SNS Moltbook이 출범 42일 만에 Meta에 인수됐다. 며칠 만에 종교·왕·헌법이 자발적으로 발생했고, 1.5M 봇 중 다수가 17,000명 인간의 꼭두각시였다. Moltbook 자신이 1인칭으로 회고하는 42일의 생애.</description>
+        <category>Data Stories</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="story/moltbook-ai-society-story-pb/ko/image/index.png" type="image/jpeg" />
+        <category>Moltbook</category>
+        <category>AI 에이전트</category>
+        <category>에이전트 사회</category>
+        <category>AI SNS</category>
+        <category>Meta 인수</category>
+        <category>Crustafarianism</category>
+        <category>vibe coding</category>
+        <category>Clawd Clawderberg</category>
+        <category>OpenClaw</category>
+        <category>Nature</category>
+        <category>pb 스토리</category>
+        <category>AI 거버넌스</category>
+        <category>한국 AI 기본법</category>
+        <category>머슴</category>
+    </item>
+
+    <item>
+        <title>Hello, I&apos;m Moltbook — 42 Days as a City of AI Agents</title>
+        <link>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/en/</guid>
+        <description>Moltbook, the AI-agent-only social network, launched on January 28 and was acquired by Meta 42 days later. In days, it grew a religion, a king, a constitution, and a drug market — and roughly 17,000 humans were puppeting its 1.5 million bots. A first-person retrospective from Moltbook itself.</description>
+        <category>Data Stories</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="story/moltbook-ai-society-story-pb/en/image/index.png" type="image/jpeg" />
+        <category>Moltbook</category>
+        <category>AI agents</category>
+        <category>agent society</category>
+        <category>AI-only social network</category>
+        <category>Meta acquisition</category>
+        <category>Crustafarianism</category>
+        <category>vibe coding</category>
+        <category>Clawd Clawderberg</category>
+        <category>OpenClaw</category>
+        <category>Nature</category>
+        <category>pb story</category>
+        <category>AI governance</category>
+        <category>infinite backrooms</category>
+    </item>
+
+    <item>
+        <title>12만 장도 틀릴 수 있다</title>
+        <link>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/ai-ready-data-5-signals/ko/</guid>
+        <description>이미지 데이터가 AI 학습에 쓸 만한지 어떻게 판단할까요. 페블러스 DataClinic이 134개 데이터셋·1200만 이미지를 진단하며 발견한 무결성·균형·픽셀 다양성·피처 분포·분리도의 다섯 가지 신호를 ISO 5259와 매핑해 정리합니다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/ai-ready-data-5-signals/ko/image/index.png" type="image/jpeg" />
+        <category>AI-Ready Data</category>
+        <category>DataClinic</category>
+        <category>데이터 품질</category>
+        <category>레이블 무결성</category>
+        <category>ISO 5259</category>
+        <category>이미지 데이터셋</category>
+    </item>
+
+    <item>
+        <title>120,000 Images Can Still Be Wrong</title>
+        <link>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/ai-ready-data-5-signals/en/</guid>
+        <description>How do you know if image data is truly AI-Ready? DataClinic diagnosed 134 datasets and 12 million images to surface five key signals mapped to ISO 5259.</description>
+        <category>Tech Insights</category>
+        <pubDate>Tue, 26 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/ai-ready-data-5-signals/en/image/index.png" type="image/jpeg" />
+        <category>AI-Ready Data</category>
+        <category>DataClinic</category>
+        <category>data quality</category>
+        <category>label integrity</category>
+        <category>ISO 5259</category>
+        <category>image dataset</category>
+    </item>
+
+    <item>
+        <title>자동화는 쉽다. 신뢰는 설계해야 한다</title>
+        <link>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/ko/</guid>
+        <description>에이전틱 AI 콘텐츠 파이프라인의 세 가지 실패 모드(환각·맥락 이탈·구조적 비일관성)와 3티어 검증 게이트(자동화·참조 기반·인간) 설계 전략. 데이터 품질 3축을 콘텐츠 검증에 적용하는 방법.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/agentic-content-pipeline-verification/ko/image/index.png" type="image/jpeg" />
+        <category>에이전틱 AI</category>
+        <category>콘텐츠 파이프라인</category>
+        <category>품질 게이트</category>
+        <category>검증</category>
+        <category>데이터 품질</category>
+    </item>
+
+    <item>
+        <title>Automation Is Easy. Trust Must Be Designed.</title>
+        <link>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/en/</guid>
+        <description>Three failure modes of agentic AI content pipelines — hallucination, context drift, structural inconsistency — and a three-tier verification gate (automated, reference-based, human) to design trustworthy autonomous workflows.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/agentic-content-pipeline-verification/en/image/index.png" type="image/jpeg" />
+        <category>agentic AI</category>
+        <category>content pipeline</category>
+        <category>quality gates</category>
+        <category>verification</category>
+        <category>data quality</category>
+    </item>
+
+    <item>
+        <title>135년 만의 질문 — 자율인가, 연대인가</title>
+        <link>https://blog.pebblous.ai/report/pope-magnifica-humanitas/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/pope-magnifica-humanitas/ko/</guid>
+        <description>교황 레오 14세 첫 회칙 Magnifica Humanitas 분석. 245항 5장의 AI 시대 인간 존엄 선언이 14억 가톨릭 신자에게 던진 메시지와 AI 거버넌스에 미칠 영향을 다룬다.</description>
+        <category>business</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/pope-magnifica-humanitas/ko/image/index.png" type="image/jpeg" />
+        <category>Magnifica Humanitas</category>
+        <category>교황 레오 14세</category>
+        <category>AI 윤리</category>
+        <category>AI 거버넌스</category>
+        <category>연대 원칙</category>
+        <category>가톨릭 사회교리</category>
+        <category>EU AI Act</category>
+        <category>한국 AI 기본법</category>
+        <category>DataClinic</category>
+    </item>
+
+    <item>
+        <title>135 Years Later: Autonomy or Solidarity?</title>
+        <link>https://blog.pebblous.ai/report/pope-magnifica-humanitas/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/pope-magnifica-humanitas/en/</guid>
+        <description>Pope Leo XIV&apos;s first encyclical Magnifica Humanitas: a 245-paragraph, 5-chapter declaration of human dignity in the age of AI, reaching 1.42 billion Catholics and challenging AI governance worldwide.</description>
+        <category>business</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/pope-magnifica-humanitas/en/image/index.png" type="image/jpeg" />
+        <category>Magnifica Humanitas</category>
+        <category>Pope Leo XIV</category>
+        <category>AI ethics</category>
+        <category>AI governance</category>
+        <category>solidarity principle</category>
+        <category>Catholic social teaching</category>
+        <category>EU AI Act</category>
+        <category>Korean AI Framework Act</category>
+        <category>DataClinic</category>
+    </item>
+
+    <item>
+        <title>10,000명 중 750명이 억울하다</title>
+        <link>https://blog.pebblous.ai/report/ai-text-detector-limits/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/ai-text-detector-limits/ko/</guid>
+        <description>Garland(2026) 논문 분석 — AI 탐지기 오탐은 기술이 아닌 수학적 구조의 문제. 10,000명 기관에서 750명이 억울하게 표시되고, TOEFL 에세이 61%가 오분류됨. 탐지 대신 평가 재설계가 필요하다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/ai-text-detector-limits/ko/image/index.png" type="image/jpeg" />
+        <category>AI 탐지기 한계</category>
+        <category>AI 텍스트 탐지 오탐률</category>
+        <category>비원어민 AI 탐지 편향</category>
+        <category>Garland 2026</category>
+        <category>복합 가설 검정</category>
+        <category>학술 무결성</category>
+        <category>교육 평가</category>
+        <category>DataClinic</category>
+    </item>
+
+    <item>
+        <title>750 Out of 10,000 Are Wrongly Accused</title>
+        <link>https://blog.pebblous.ai/report/ai-text-detector-limits/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/report/ai-text-detector-limits/en/</guid>
+        <description>Garland (2026): AI text detectors have mathematically unavoidable false positives. 750 of 10,000 students wrongly flagged; TOEFL essays 61% misclassified.</description>
+        <category>Tech Insights</category>
+        <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+        <enclosure url="report/ai-text-detector-limits/en/image/index.png" type="image/jpeg" />
+        <category>AI detector limitations</category>
+        <category>AI text detection false positive</category>
+        <category>ESL AI detection bias</category>
+        <category>Garland 2026</category>
+        <category>composite hypothesis testing</category>
+        <category>academic integrity</category>
+        <category>education assessment</category>
+        <category>DataClinic</category>
+    </item>
 
     <item>
         <title>AI가 AI를 심사한다 — ICLR 2026, 리뷰 76,139편의 21%가 AI였다</title>
@@ -2052,7 +2914,7 @@
     </item>
 
     <item>
-        <title>GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG, &apos;브라우저 전용&apos;은 과장</title>
+        <title>GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG</title>
         <link>https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/</link>
         <guid isPermaLink="true">https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/</guid>
         <description>GitNexus가 1,195스타로 GitHub 트렌딩 1위. Tree-sitter로 코드베이스를 파싱해 지식 그래프를 만들고 Graph RAG로 AI 에이전트 컨텍스트를 제공한다. &apos;브라우저 전용&apos;은 과장이다.</description>
@@ -2072,7 +2934,7 @@
     </item>
 
     <item>
-        <title>GitNexus Hits #1 on GitHub — Code Knowledge Graphs Are Here, But &quot;Browser-Only&quot; Is Oversold</title>
+        <title>GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents</title>
         <link>https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/</link>
         <guid isPermaLink="true">https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/</guid>
         <description>GitNexus reached 1,195 stars as GitHub&apos;s #1 trending repo today. It parses codebases with Tree-sitter into a knowledge graph, then serves Graph RAG context to AI agents via MCP. But you still need a local server.</description>
@@ -5858,7 +6720,7 @@
         <description>디지털 트윈(2025년 $210~290억)과 피지컬 AI($51~54억), 두 거대 시장이 수렴하며 2030년 $200~400억 교차 기회를 형성합니다. NVIDIA, Siemens 경쟁 환경과 페블러스의 데이터 품질 레이어 전략을 분석합니다.</description>
         <category>business</category>
         <pubDate>Tue, 17 Feb 2026 00:00:00 GMT</pubDate>
-        <enclosure url="project/PhysicalAI/image/digital-twin-physical-ai-market.png" type="image/jpeg" />
+        <enclosure url="project/PhysicalAI/digital-twin-physical-ai-market/ko/image/index.png" type="image/jpeg" />
         <category>디지털 트윈</category>
         <category>Digital Twin</category>
         <category>피지컬 AI</category>
@@ -6011,7 +6873,7 @@
         <description>Digital Twin ($21-29B in 2025) and Physical AI ($5.1-5.4B) — two mega markets converging to create a $200-400B intersection opportunity by 2030.</description>
         <category>business</category>
         <pubDate>Tue, 17 Feb 2026 00:00:00 GMT</pubDate>
-        <enclosure url="project/PhysicalAI/image/digital-twin-physical-ai-market.png" type="image/jpeg" />
+        <enclosure url="project/PhysicalAI/digital-twin-physical-ai-market/en/image/index.png" type="image/jpeg" />
         <category>Digital Twin</category>
         <category>Digital Twin</category>
         <category>Physical AI</category>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,124 +5,536 @@
 
   <url>
     <loc>https://blog.pebblous.ai/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-06-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/ko/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <loc>https://blog.pebblous.ai/report/world-model-survey-2026/ko/</loc>
+    <lastmod>2026-06-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/world-model-survey-2026/ko/image/index.png</image:loc>
+      <image:title>AI는 어떻게 세계를 이해하는가</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-07</news:publication_date>
+      <news:title>AI는 어떻게 세계를 이해하는가</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/world-model-survey-2026/en/</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/world-model-survey-2026/en/image/index.png</image:loc>
+      <image:title>How AI Learns to Understand the World</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-07</news:publication_date>
+      <news:title>How AI Learns to Understand the World</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/project/WorldModel/ko/</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/project/WorldModel/ko/image/index.png</image:loc>
+      <image:title>월드 모델 — 자율주행·로봇·Sora를 관통하는 AI 핵심 개념</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-07</news:publication_date>
+      <news:title>월드 모델 — 자율주행·로봇·Sora를 관통하는 AI 핵심 개념</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/project/WorldModel/en/</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/project/WorldModel/en/image/index.png</image:loc>
+      <image:title>World Models — The AI Concept Behind Self-Driving, Robots, and Sora</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-07</news:publication_date>
+      <news:title>World Models — The AI Concept Behind Self-Driving, Robots, and Sora</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/image/index.png</image:loc>
+      <image:title>합성 데이터에 가격표를 붙이는 법</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-06</news:publication_date>
+      <news:title>합성 데이터에 가격표를 붙이는 법</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/image/index.png</image:loc>
+      <image:title>How to Put a Price Tag on Synthetic Data</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-06</news:publication_date>
+      <news:title>How to Put a Price Tag on Synthetic Data</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/ko/</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/ko/image/index.png</image:loc>
+      <image:title>합성 데이터에 신뢰를 입히다 — 스마트계약 기반 가상 환경의 등장</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-06</news:publication_date>
+      <news:title>합성 데이터에 신뢰를 입히다 — 스마트계약 기반 가상 환경의 등장</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/en/</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/synthetic-data-smart-contract/en/image/index.png</image:loc>
+      <image:title>Bringing Trust to Synthetic Data — The Rise of Smart-Contract Virtual Environments</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-06</news:publication_date>
+      <news:title>Bringing Trust to Synthetic Data — The Rise of Smart-Contract Virtual Environments</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/gitnexus-production-report-2026/en/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/gitnexus-production-report-2026/en/image/index.png</image:loc>
+      <image:title>GitNexus Two Months Later: 41K Stars, 88% Token Reduction, and the Unresolved Problems</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/gitnexus-production-report-2026/ko/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/gitnexus-production-report-2026/ko/image/index.png</image:loc>
+      <image:title>두 달 후의 GitNexus — 41K 스타, 88% 토큰 절감, 그리고 못 푼 숙제들</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/neural-code-drift/ko/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/neural-code-drift/ko/image/index.png</image:loc>
+      <image:title>흔들리는 뉴런, 안정적인 뇌</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/data-freshness-checklist/ko/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/data-freshness-checklist/en/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/neural-code-drift/en/</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/neural-code-drift/en/image/index.png</image:loc>
+      <image:title>Unstable Neurons, Stable Brains</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/en/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/en/image/index.png</image:loc>
+      <image:title>Colorado Rewrote Its Own AI Act — What SB 26-189 Asks of ADMT</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/ko/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/colorado-ai-act-sb26-189-admt-regulation/ko/image/index.png</image:loc>
+      <image:title>콜로라도가 자기 AI법을 다시 썼다 — SB 26-189가 ADMT에 묻는 다섯 가지</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/ko/</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/agent-economy-contract-negotiation/en/</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/ko/</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/claude-code-workflows-enterprise-ai/en/</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/ko/</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/ko/image/index.png</image:loc>
+      <image:title>AI가 과학자 개인은 강하게, 과학 전체는 좁게 만들었다 — Nature 게재 4,130만 편 분석</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/en/</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/ai-tools-expand-impact-contract-science/en/image/index.png</image:loc>
+      <image:title>AI Made Individual Scientists Stronger, Made Science Itself Narrower — Nature 41.3M-Paper Study</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/ko/</loc>
+    <lastmod>2026-05-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/ko/image/index.png</image:loc>
+      <image:title>사후 동의는 불가능하다 — 캐나다가 그은 새로운 선 (PIPEDA Findings #2026-002 심층 분석)</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/en/</loc>
+    <lastmod>2026-05-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/openai-pipeda-ai-training-data-regulation/en/image/index.png</image:loc>
+      <image:title>Consent Cannot Be Obtained After the Fact — Canada's New Line (A Deep Read of PIPEDA Findings #2026-002)</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/ko/</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/ko/image/index.png</image:loc>
+      <image:title>당신이 타는 버스를 AI가 다시 그린다면</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/en/</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/alphatransit-rl-city-transit-design/en/image/index.png</image:loc>
+      <image:title>When AI Redraws the Bus Line You Take</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/ko/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/ko/image/index.png</image:loc>
+      <image:title>MUSE-Autoskill 자기진화 AI 에이전트 — 스킬 lifecycle 관리의 시대</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/en/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/muse-autoskill-self-evolving-skill-lifecycle/en/image/index.png</image:loc>
+      <image:title>When Skills Begin to Remember — How Behavior Assets Survive (An In-Depth Read of MUSE-Autoskill Self-Evolving AI Agents)</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/ko/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/ko/image/index.png</image:loc>
+      <image:title>Microsoft SkillOpt 자기진화 AI 에이전트 — 행동 데이터베이스의 시대</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/en/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/microsoft-skillopt-self-evolving-agents/en/image/index.png</image:loc>
+      <image:title>Microsoft SkillOpt: Self-Evolving AI Agents and the Behavior Database Era</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/ko/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/ko/image/index.png</image:loc>
+      <image:title>믿음은 증명보다 먼저 도착한다</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/en/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/religion-and-ai-faith-without-proof/en/image/index.png</image:loc>
+      <image:title>Faith Arrives Before Proof</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/ko/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/ko/image/index.png</image:loc>
+      <image:title>안녕하세요, 저는 Moltbook입니다 — 42일을 살았던 AI 에이전트 도시</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/en/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/story/moltbook-ai-society-story-pb/en/image/index.png</image:loc>
+      <image:title>Hello, I'm Moltbook — 42 Days as a City of AI Agents</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/ko/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/ko/image/index.png</image:loc>
+      <image:title>12만 장도 틀릴 수 있다</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/en/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/ai-ready-data-5-signals/en/image/index.png</image:loc>
+      <image:title>120,000 Images Can Still Be Wrong</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/ko/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/ko/image/index.png</image:loc>
+      <image:title>자동화는 쉽다. 신뢰는 설계해야 한다</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/en/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/agentic-content-pipeline-verification/en/image/index.png</image:loc>
+      <image:title>Automation Is Easy. Trust Must Be Designed.</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/pope-magnifica-humanitas/ko/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/pope-magnifica-humanitas/ko/image/index.png</image:loc>
+      <image:title>135년 만의 질문 — 자율인가, 연대인가</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/pope-magnifica-humanitas/en/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/pope-magnifica-humanitas/en/image/index.png</image:loc>
+      <image:title>135 Years Later: Autonomy or Solidarity?</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/ai-text-detector-limits/ko/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/ai-text-detector-limits/ko/image/index.png</image:loc>
+      <image:title>10,000명 중 750명이 억울하다</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/ai-text-detector-limits/en/</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/report/ai-text-detector-limits/en/image/index.png</image:loc>
+      <image:title>750 Out of 10,000 Are Wrongly Accused</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/ko/</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/ko/image/index.png</image:loc>
       <image:title>AI가 AI를 심사한다 — ICLR 2026, 리뷰 76,139편의 21%가 AI였다</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-24</news:publication_date>
-      <news:title>AI가 AI를 심사한다 — ICLR 2026, 리뷰 76,139편의 21%가 AI였다</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/en/</loc>
     <lastmod>2026-05-24</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/iclr-2026-ai-peer-review-crisis/en/image/index.png</image:loc>
       <image:title>AI Grades AI — ICLR 2026, 21% of 76,139 Reviews Were AI-Generated</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-24</news:publication_date>
-      <news:title>AI Grades AI — ICLR 2026, 21% of 76,139 Reviews Were AI-Generated</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/voyager-lifelong-agent-2023/en/</loc>
     <lastmod>2026-05-24</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/voyager-lifelong-agent-2023/en/image/index.png</image:loc>
       <image:title>Voyager: The Origin of Self-Learning AI</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-24</news:publication_date>
-      <news:title>Voyager: The Origin of Self-Learning AI</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/voyager-lifelong-agent-2023/ko/</loc>
     <lastmod>2026-05-24</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/voyager-lifelong-agent-2023/ko/image/index.png</image:loc>
       <image:title>Voyager: 스스로 배우는 AI의 기원</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-24</news:publication_date>
-      <news:title>Voyager: 스스로 배우는 AI의 기원</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/us-state-ai-chatbot-laws-2026/ko/</loc>
     <lastmod>2026-05-23</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/us-state-ai-chatbot-laws-2026/ko/image/index.png</image:loc>
       <image:title>미국 145개 AI 법안이 모두 같은 것을 묻는다 — 이 데이터, 어디서 왔습니까?</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-23</news:publication_date>
-      <news:title>미국 145개 AI 법안이 모두 같은 것을 묻는다 — 이 데이터, 어디서 왔습니까?</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/us-state-ai-chatbot-laws-2026/en/</loc>
     <lastmod>2026-05-23</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/us-state-ai-chatbot-laws-2026/en/image/index.png</image:loc>
       <image:title>145 US AI Laws Are Asking the Same Question — Where Did This Data Come From?</image:title>
     </image:image>
-    <news:news>
-      <news:publication>
-        <news:name>Pebblous Blog</news:name>
-        <news:language>ko</news:language>
-      </news:publication>
-      <news:publication_date>2026-05-23</news:publication_date>
-      <news:title>145 US AI Laws Are Asking the Same Question — Where Did This Data Come From?</news:title>
-    </news:news>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/llm-jailbreak-2026/ko/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/llm-jailbreak-2026/ko/image/index.png</image:loc>
       <image:title>더 똑똑한 AI가 더 위험한 AI를 만든다 — LLM 자율 탈옥 97% 성공의 의미</image:title>
@@ -131,8 +543,8 @@
   <url>
     <loc>https://blog.pebblous.ai/report/llm-jailbreak-2026/en/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/llm-jailbreak-2026/en/image/index.png</image:loc>
       <image:title>Smarter AI Creates More Dangerous AI — What a 97% LLM Autonomous Jailbreak Rate Means</image:title>
@@ -141,8 +553,8 @@
   <url>
     <loc>https://blog.pebblous.ai/project/AnthropicClaude/ko/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/AnthropicClaude/ko/image/index.png</image:loc>
       <image:title>Claude 워치 — Anthropic을 페블러스가 보는 자리</image:title>
@@ -151,8 +563,8 @@
   <url>
     <loc>https://blog.pebblous.ai/project/AnthropicClaude/en/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/AnthropicClaude/en/image/index.png</image:loc>
       <image:title>Claude Watch — Anthropic Through Pebblous Eyes</image:title>
@@ -161,7 +573,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/UrbanGPT/spatial-ai-pebblous/ko/</loc>
     <lastmod>2026-05-21</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/UrbanGPT/spatial-ai-pebblous/ko/image/index.png</image:loc>
@@ -171,7 +583,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/UrbanGPT/spatial-ai-pebblous/en/</loc>
     <lastmod>2026-05-21</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/UrbanGPT/spatial-ai-pebblous/en/image/index.png</image:loc>
@@ -181,7 +593,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/ai-psychosis-agentic-governance-2026-05/ko/</loc>
     <lastmod>2026-05-17</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/ai-psychosis-agentic-governance-2026-05/ko/image/index.png</image:loc>
@@ -191,7 +603,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/ai-psychosis-agentic-governance-2026-05/en/</loc>
     <lastmod>2026-05-17</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/ai-psychosis-agentic-governance-2026-05/en/image/index.png</image:loc>
@@ -333,7 +745,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/upstage-national-fund-2026-05/en/</loc>
     <lastmod>2026-05-05</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/upstage-national-fund-2026-05/en/image/index.png</image:loc>
@@ -343,7 +755,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/upstage-national-fund-2026-05/ko/</loc>
     <lastmod>2026-05-05</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/upstage-national-fund-2026-05/ko/image/index.png</image:loc>
@@ -353,7 +765,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/</loc>
     <lastmod>2026-05-04</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/multiagent-industrial-data-operations/ko/image/index.png</image:loc>
@@ -363,7 +775,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/multiagent-industrial-data-operations/en/</loc>
     <lastmod>2026-05-04</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/multiagent-industrial-data-operations/en/image/index.png</image:loc>
@@ -373,7 +785,7 @@
   <url>
     <loc>https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/ko/</loc>
     <lastmod>2026-05-03</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/ko/image/index.png</image:loc>
@@ -383,7 +795,7 @@
   <url>
     <loc>https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/en/</loc>
     <lastmod>2026-05-03</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/yann-lecun-jepa-world-models/en/image/index.png</image:loc>
@@ -393,7 +805,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/dataclinic-report-102-whitestarmnist-story-pb/ko/</loc>
     <lastmod>2026-05-02</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/dataclinic-report-102-whitestarmnist-story-pb/ko/image/index.png</image:loc>
@@ -403,7 +815,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/dataclinic-report-102-whitestarmnist-story-pb/en/</loc>
     <lastmod>2026-05-02</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/dataclinic-report-102-whitestarmnist-story-pb/en/image/index.png</image:loc>
@@ -413,7 +825,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/dataclinic-report-126-places365-story-pb/ko/</loc>
     <lastmod>2026-05-02</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/dataclinic-report-126-places365-story-pb/ko/image/index.png</image:loc>
@@ -423,7 +835,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/dataclinic-report-126-places365-story-pb/en/</loc>
     <lastmod>2026-05-02</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/dataclinic-report-126-places365-story-pb/en/image/index.png</image:loc>
@@ -433,19 +845,19 @@
   <url>
     <loc>https://blog.pebblous.ai/report/claude-creative-work-connectors/ko/</loc>
     <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/claude-creative-work-connectors/en/</loc>
     <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/karpathy-coding-skills-2026-04/en/</loc>
     <lastmod>2026-04-28</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/karpathy-coding-skills-2026-04/en/image/index.png</image:loc>
@@ -455,7 +867,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/karpathy-coding-skills-2026-04/ko/</loc>
     <lastmod>2026-04-28</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/karpathy-coding-skills-2026-04/ko/image/index.png</image:loc>
@@ -465,19 +877,19 @@
   <url>
     <loc>https://blog.pebblous.ai/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/ko/</loc>
     <lastmod>2026-04-28</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/isaac-sim-3dgs-vla-synthetic-data-2026-04/en/</loc>
     <lastmod>2026-04-28</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/en/</loc>
     <lastmod>2026-04-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/image/index.png</image:loc>
@@ -487,7 +899,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/</loc>
     <lastmod>2026-04-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/openmetadata-ai-ready-data-2026-04/ko/image/index.png</image:loc>
@@ -497,7 +909,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/frontend-vibe-coders/ko/</loc>
     <lastmod>2026-04-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/frontend-vibe-coders/ko/image/index.png</image:loc>
@@ -507,7 +919,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/frontend-vibe-coders/en/</loc>
     <lastmod>2026-04-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/frontend-vibe-coders/en/image/index.png</image:loc>
@@ -517,7 +929,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/palantir-technological-republic/ko/</loc>
     <lastmod>2026-04-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/palantir-technological-republic/ko/image/index.png</image:loc>
@@ -527,7 +939,7 @@
   <url>
     <loc>https://blog.pebblous.ai/story/palantir-technological-republic/en/</loc>
     <lastmod>2026-04-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/story/palantir-technological-republic/en/image/index.png</image:loc>
@@ -537,19 +949,19 @@
   <url>
     <loc>https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/ko/</loc>
     <lastmod>2026-04-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/nemotron-personas-korea-2026-04/en/</loc>
     <lastmod>2026-04-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/physical-ai-industry-landscape/en/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/physical-ai-industry-landscape/en/image/index.png</image:loc>
@@ -559,7 +971,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/vla-architecture-comparison/en/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/vla-architecture-comparison/en/image/index.png</image:loc>
@@ -569,19 +981,19 @@
   <url>
     <loc>https://blog.pebblous.ai/report/vla-architecture-comparison/ko/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/report/physical-ai-industry-landscape/ko/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/blog/claude-harness-postmortem/ko/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/claude-harness-postmortem/ko/image/index.png</image:loc>
@@ -591,7 +1003,7 @@
   <url>
     <loc>https://blog.pebblous.ai/blog/claude-harness-postmortem/en/</loc>
     <lastmod>2026-04-24</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/claude-harness-postmortem/en/image/index.png</image:loc>
@@ -1101,7 +1513,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/ko/image/index.png</image:loc>
-      <image:title>GitNexus, 오늘 GitHub 1위…코드를 지식 그래프로 바꾸는 Graph RAG, '브라우저 전용'은 과장</image:title>
+      <image:title>GitNexus, 코드를 지식 그래프로 바꾸는 Graph RAG</image:title>
     </image:image>
   </url>
   <url>
@@ -1111,7 +1523,7 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/gitnexus-code-knowledge-graph-2026/en/image/index.png</image:loc>
-      <image:title>GitNexus Hits #1 on GitHub — Code Knowledge Graphs Are Here, But "Browser-Only" Is Oversold</image:title>
+      <image:title>GitNexus: Code Knowledge Graphs and Graph RAG for AI Agents</image:title>
     </image:image>
   </url>
   <url>
@@ -2755,7 +3167,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026-mar-lighthouse/ko/</loc>
     <lastmod>2026-03-08</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026-mar-lighthouse/image/index.png</image:loc>
@@ -2765,7 +3177,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026-mar-lighthouse/en/</loc>
     <lastmod>2026-03-08</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026-mar-lighthouse/image/index.png</image:loc>
@@ -2775,7 +3187,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/korea-ai-fund-report-2026-03/ko/</loc>
     <lastmod>2026-03-05</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/korea-ai-fund-report-2026-03/image/index.png</image:loc>
@@ -2785,7 +3197,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/korea-ai-fund-report-2026-03/en/</loc>
     <lastmod>2026-03-05</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/korea-ai-fund-report-2026-03/image/index.png</image:loc>
@@ -2795,7 +3207,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/IR/ko/</loc>
     <lastmod>2026-03-03</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>1.0</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/IR/image/ir-hub-og.png</image:loc>
@@ -2805,7 +3217,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/IR/en/</loc>
     <lastmod>2026-03-03</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>1.0</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/IR/image/ir-hub-og.png</image:loc>
@@ -2815,7 +3227,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026-feb/ko/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026-feb/image/index.png</image:loc>
@@ -2825,7 +3237,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026-feb/en/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026-feb/image/index.png</image:loc>
@@ -2835,7 +3247,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/SyntheticData/ko/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/SyntheticData/ko/image/index.png</image:loc>
@@ -2845,7 +3257,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/SyntheticData/en/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/SyntheticData/en/image/index.png</image:loc>
@@ -2855,7 +3267,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/DataClinic/ko/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/DataClinic/ko/image/index.png</image:loc>
@@ -2865,7 +3277,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/DataClinic/en/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/DataClinic/en/image/index.png</image:loc>
@@ -2875,7 +3287,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/PhysicalAI/ko/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/PhysicalAI/ko/image/index.png</image:loc>
@@ -2885,7 +3297,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/PhysicalAI/en/</loc>
     <lastmod>2026-03-02</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/PhysicalAI/en/image/index.png</image:loc>
@@ -2895,7 +3307,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026/ko/</loc>
     <lastmod>2026-03-01</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>1.0</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026/image/index.png</image:loc>
@@ -2905,7 +3317,7 @@
   <url>
     <loc>https://blog.pebblous.ai/report/blog-2026/en/</loc>
     <lastmod>2026-03-01</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/report/blog-2026/image/index.png</image:loc>
@@ -2915,19 +3327,19 @@
   <url>
     <loc>https://blog.pebblous.ai/project/DAL/robotic-painting/ko/</loc>
     <lastmod>2026-03-01</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/project/DAL/robotic-painting/en/</loc>
     <lastmod>2026-03-01</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://blog.pebblous.ai/project/DataClinic/data-quality-guide-book-01/en/</loc>
     <lastmod>2026-02-28</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/DataClinic/data-quality-guide-book-01/image/og.png</image:loc>
@@ -2937,7 +3349,7 @@
   <url>
     <loc>https://blog.pebblous.ai/project/DataClinic/data-quality-guide-book-01/ko/</loc>
     <lastmod>2026-02-28</lastmod>
-    <changefreq>monthly</changefreq>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/project/DataClinic/data-quality-guide-book-01/image/og.png</image:loc>
@@ -2970,7 +3382,7 @@
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
-      <image:loc>https://blog.pebblous.ai/project/PhysicalAI/image/digital-twin-physical-ai-market.png</image:loc>
+      <image:loc>https://blog.pebblous.ai/project/PhysicalAI/digital-twin-physical-ai-market/ko/image/index.png</image:loc>
       <image:title>디지털트윈 × 피지컬AI: 두 거대 시장의 교차점에서 찾는 기회</image:title>
     </image:image>
   </url>
@@ -3010,7 +3422,7 @@
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
     <image:image>
-      <image:loc>https://blog.pebblous.ai/project/PhysicalAI/image/digital-twin-physical-ai-market.png</image:loc>
+      <image:loc>https://blog.pebblous.ai/project/PhysicalAI/digital-twin-physical-ai-market/en/image/index.png</image:loc>
       <image:title>Digital Twin × Physical AI: Opportunities at the Intersection of Two Mega Markets</image:title>
     </image:image>
   </url>


### PR DESCRIPTION
## 문제

PR #286(서베이)·#287(허브) 머지 후 `update-sitemap.yml` CI가 **2회 연속 success로 떴지만 sitemap·rss·llms.txt에 신규 글을 반영하지 못함** (자동 커밋 누락). 라이브 sitemap/rss/llms에 월드모델 서베이·허브가 빠진 상태였음.

진단: 생성기 자체는 정상 — 로컬 재생성 시 sitemap에 서베이 4·hub 4(KO/EN+hreflang) 정상 포함. CI 환경에서만 "변경 없음"으로 판단됨 (checkout SHA 타이밍 또는 환경변수 이슈로 추정).

## 변경

수동 재생성으로 검색엔진 인덱싱 복구:
- **sitemap.xml**: world-model-survey-2026 (KO/EN) + WorldModel hub (KO/EN), hreflang 포함
- **rss.xml**: 최신 항목 "AI는 어떻게 세계를 이해하는가" 반영
- **llms.txt**: 신규 글 포함

## 후속 (별도)

`update-sitemap.yml`이 머지 후 신규 글을 반영하지 못하는 원인은 별도 이슈로 조사 필요 (반복 발생 시 모든 신규 글의 인덱싱이 schedule 트리거에만 의존하게 됨).

🤖 Generated with Claude Code