### PR TITLE
chore: articles.json + changelog.jsonl 머지 드라이버 (반복 충돌 자동 해소)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Merge drivers for high-velocity shared metadata files.
+#
+# changelog.jsonl is append-only one-JSON-per-line: the built-in `union` driver
+# keeps both sides' lines on conflict (no manual resolution needed).
+history/changelog.jsonl merge=union
+
+# articles.json is a structured {categories, articles[]} wrapper, so `union`
+# would corrupt it. Use the custom id-union driver in tools/merge-articles-json.py.
+# Requires one-time registration per clone — run: tools/setup-merge-drivers.sh
+articles.json merge=articles-union

--- a/tools/merge-articles-json.py
+++ b/tools/merge-articles-json.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Git merge driver for articles.json — id-union of the articles array.
+
+Git invokes this as:  merge-articles-json.py %O %A %B
+  %O  ancestor version (base)
+  %A  current version (ours) — also the OUTPUT path; result must be written here
+  %B  other version (theirs)
+
+Strategy: both sides only ever *add* new articles (insert-at-head) or touch the
+`modified`/`wordCount` of existing ones. We union by `id`:
+  - keep every article whose id exists on either side
+  - for ids on both sides, prefer "ours" then fill missing fields from "theirs"
+  - article order: new ids (present on exactly one side) first, then the shared
+    base order, so freshly added posts stay near the top of the index.
+The `categories` wrapper is taken from whichever side has it (they're identical
+in practice; ours wins on conflict).
+
+Exits 0 on clean union, 1 if it cannot safely merge (Git then falls back to
+leaving conflict markers for a human).
+"""
+import json
+import sys
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv):
+    if len(argv) < 4:
+        sys.stderr.write("usage: merge-articles-json.py <base> <ours> <theirs>\n")
+        return 2
+    base_path, ours_path, theirs_path = argv[1], argv[2], argv[3]
+
+    try:
+        ours = load(ours_path)
+        theirs = load(theirs_path)
+    except (json.JSONDecodeError, OSError) as e:
+        sys.stderr.write(f"merge-articles-json: cannot parse inputs ({e})\n")
+        return 1
+
+    # Both must be the wrapper object {categories, articles}
+    if not (isinstance(ours, dict) and isinstance(theirs, dict)
+            and "articles" in ours and "articles" in theirs):
+        sys.stderr.write("merge-articles-json: unexpected shape, not {categories, articles}\n")
+        return 1
+
+    try:
+        base = load(base_path)
+        base_articles = base.get("articles", []) if isinstance(base, dict) else []
+    except (json.JSONDecodeError, OSError):
+        base_articles = []
+
+    ours_by_id = {a["id"]: a for a in ours["articles"] if "id" in a}
+    theirs_by_id = {a["id"]: a for a in theirs["articles"] if "id" in a}
+    base_ids = {a.get("id") for a in base_articles}
+
+    # Bail if either side has entries without an id — can't union safely.
+    if len(ours_by_id) != len(ours["articles"]) or len(theirs_by_id) != len(theirs["articles"]):
+        sys.stderr.write("merge-articles-json: an article is missing 'id'\n")
+        return 1
+
+    def merged_entry(aid):
+        o = ours_by_id.get(aid)
+        t = theirs_by_id.get(aid)
+        if o and t:
+            # ours wins; fill any key only theirs has
+            out = dict(t)
+            out.update(o)
+            return out
+        return o or t
+
+    all_ids = list(ours_by_id) + [i for i in theirs_by_id if i not in ours_by_id]
+    # newly-added ids (not in base) first, preserving each side's order, then shared
+    new_ids = [i for i in all_ids if i not in base_ids]
+    shared_ids = [i for i in all_ids if i in base_ids]
+
+    merged_articles = [merged_entry(i) for i in (new_ids + shared_ids)]
+
+    result = dict(ours)  # keep ours' categories/wrapper
+    if "categories" not in result and "categories" in theirs:
+        result["categories"] = theirs["categories"]
+    result["articles"] = merged_articles
+
+    with open(ours_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+    sys.stderr.write(
+        "merge-articles-json: union ok — ours=%d theirs=%d -> %d (new=%d)\n"
+        % (len(ours["articles"]), len(theirs["articles"]), len(merged_articles), len(new_ids))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/setup-merge-drivers.sh
+++ b/tools/setup-merge-drivers.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Register the custom git merge driver(s) this repo declares in .gitattributes.
+#
+# .gitattributes maps `articles.json` to merge=articles-union, but the *driver
+# command* for that name lives in local git config, which is NOT version-
+# controlled. Every fresh clone (and every agent worktree) must run this once,
+# or `articles.json` conflicts fall back to manual resolution.
+#
+# Safe to re-run. Idempotent.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DRIVER="$REPO_ROOT/tools/merge-articles-json.py"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "error: $DRIVER not found" >&2
+  exit 1
+fi
+
+git config merge.articles-union.name "id-union merge for articles.json"
+git config merge.articles-union.driver "python3 '$DRIVER' %O %A %B"
+
+# changelog.jsonl uses the built-in `union` driver — no registration needed.
+
+echo "Registered merge driver 'articles-union' -> python3 tools/merge-articles-json.py"
+echo "changelog.jsonl uses built-in 'union' (no setup needed)."
+echo "Done. articles.json + changelog.jsonl conflicts will now auto-resolve on merge."


### PR DESCRIPTION
## 배경

콘텐츠 PR(나노클로 등)이 열려 있는 동안 다른 글이 먼저 머지되면, 매번 두 파일에서 충돌이 났다:

- `articles.json` — 배열 맨 앞에 신규 글 삽입 (hot-spot)
- `history/changelog.jsonl` — 파일 끝에 한 줄 append (hot-spot)

콘텐츠 HTML·이미지는 새 경로라 절대 충돌하지 않는다. **공유 메타 두 줄**이 같은 지점을 동시에 건드려서 Git이 자동 병합을 못 했을 뿐이다. 최근 PR #327·#328·#339·#340을 순차 머지할 때마다 뒤 PR이 재충돌 → 수동 "양쪽 다 살리기"를 반복했다.

## 변경

| 파일 | 드라이버 | 동작 |
|------|---------|------|
| `history/changelog.jsonl` | 내장 `union` | 충돌 시 양쪽 줄 모두 보존 (append-only JSONL이라 안전) |
| `articles.json` | 커스텀 `articles-union` | `tools/merge-articles-json.py` — id 기준 병합. 신규 id를 앞에 두어 새 글이 인덱스 상단 유지 |

- `.gitattributes` — 두 파일을 각 드라이버에 매핑
- `tools/merge-articles-json.py` — id-union 머지 드라이버 (`%O %A %B`, ours 우선 + theirs 보충, wrapper `{categories, articles}` 보존, id 누락·파싱 실패 시 exit 1로 안전하게 수동 폴백)
- `tools/setup-merge-drivers.sh` — 클론/워크트리당 1회 등록 (`.gitattributes`는 이름만 매핑, 명령은 local git config에 등록해야 효과)

## 왜 articles.json은 union이 안 되나

`union`은 충돌 줄을 단순 양쪽 합치기 → JSON 배열은 괄호·쉼표가 깨져 invalid가 된다. 그래서 구조를 이해하는 커스텀 드라이버로 id-union.

## 테스트

합성 충돌 시나리오(두 브랜치가 각각 다른 글 + changelog 줄을 같은 지점에 추가) e2e 테스트:
- `articles.json` → valid JSON, 양쪽 신규 글 + base 모두 보존, 중복 id 0
- `changelog.jsonl` → 세 줄 모두 자동 보존
- **conflict markers 0** ✅

## ⚠️ 머지 후 필요 동작

머지 후 각 작업 클론/워크트리에서 **1회** 실행해야 articles.json 드라이버가 활성화됩니다:

\`\`\`bash
bash tools/setup-merge-drivers.sh
\`\`\`

(changelog.jsonl union은 내장이라 setup 불필요)

## 자산 분류 메모

머지 드라이버 파일은 자산3(도구)·인프라. 진본/사본 정책상 자산2/3은 진본 SSOT이지만, 이 드라이버는 **사본 main에 있어야 사본 PR 머지에서 효과**가 나므로 JH 승인하에 사본 직접 PR로 진행. 추후 진본(blog-service)에 reverse-sync 예정. CLAUDE.md(자산2) 문서화는 reverse-sync 시 진본에서 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)