### PR TITLE
auto-sync: 진본 blog-service@1dd57de

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Merge drivers for high-velocity shared metadata files.
+#
+# NOTE on the 진본/사본 model: the target files below (articles.json,
+# history/changelog.jsonl) are CONTENT (asset 1) that live only in the 사본
+# (pebblous/pebblous.github.io). They don't exist here in the 진본, but this
+# .gitattributes is mirrored to the 사본 by sync-to-sabon.yml, where it takes
+# effect on 사본 PR merges. The driver SCRIPTS live in tools/ (asset 3).
+#
+# changelog.jsonl is append-only one-JSON-per-line: the built-in `union` driver
+# keeps both sides' lines on conflict (no manual resolution needed).
+history/changelog.jsonl merge=union
+
+# articles.json is a structured {categories, articles[]} wrapper, so `union`
+# would corrupt it. Use the custom id-union driver in tools/merge-articles-json.py.
+# Requires one-time registration per clone — run: tools/setup-merge-drivers.sh
+articles.json merge=articles-union

--- a/tools/merge-articles-json.py
+++ b/tools/merge-articles-json.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Git merge driver for articles.json — id-union of the articles array.
+
+Git invokes this as:  merge-articles-json.py %O %A %B
+  %O  ancestor version (base)
+  %A  current version (ours) — also the OUTPUT path; result must be written here
+  %B  other version (theirs)
+
+Strategy: both sides only ever *add* new articles (insert-at-head) or touch the
+`modified`/`wordCount` of existing ones. We union by `id`:
+  - keep every article whose id exists on either side
+  - for ids on both sides, prefer "ours" then fill missing fields from "theirs"
+  - article order: new ids (present on exactly one side) first, then the shared
+    base order, so freshly added posts stay near the top of the index.
+The `categories` wrapper is taken from whichever side has it (they're identical
+in practice; ours wins on conflict).
+
+Exits 0 on clean union, 1 if it cannot safely merge (Git then falls back to
+leaving conflict markers for a human).
+"""
+import json
+import sys
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv):
+    if len(argv) < 4:
+        sys.stderr.write("usage: merge-articles-json.py <base> <ours> <theirs>\n")
+        return 2
+    base_path, ours_path, theirs_path = argv[1], argv[2], argv[3]
+
+    try:
+        ours = load(ours_path)
+        theirs = load(theirs_path)
+    except (json.JSONDecodeError, OSError) as e:
+        sys.stderr.write(f"merge-articles-json: cannot parse inputs ({e})\n")
+        return 1
+
+    # Both must be the wrapper object {categories, articles}
+    if not (isinstance(ours, dict) and isinstance(theirs, dict)
+            and "articles" in ours and "articles" in theirs):
+        sys.stderr.write("merge-articles-json: unexpected shape, not {categories, articles}\n")
+        return 1
+
+    try:
+        base = load(base_path)
+        base_articles = base.get("articles", []) if isinstance(base, dict) else []
+    except (json.JSONDecodeError, OSError):
+        base_articles = []
+
+    ours_by_id = {a["id"]: a for a in ours["articles"] if "id" in a}
+    theirs_by_id = {a["id"]: a for a in theirs["articles"] if "id" in a}
+    base_ids = {a.get("id") for a in base_articles}
+
+    # Bail if either side has entries without an id — can't union safely.
+    if len(ours_by_id) != len(ours["articles"]) or len(theirs_by_id) != len(theirs["articles"]):
+        sys.stderr.write("merge-articles-json: an article is missing 'id'\n")
+        return 1
+
+    def merged_entry(aid):
+        o = ours_by_id.get(aid)
+        t = theirs_by_id.get(aid)
+        if o and t:
+            # ours wins; fill any key only theirs has
+            out = dict(t)
+            out.update(o)
+            return out
+        return o or t
+
+    all_ids = list(ours_by_id) + [i for i in theirs_by_id if i not in ours_by_id]
+    # newly-added ids (not in base) first, preserving each side's order, then shared
+    new_ids = [i for i in all_ids if i not in base_ids]
+    shared_ids = [i for i in all_ids if i in base_ids]
+
+    merged_articles = [merged_entry(i) for i in (new_ids + shared_ids)]
+
+    result = dict(ours)  # keep ours' categories/wrapper
+    if "categories" not in result and "categories" in theirs:
+        result["categories"] = theirs["categories"]
+    result["articles"] = merged_articles
+
+    with open(ours_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+    sys.stderr.write(
+        "merge-articles-json: union ok — ours=%d theirs=%d -> %d (new=%d)\n"
+        % (len(ours["articles"]), len(theirs["articles"]), len(merged_articles), len(new_ids))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/setup-merge-drivers.sh
+++ b/tools/setup-merge-drivers.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Register the custom git merge driver(s) this repo declares in .gitattributes.
+#
+# .gitattributes maps `articles.json` to merge=articles-union, but the *driver
+# command* for that name lives in local git config, which is NOT version-
+# controlled. Every fresh clone (and every agent worktree) must run this once,
+# or `articles.json` conflicts fall back to manual resolution.
+#
+# Safe to re-run. Idempotent.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DRIVER="$REPO_ROOT/tools/merge-articles-json.py"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "error: $DRIVER not found" >&2
+  exit 1
+fi
+
+git config merge.articles-union.name "id-union merge for articles.json"
+git config merge.articles-union.driver "python3 '$DRIVER' %O %A %B"
+
+# changelog.jsonl uses the built-in `union` driver — no registration needed.
+
+echo "Registered merge driver 'articles-union' -> python3 tools/merge-articles-json.py"
+echo "changelog.jsonl uses built-in 'union' (no setup needed)."
+echo "Done. articles.json + changelog.jsonl conflicts will now auto-resolve on merge."


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@1dd57de

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서
- .gitattributes — 머지 드라이버 매핑

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
