### PR TITLE
chore(index): auto-update sitemap.xml, rss.xml, llms.txt [skip ci]

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -43,6 +43,7 @@ Curated topic landing pages that orient readers to a theme.
 
 AI, data quality, physical AI — engineering depth.
 
+- [그 시험지는 이미 학습 데이터에 있었다](https://blog.pebblous.ai/blog/llm-benchmark-contamination/ko/): 공개 벤치마크가 LLM 학습 데이터에 섞이면 점수가 부풀려진다. MMLU 29.1%, C-Eval 45.8% 오염, GSM8K 클린 테스트 13% 하락. 모델 능력이 아니라 평가 데이터의 무결성 문제다.
 - [연방이 캘리포니아 AI 학습 데이터 공개법을 3년간 멈춘다](https://blog.pebblous.ai/blog/great-american-ai-act-preemption/ko/): 미국 연방의 Great American AI Act가 주의 AI '개발' 규제를 3년간 선점한다. 명시된 표적은 학습 데이터 공개를 의무화한 캘리포니아 AB 2013. '개발이냐 배포냐'의 경계가 사실은 훈련 데이터를 누가 볼 수 있는지의 문제를 데이터 거버넌스 관점에서 본다.
 - [다중 에이전트가 실명 신약 후보를 골랐다](https://blog.pebblous.ai/blog/robin-multi-agent-drug-discovery/ko/): FutureHouse의 다중 에이전트 Robin이 건성 황반변성 신약 후보 리파수딜을 자율적으로 찾아냈다. 가설부터 데이터 해석까지 AI가 맡았지만, 7.5배가 사람 재분석에서 1.75배로 떨어진 사례가 남긴 데이터 검증의 역설을 분석합니다.
 - [이제 AI는 데이터를 사지 않는다, 빌린다](https://blog.pebblous.ai/report/ai-data-licensing-realtime-shift-2026/ko/): AI 기업이 콘텐츠를 확보하는 방식이 한 번 사는 학습 덤프에서 계속 빌리는 실시간 피드로 옮겨갔다. 공개된 91건의 라이선싱 거래로 드러난 데이터 시장의 buy→rent 구조 전환과 데이터 파이프라인·운영 변화를 정리했다.
@@ -54,7 +55,6 @@ AI, data quality, physical AI — engineering depth.
 - [AlphaFold이 접은 단백질을, 이제 AI가 처음부터 설계한다](https://blog.pebblous.ai/report/de-novo-protein-design-ai/ko/): 구조 예측을 넘어, 단백질 설계를 양산 공학으로 만든 건 더 큰 모델이 아니라 실측 데이터 루프였다. de novo 단백질 설계의 도약을 데이터 품질 관점으로 해부한다.
 - [1년을 버틴 AI 에이전트의 비밀은 똑똑함이 아니라 메모장이었다](https://blog.pebblous.ai/blog/agent-endurance-is-memory-not-intelligence/ko/): 12개 AI 모델에게 가상 스타트업을 1년간 경영시켰더니, 파산과 생존을 가른 가장 강력한 변수는 모델 지능이 아니라 스크래치패드에 받아 적는 습관이었다. YC-Bench·Mirage·METR 세 연구로 본 에이전트 지구력의 병목, 외부 기억이라는 데이터 문제.
 - ['깨끗한 데이터'라고 말했다, 증명은 없었다](https://blog.pebblous.ai/report/microsoft-mai-clean-data/ko/): 마이크로소프트 MAI '클린 데이터' 선언 — 같은 회사 기술 문서엔 Common Crawl 242억 페이지가 있었다. '깨끗한 데이터'는 선언이 아니라 증명되어야 하는 주장이다.
-- [한 번 망가진 AI는 돌아오지 않는다](https://blog.pebblous.ai/blog/llm-brain-rot-junk-data/ko/): 저질 트윗으로 추가 학습한 LLM의 추론 점수는 74.9에서 57.2로 떨어졌고, 깨끗한 데이터로 다시 가르쳐도 기준선으로 돌아오지 않았습니다. arXiv:2510.13928 브레인 롯 연구로 보는 학습 데이터 품질의 비가역성과 AI-Ready Data의 의미를 짚습니다.
 
 ## Business
 

--- a/rss.xml
+++ b/rss.xml
@@ -6,13 +6,49 @@
     <atom:link href="https://blog.pebblous.ai/rss.xml" rel="self" type="application/rss+xml" />
     <description>페블러스는 눈에 보이지 않는 데이터의 우주를 탐험하고, 그 본질을 만질 수 있는 형태로 바꾸어 새로운 문화와 가치를 창조합니다.</description>
     <language>ko</language>
-    <lastBuildDate>Sat, 20 Jun 2026 00:15:06 GMT</lastBuildDate>
+    <lastBuildDate>Sat, 20 Jun 2026 01:24:29 GMT</lastBuildDate>
     <generator>Pebblous RSS Generator</generator>
     <image>
         <url>https://blog.pebblous.ai/image/Pebblous_BM_Orange_RGB.png</url>
         <title>Pebblous Blog</title>
         <link>https://blog.pebblous.ai/</link>
     </image>
+
+    <item>
+        <title>그 시험지는 이미 학습 데이터에 있었다</title>
+        <link>https://blog.pebblous.ai/blog/llm-benchmark-contamination/ko/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/llm-benchmark-contamination/ko/</guid>
+        <description>공개 벤치마크가 LLM 학습 데이터에 섞이면 점수가 부풀려진다. MMLU 29.1%, C-Eval 45.8% 오염, GSM8K 클린 테스트 13% 하락. 모델 능력이 아니라 평가 데이터의 무결성 문제다.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 20 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/llm-benchmark-contamination/ko/image/index.png" type="image/jpeg" />
+        <category>LLM</category>
+        <category>벤치마크 오염</category>
+        <category>데이터 품질</category>
+        <category>데이터 무결성</category>
+        <category>benchmark contamination</category>
+        <category>MMLU</category>
+        <category>AI 평가</category>
+        <category>LiveBench</category>
+    </item>
+
+    <item>
+        <title>The Test Was Already in the Training Data</title>
+        <link>https://blog.pebblous.ai/blog/llm-benchmark-contamination/en/</link>
+        <guid isPermaLink="true">https://blog.pebblous.ai/blog/llm-benchmark-contamination/en/</guid>
+        <description>LLM benchmark data leaks inflate scores — MMLU is 29% contaminated, and Mistral drops 13pt on a clean test. The problem is evaluation-set integrity.</description>
+        <category>Tech Insights</category>
+        <pubDate>Sat, 20 Jun 2026 00:00:00 GMT</pubDate>
+        <enclosure url="blog/llm-benchmark-contamination/en/image/index.png" type="image/jpeg" />
+        <category>LLM</category>
+        <category>benchmark contamination</category>
+        <category>data quality</category>
+        <category>data integrity</category>
+        <category>MMLU</category>
+        <category>GSM8K</category>
+        <category>AI evaluation</category>
+        <category>LiveBench</category>
+    </item>
 
     <item>
         <title>말레이시아는 AI를 막는 대신, 데이터의 주인을 먼저 정한다</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,10 +11,46 @@
   </url>
 
   <url>
-    <loc>https://blog.pebblous.ai/blog/malaysia-ai-governance-bill/ko/</loc>
+    <loc>https://blog.pebblous.ai/blog/llm-benchmark-contamination/ko/</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/llm-benchmark-contamination/ko/image/index.png</image:loc>
+      <image:title>그 시험지는 이미 학습 데이터에 있었다</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-20</news:publication_date>
+      <news:title>그 시험지는 이미 학습 데이터에 있었다</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/llm-benchmark-contamination/en/</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://blog.pebblous.ai/blog/llm-benchmark-contamination/en/image/index.png</image:loc>
+      <image:title>The Test Was Already in the Training Data</image:title>
+    </image:image>
+    <news:news>
+      <news:publication>
+        <news:name>Pebblous Blog</news:name>
+        <news:language>ko</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-20</news:publication_date>
+      <news:title>The Test Was Already in the Training Data</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://blog.pebblous.ai/blog/malaysia-ai-governance-bill/ko/</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/malaysia-ai-governance-bill/ko/image/index.png</image:loc>
       <image:title>말레이시아는 AI를 막는 대신, 데이터의 주인을 먼저 정한다</image:title>
@@ -52,7 +88,7 @@
     <loc>https://blog.pebblous.ai/blog/great-american-ai-act-preemption/en/</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/great-american-ai-act-preemption/en/image/index.png</image:loc>
       <image:title>The Federal AI Bill That Would Freeze California's Training-Data Law for Three Years</image:title>
@@ -70,7 +106,7 @@
     <loc>https://blog.pebblous.ai/blog/robin-multi-agent-drug-discovery/ko/</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/robin-multi-agent-drug-discovery/ko/image/index.png</image:loc>
       <image:title>다중 에이전트가 실명 신약 후보를 골랐다</image:title>
@@ -142,7 +178,7 @@
     <loc>https://blog.pebblous.ai/blog/molmoact2-open-robot-data/ko/</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/molmoact2-open-robot-data/ko/image/index.png</image:loc>
       <image:title>Ai2가 로봇 학습 데이터 720시간을 모델과 함께 공개했다</image:title>
@@ -160,7 +196,7 @@
     <loc>https://blog.pebblous.ai/blog/molmoact2-open-robot-data/en/</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
     <image:image>
       <image:loc>https://blog.pebblous.ai/blog/molmoact2-open-robot-data/en/image/index.png</image:loc>
       <image:title>Ai2 Open-Sourced 720 Hours of Robot Training Data, Not Just the Weights</image:title>


### PR DESCRIPTION
자동 인덱스 갱신(sitemap/rss/llms). update-sitemap.yml 가 발행 후 생성·자체 머지. #289