### PR TITLE
content: 최근 발행 5편 SNS 백필

### DIFF
--- a/blog/ai-ready-data-conditions/sns/index.md
+++ b/blog/ai-ready-data-conditions/sns/index.md
@@ -1,0 +1,106 @@
+# SNS 홍보 글: 모델이 아니라 데이터가 먼저다
+
+> 소스: blog/ai-ready-data-conditions/ko/index.html
+> 생성일: 2026-06-20
+> URL: https://blog.pebblous.ai/blog/ai-ready-data-conditions/ko/
+> voice: LinkedIn/Twitter = sns-cover, Facebook = reflective
+
+---
+
+## LinkedIn (KO)
+
+생성형 AI 프로젝트의 약 30%가 모델이 아니라 데이터 품질 때문에 멈춘다. 모델을 바꾸기 전에 들여다봐야 할 곳이 따로 있다는 뜻이다.
+
+원인은 데이터 쪽에 더 깊이 박혀 있다. LLM이 사실과 다른 답을 내는 환각의 원인 가운데 55%가 데이터에서 비롯되고, 가장 큰 비중은 학습 데이터의 편향, 즉 대표성 부족이다. 반대로 데이터를 검색 가능한 형태로 잘 준비해 붙이면 환각률이 50%에서 13.9%까지 내려간다.
+
+AI-Ready Data는 완벽한 데이터가 아니라 목적에 맞게 준비되고 추적되는 데이터다. 정확성·완전성·일관성·적시성에 대표성·유효성·유일성을 더한 일곱 차원, 출처와 변환을 따라가는 계보, 접근과 책임을 정한 거버넌스가 그 조건이다.
+
+이 조건은 이제 권고가 아니라 규제로 이동하고 있다. EU AI Act는 2026년 8월 2일부터 학습 데이터의 출처와 처리 과정을 문서화하도록 요구하고, 데이터 계보 시장은 연평균 23.1%씩 커지고 있다.
+
+데이터의 가치가 보유에서 추적으로 옮겨가면, 데이터 품질도 한 번 검수하는 일에서 상태를 측정하는 운영으로 옮겨간다.
+
+▶ 전문: https://blog.pebblous.ai/blog/ai-ready-data-conditions/ko/
+
+#페블러스 #데이터클리닉 #데이터품질 #데이터저널리즘 #AIReadyData #데이터거버넌스 #RAG #EUAIAct
+
+---
+
+## LinkedIn (EN)
+
+Roughly 30% of generative AI projects stall on data quality, not the model. The thing worth fixing first sits one step earlier than the architecture.
+
+The problem runs deeper into the data. About 55% of the causes behind LLM hallucinations trace back to data, and the largest share is bias in training data — a failure of representativeness. The reverse holds too: prepare data into a retrievable form and bolt it on, and the hallucination rate falls from 50% to 13.9%.
+
+AI-Ready Data is not perfect data but data prepared and tracked for a purpose. Its conditions are seven quality dimensions — accuracy, completeness, consistency, timeliness, plus representativeness, validity, uniqueness — lineage that follows source and transformation, and governance that fixes access and accountability.
+
+These conditions are moving from advice to regulation. From 2 August 2026, the EU AI Act requires documentation of where training data came from and how it was processed, and the data lineage market is growing 23.1% a year.
+
+Once data's value moves from holding to tracking, data quality has to move with it: from a one-time inspection to an operation that keeps measuring the state.
+
+▶ Read: https://blog.pebblous.ai/blog/ai-ready-data-conditions/en/
+
+#Pebblous #DataClinic #DataQuality #DataJournalism #AIReadyData #DataGovernance #RAG #EUAIAct
+
+---
+
+## Twitter/X (KO)
+
+생성형 AI 프로젝트의 30%는 모델이 아니라 데이터 품질 때문에 멈춘다. LLM 환각 원인의 55%도 데이터에서 나온다.
+
+AI-Ready Data는 완벽한 데이터가 아니라 목적에 맞게 준비되고 추적되는 데이터다. 품질 일곱 차원, 계보, 거버넌스가 그 조건이다.
+
+https://blog.pebblous.ai/blog/ai-ready-data-conditions/ko/
+
+#페블러스 #데이터품질 #AIReadyData #RAG
+
+---
+
+## Twitter/X (EN)
+
+About 30% of generative AI projects stall on data quality, not the model. And 55% of LLM hallucination causes trace back to data.
+
+AI-Ready Data isn't perfect data. It's data prepared and tracked for a purpose: seven quality dimensions, lineage, governance.
+
+https://blog.pebblous.ai/blog/ai-ready-data-conditions/en/
+
+#Pebblous #DataQuality #AIReadyData #RAG
+
+---
+
+## Facebook (KO)
+
+좋은 모델을 붙였는데도 결과가 기대만큼 나오지 않을 때, 저는 보통 모델부터 의심하곤 했습니다.
+
+그런데 한 조사에서는 생성형 AI 프로젝트의 약 30%가 모델이 아니라 데이터 품질 때문에 멈춘다고 합니다. 의심해야 할 곳이 한 단계 앞에 있었던 셈입니다.
+
+오래전부터 우리는 "깨끗한 데이터"를 이야기해 왔습니다. 오타가 적고 빈칸이 적고 형식이 통일된 데이터. 사람이 보고서를 읽을 때는 그것으로 충분했습니다. 그런데 데이터를 사람이 아니라 모델이 학습하고 추론에 쓰기 시작하면서, "쓸 만하다"의 기준점이 조용히 옮겨졌습니다.
+
+저는 이렇게 옮겨진 기준을 'AI-Ready Data'라고 부르고 싶었습니다.
+
+완벽한 데이터가 아니라, 쓰려는 목적에 맞게 준비되고 출처와 변환이 추적되는 데이터. 정확성과 완전성 같은 익숙한 축에 대표성·계보·거버넌스가 더해진 무엇입니다. LLM이 사실과 다른 답을 내는 원인의 절반이 넘게 데이터에서 비롯된다는 숫자를 보면, 이 옮겨진 기준이 왜 무거워졌는지 짐작이 갑니다.
+
+그렇다면 우리가 오래 말해 온 "데이터는 자산이다"라는 문장은, 절반만 맞는 말이었는지도 모르겠습니다. 쌓아 두기만 한 데이터는 측정되지 않은 가능성에 가깝습니다. 우리 데이터가 정말 AI에 쓸 수 있는 상태인지, 그 질문을 직관이 아니라 측정으로 바꿀 수 있을까. 한참을 다시 생각하게 됩니다.
+
+▶ 전문: https://blog.pebblous.ai/blog/ai-ready-data-conditions/ko/
+
+#페블러스 #데이터품질 #데이터저널리즘 #AIReadyData #데이터거버넌스
+
+---
+
+## Facebook (EN)
+
+When a good model still underdelivers, my first instinct used to be to blame the model.
+
+Yet one survey found that about 30% of generative AI projects stall on data quality, not the model. The thing worth suspecting sat one step earlier all along.
+
+For a long time we talked about "clean data." Few typos, few blanks, a consistent format. That was enough when a person was reading a report. But the moment data stopped being read by people and started being learned and reasoned over by models, the bar for "usable" quietly moved.
+
+I started thinking of that moved bar as "AI-Ready Data."
+
+Not perfect data, but data prepared for its purpose, with its source and transformations kept traceable. The familiar axes — accuracy, completeness — joined now by representativeness, lineage, governance. When more than half of the causes behind an LLM's wrong answers trace back to data, it becomes easier to see why that moved bar grew so heavy.
+
+So maybe the line we've repeated for years, "data is an asset," was only half true. Data that is merely stockpiled is closer to an unmeasured possibility. Is our data actually in a state we can hand to an AI — and can we turn that question from a hunch into a measurement? I find myself sitting with that one for a while.
+
+▶ Read: https://blog.pebblous.ai/blog/ai-ready-data-conditions/en/
+
+#Pebblous #DataQuality #DataJournalism #AIReadyData #DataGovernance

--- a/blog/data-freshness-checklist/sns/index.md
+++ b/blog/data-freshness-checklist/sns/index.md
@@ -1,0 +1,110 @@
+# SNS 홍보 글: 데이터도 유통기한이 있다
+
+> 소스: blog/data-freshness-checklist/ko/index.html
+> 생성일: 2026-06-20
+> URL: https://blog.pebblous.ai/blog/data-freshness-checklist/ko/
+> voice: LinkedIn/Twitter = sns-cover, Facebook = reflective
+
+---
+
+## LinkedIn (KO)
+
+50ms 만에 열리는 대시보드가 2시간 전 데이터를 그리고 있을 수 있다. 빠른 시스템과 신선한 데이터는 같은 말이 아니다.
+
+데이터 신선도(freshness)는 사건이 실제로 일어난 시점과 그 데이터를 모델이 쓸 수 있게 되는 시점 사이의 간격이다. 이 간격이 벌어져도 모델은 모른다. 한 시간 전 입력이든 1초 전 입력이든 똑같은 신뢰도로 예측을 내놓기 때문에, 신선도 격차는 곧 정확도 격차가 되면서도 에러 로그에는 한 줄도 남지 않는다.
+
+AI 에이전트가 임계점을 바꿨다. 사람이 분기당 한 번 보던 예측을 에이전트는 초당 한 번 실행한다. 피처가 한 시간에 한 번만 갱신되면, 그 한 시간 동안 내려진 3,600번의 결정이 모두 같은 낡은 컨텍스트 위에 쌓인다.
+
+문제는 신선도가 데이터 품질 중 가장 측정되지 않는 차원이라는 점이다. 정확도 리포트에는 어제 데이터로 계산한 95%가 찍히지만, 그 95%가 오늘도 유효한지는 아무도 묻지 않는다.
+
+페블러스는 이미지 데이터의 AI-Ready 여부를 다섯 신호로 진단해 왔고, 신선도는 그 신호들이 시간 축 위에서도 유지되는지를 묻는 여섯 번째 질문이다. 데이터에 유통기한이 없다면, 그 유통기한을 정의하는 일이 다음 한 걸음이다.
+
+▶ 전문: https://blog.pebblous.ai/blog/data-freshness-checklist/ko/
+
+#페블러스 #데이터클리닉 #데이터품질 #데이터저널리즘 #AIReadyData #데이터거버넌스 #MLOps #AI에이전트
+
+---
+
+## LinkedIn (EN)
+
+A dashboard that opens in 50ms can be drawing data from two hours ago. A fast system and fresh data are not the same thing.
+
+Data freshness is the gap between the moment a real event happens and the moment a model can actually use it. When that gap widens, the model has no idea. It returns a prediction with the same confidence whether the input is an hour old or a second old, so the freshness gap becomes the accuracy gap while leaving no trace in the error logs.
+
+AI agents moved the threshold. A prediction a human reviewed once a quarter, an agent now runs once a second. If a feature refreshes only once an hour, all 3,600 decisions made in that hour sit on the same stale context.
+
+The catch is that freshness is the least-measured dimension of data quality. The accuracy report shows 95% computed on yesterday's data, but no one asks whether that 95% still holds today.
+
+Pebblous has been diagnosing AI-Ready image data through five signals; freshness is the sixth question — whether those signals still hold along the axis of time. If data carries no expiration date, defining one is the next step.
+
+▶ Read: https://blog.pebblous.ai/blog/data-freshness-checklist/en/
+
+#Pebblous #DataClinic #DataQuality #DataJournalism #AIReadyData #DataGovernance #MLOps #AIAgent
+
+---
+
+## Twitter/X (KO)
+
+50ms 만에 열리는 대시보드가 2시간 전 데이터를 보여줄 수 있다. 빠른 시스템과 신선한 데이터는 다른 말이다.
+
+모델은 입력이 낡았는지 모른 채 똑같은 신뢰도로 틀린다. 신선도 격차가 곧 정확도 격차다.
+
+https://blog.pebblous.ai/blog/data-freshness-checklist/ko/
+
+#페블러스 #데이터품질 #AIReadyData #데이터신선도
+
+---
+
+## Twitter/X (EN)
+
+A dashboard that opens in 50ms can show data from two hours ago. Fast and fresh are not the same thing.
+
+A model has no idea its input is stale and gets it wrong with full confidence. The freshness gap is the accuracy gap.
+
+https://blog.pebblous.ai/blog/data-freshness-checklist/en/
+
+#Pebblous #DataQuality #AIReadyData #DataFreshness
+
+---
+
+## Facebook (KO)
+
+우유에는 유통기한이 찍혀 있습니다.
+
+데이터에는 없습니다.
+
+그래서 우리는 어제 만든 피처와 1분 전에 만든 피처를 자주 같은 신뢰도로 다룹니다. 문제는 데이터가 우유보다 빨리 상하는 경우가 있다는 점입니다. "최근 15분 거래 횟수"라는 피처가 사실은 한 시간 전 값이라면, 그것은 더 이상 최근 15분이 아닙니다. 형식은 멀쩡한데 의미만 비어 있는 데이터입니다.
+
+가장 마음에 걸렸던 대목은, 모델이 그 사실을 전혀 모른다는 것이었습니다. 한 시간 전 입력이든 1초 전 입력이든, 모델은 똑같은 확신으로 예측을 내놓습니다. 그래서 신선도가 떨어져도 알림은 울리지 않고, 성능 저하는 분기 리포트가 나온 뒤에야 발견됩니다.
+
+저는 이런 데이터를 '유통기한 없는 데이터'라고 부르고 싶었습니다.
+
+에이전트 시대가 되면서 이 질문은 더 무거워졌습니다. 사람이 분기에 한 번 보던 예측을, 에이전트는 초당 한 번 실행합니다. 피처가 한 시간에 한 번만 갱신되면 그 사이 3,600번의 결정이 같은 낡은 세상 위에 쌓이고, 그동안 실제 세상은 계속 움직입니다.
+
+그렇다면 우리가 오래 믿어 온 "데이터는 자산이다"라는 문장은, 시간 축을 빼놓은 절반의 진실이었는지도 모르겠습니다. 데이터에 유통기한이 없다면, 그 유통기한은 결국 우리가 직접 정의해야 하는 값이 아닐까요.
+
+▶ 전문: https://blog.pebblous.ai/blog/data-freshness-checklist/ko/
+
+#페블러스 #데이터품질 #AIReadyData #MLOps #데이터신선도
+
+---
+
+## Facebook (EN)
+
+A carton of milk has a printed sell-by date.
+
+Data has none.
+
+So we routinely treat a feature computed yesterday and one computed a minute ago with the same trust. The trouble is that some data spoils faster than milk. A feature called "transactions in the last 15 minutes" that actually carries an hour-old value is no longer about the last 15 minutes at all. It looks structurally intact while its meaning has quietly drained away.
+
+What stayed with me is that the model has no way of knowing this. Whether the input is an hour old or a second old, it returns its prediction with the same conviction. So when freshness slips, no alert fires, and the performance decay surfaces only after the quarterly report is out.
+
+I started thinking of this as "data without a sell-by date."
+
+The age of agents makes the question heavier. A prediction a human reviewed once a quarter, an agent runs once a second. If a feature refreshes only once an hour, 3,600 decisions pile up on the same stale world while the real world keeps moving.
+
+So perhaps the line we have repeated for years, "data is an asset," was only half true — the half that left out time. If data carries no expiration date, maybe that date is something we have to define for ourselves.
+
+▶ Read: https://blog.pebblous.ai/blog/data-freshness-checklist/en/
+
+#Pebblous #DataQuality #AIReadyData #MLOps #DataFreshness

--- a/blog/synthetic-data-quality-contribution/sns/index.md
+++ b/blog/synthetic-data-quality-contribution/sns/index.md
@@ -1,0 +1,110 @@
+# SNS 홍보 글: 합성 데이터에 가격표를 붙이는 법
+
+> 소스: blog/synthetic-data-quality-contribution/ko/index.html
+> 생성일: 2026-06-20
+> URL: https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/
+> voice: LinkedIn/Twitter = sns-cover, Facebook = reflective
+
+---
+
+## LinkedIn (KO)
+
+합성 데이터를 만드는 기술은 매년 진화하는데, 그것을 평가하는 기술은 아직 원시적인 상태에 머물러 있다.
+
+기업의 67%가 이미 합성 데이터를 쓰고 있다. 그런데 그 데이터가 정말 쓸 만한지 객관적으로 증명하는 표준은 없다. 누가 좋은 데이터를 만들었는지 구분할 수 없으니 보상도 공정하지 않고, 좋은 생산자가 시장을 떠나는 악순환이 반복된다. 글로벌 데이터 브로커 시장이 3,190억 달러인데 순수 데이터 마켓플레이스는 18억 달러에 그치는 170배 격차도 결국 같은 정보 비대칭에서 나온다.
+
+페블러스 등록특허 제10-2969403호는 Fidelity·Utility·Privacy 세 축의 품질 점수를 자동으로 산출하고, 그 점수에서 곧장 생산자의 기여도를 도출해 보상까지 배분한다. 협력 게임 이론의 Shapley value가 참여자 20명만 넘어도 조합이 100만 개로 폭발하는 계산 비용을 우회하는 경로를 설계한 것이 구조적 차별점이다.
+
+물론 한계도 분명하다. 표준은 "무엇을 측정해야 하는가"까지만 정의하고, "어떻게 자동으로 측정해 보상까지 연결하는가"는 여전히 빈칸으로 남아 있다. EU AI Act가 2026년 8월 고위험 AI의 학습 데이터 품질 증명을 법적으로 의무화하면, 이 빈칸은 비용이 아니라 시장 진입 장벽이 된다.
+
+품질 증명 기술을 가진 쪽이 시장을 선점한다.
+
+▶ 전문: https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/
+
+#페블러스 #데이터클리닉 #데이터품질 #데이터저널리즘 #합성데이터 #AIReadyData #DataGreenhouse #EUAIAct
+
+---
+
+## LinkedIn (EN)
+
+The technology to generate synthetic data improves every year. The technology to evaluate it remains primitive.
+
+67% of enterprises already use synthetic data, yet no objective standard exists for proving its quality. Without a way to tell who produced good data, rewards can't be fair, and the best producers quietly leave the market. The same information asymmetry shows up in the 170x gap between the $319B global data broker market and the $1.8B pure-play data marketplace: buyers simply cannot verify quality before they buy.
+
+Pebblous registered patent No. 10-2969403 computes quality scores along three axes — Fidelity, Utility, Privacy — and derives each producer's contribution directly from those scores, all the way to reward distribution. The structural twist is routing around Shapley value, whose coalitions explode past a million once participants pass twenty.
+
+The limits are real. Standards define what to measure; how to measure it automatically and tie it to compensation is still a blank. When the EU AI Act mandates training-data quality proof for high-risk AI in August 2026, that blank stops being a cost and becomes a barrier to entry.
+
+Whoever holds the proof technology takes the market first.
+
+▶ Read: https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/
+
+#Pebblous #DataClinic #DataQuality #DataJournalism #SyntheticData #AIReadyData #DataGreenhouse #EUAIAct
+
+---
+
+## Twitter/X (KO)
+
+합성 데이터를 만드는 기술은 매년 진화하는데, 평가하는 기술은 원시적인 상태에 머물러 있다. 기업 67%가 쓰지만 품질을 증명할 표준은 없다.
+
+페블러스 특허 10-2969403호는 품질 3축 점수에서 기여도와 보상까지 자동으로 잇는다. 만드는 기술이 아니라 증명하는 기술의 싸움이다.
+
+https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/
+
+#페블러스 #데이터품질 #합성데이터 #EUAIAct
+
+---
+
+## Twitter/X (EN)
+
+Generating synthetic data gets better every year. Evaluating it stays primitive. 67% of enterprises use it, yet no standard proves its quality.
+
+Pebblous patent No. 10-2969403 links a 3-axis quality score to contribution and reward automatically. The fight isn't making data. It's proving it.
+
+https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/
+
+#Pebblous #DataQuality #SyntheticData #EUAIAct
+
+---
+
+## Facebook (KO)
+
+"이 데이터, 정말 쓸 만한가?"
+
+합성 데이터를 받아 본 사람이라면 한 번쯤 멈칫하게 되는 질문입니다.
+
+만드는 일은 이제 너무 쉬워졌습니다. 누구나 몇 줄의 코드로 진짜 같은 데이터를 찍어 냅니다. 기업의 67%가 이미 쓰고 있다고 합니다. 그런데 그 데이터가 원본을 충분히 닮았는지, 실제 학습에 쓸모가 있는지, 누군가의 개인정보가 새어 나가지는 않는지를 가려낼 공통의 자(尺)는 아직 없습니다.
+
+자가 없으니 값을 매길 수 없고, 값을 매길 수 없으니 누가 좋은 데이터를 만들었는지도 알 수 없습니다. 결국 정성껏 좋은 데이터를 만든 사람이 가장 먼저 시장을 떠납니다. 만드는 기술은 해마다 자라는데, 그것을 알아보는 눈은 좀처럼 자라지 않는 풍경입니다.
+
+페블러스가 이 자리에서 골몰한 것은, 화려한 생성 기술이 아니라 '알아보는 눈'이었습니다. 충실도와 유용성과 프라이버시, 서로 밀고 당기는 세 축의 점수를 자동으로 읽어 내고, 그 점수에서 곧장 "누가 얼마나 기여했는가"를 끌어내는 길을 등록특허 한 건에 담았습니다. 좋은 데이터를 만든 사람에게 더 많은 몫이 돌아가도록.
+
+다만 이 글을 덮으며 오래 남은 문장은 따로 있었습니다.
+
+검증되지 않은 데이터의 흐름은 자산이 아니라 부채가 될 수도 있다는 것. 그리고 내년 여름 EU AI Act가 품질 증명을 법으로 묻기 시작하면, 그 부채가 누구의 몫이 될 것인가 하는 물음이었습니다.
+
+▶ 전문: https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/ko/
+
+#페블러스 #데이터품질 #합성데이터 #DataClinic #DataGreenhouse
+
+---
+
+## Facebook (EN)
+
+"Is this data actually any good?"
+
+Anyone who has been handed a synthetic dataset has paused on that question at least once.
+
+Making the data is the easy part now. A few lines of code, and out comes something that looks just like the real thing. 67% of enterprises already rely on it. And yet there is still no shared yardstick to tell whether it resembles the original closely enough, whether it is useful for actual training, or whether someone's private record is quietly leaking through.
+
+With no yardstick, there is no price. With no price, there is no way to know who made the good data. So the people who carefully make good data are the first to leave. The craft of generating grows year after year, while the eye that recognizes quality barely grows at all.
+
+What Pebblous sat with was not a flashier generator, but that eye. A registered patent reads the scores along three pulling-against-each-other axes — fidelity, utility, privacy — automatically, then draws straight from those scores the answer to "who contributed, and how much," so that the people who made good data receive the larger share.
+
+But the line that stayed with me after closing the article was a different one.
+
+A flow of data that no one has verified can become a liability rather than an asset. And once the EU AI Act starts asking for proof of quality by law next summer, the question becomes simply this: whose liability will it be?
+
+▶ Read: https://blog.pebblous.ai/blog/synthetic-data-quality-contribution/en/
+
+#Pebblous #DataQuality #SyntheticData #DataClinic #DataGreenhouse

--- a/project/WorldModel/sns/index.md
+++ b/project/WorldModel/sns/index.md
@@ -1,0 +1,110 @@
+# SNS 홍보 글: 월드 모델 — 자율주행·로봇·Sora를 관통하는 AI 핵심 개념
+
+> 소스: project/WorldModel/ko/index.html
+> 생성일: 2026-06-20
+> URL: https://blog.pebblous.ai/project/WorldModel/ko/
+> voice: LinkedIn/Twitter = sns-cover, Facebook = reflective
+
+---
+
+## LinkedIn (KO)
+
+자율주행, 로봇, Sora. 멀어 보이는 세 분야가 사실은 같은 개념 하나에 매달려 있다. 월드 모델, AI가 세계를 픽셀의 나열이 아니라 사물이 어떻게 움직이고 서로 영향을 주는지에 대한 내부 모형으로 표상하려는 시도다.
+
+자율주행차가 다음 순간 보행자의 움직임을 가늠하고, 로봇이 물건을 집기 전 결과를 머릿속으로 돌려보고, 영상 모델이 물리적으로 그럴듯한 장면을 이어 그린다. 그 바탕에는 모두 세계에 대한 내부 모형이 깔려 있다.
+
+흥미로운 건 같은 이름이 두 갈래로 갈린다는 점이다. 하나는 세계를 이해하는 길. Yann LeCun의 JEPA, DeepMind의 Dreamer처럼 픽셀을 복원하는 대신 추상적 표현 공간에서 세계의 작동 원리를 배운다. 다른 하나는 미래를 생성하는 길. Sora나 Genie처럼 다음 장면 자체를 만들어 내며 세계를 시뮬레이션한다.
+
+목표도 방법도 다른 두 흐름을 구분해서 읽으면, 지금 AI 연구의 지형이 한결 또렷해진다. 다섯 단계 입문부터 총정리 서베이, JEPA 심화, 세 갈래 비교, VLM·VLA의 한계까지 다섯 편을 한곳에 모은 허브를 페블러스가 열었다.
+
+보는 것과 이해하는 것은 다르다. 다음 AI의 과제는 더 많이 보는 모델이 아니라 세계를 이해하는 모델이다.
+
+▶ 전문: https://blog.pebblous.ai/project/WorldModel/ko/
+
+#페블러스 #데이터클리닉 #데이터품질 #데이터저널리즘 #PhysicalAI #JEPA #Sora #월드모델
+
+---
+
+## LinkedIn (EN)
+
+Self-driving cars, robots, and Sora. Three fields that look unrelated turn out to lean on a single idea. A world model — AI's attempt to represent the world not as a flat stream of pixels but as an internal model of how things move and influence one another.
+
+A car anticipates where a pedestrian will step next. A robot simulates the outcome before it grasps an object. A video model paints physically plausible scenes one after another. Each rests on an internal model of the world underneath.
+
+What is striking is that the same name splits into two paths. One is understanding the world: approaches like Yann LeCun's JEPA and DeepMind's Dreamer learn how the world works in an abstract representation space instead of reconstructing every pixel. The other is generating the future: approaches like Sora and Genie simulate the world by producing the scenes that come next.
+
+Reading these two currents as distinct brings the AI research landscape into sharper focus. Pebblous has opened a hub gathering five pieces — a five-level primer, a full survey, a JEPA deep dive, a comparison of three approaches, and the limits VLM and VLA ran into.
+
+Seeing is not understanding. The next challenge is not a model that sees more, but one that understands the world.
+
+▶ Read: https://blog.pebblous.ai/project/WorldModel/en/
+
+#Pebblous #DataClinic #DataQuality #DataJournalism #PhysicalAI #JEPA #Sora #WorldModel
+
+---
+
+## Twitter/X (KO)
+
+자율주행, 로봇, Sora가 매달린 같은 개념 하나. 월드 모델은 AI가 세계를 픽셀이 아니라 내부 모형으로 표상하려는 시도다.
+
+이해하는 길(JEPA, Dreamer)과 생성하는 길(Sora, Genie). 같은 이름, 다른 목표. 보는 것과 이해하는 것은 다르다.
+
+https://blog.pebblous.ai/project/WorldModel/ko/
+
+#페블러스 #월드모델 #JEPA #Sora
+
+---
+
+## Twitter/X (EN)
+
+Self-driving, robots, and Sora all lean on one idea. A world model lets AI represent the world as an internal model, not a flat stream of pixels.
+
+Two paths under one name: understanding (JEPA, Dreamer) and generating (Sora, Genie). Seeing is not understanding.
+
+https://blog.pebblous.ai/project/WorldModel/en/
+
+#Pebblous #WorldModel #JEPA #Sora
+
+---
+
+## Facebook (KO)
+
+Sora가 그려 내는 영상을 보다가, 문득 이 모델이 물이 어떻게 흐르고 그림자가 어디 지는지를 정말 아는 걸까 궁금해진 적이 있습니다.
+
+자율주행차는 다음 순간 보행자가 어디로 발을 디딜지 가늠합니다.
+
+로봇은 물건을 집기 전에 그 결과를 머릿속으로 한 번 돌려봅니다.
+
+서로 멀어 보이는 이 일들이, 알고 보면 같은 개념 하나에 기대고 있더군요. AI가 세계를 픽셀의 나열이 아니라, 사물이 어떻게 움직이고 서로 영향을 주는지에 대한 내부 모형으로 품으려는 시도. 월드 모델입니다.
+
+흥미로운 건 같은 이름이 두 갈래로 갈린다는 점이었습니다. 한쪽은 세계를 이해하려는 길입니다. Yann LeCun의 JEPA나 DeepMind의 Dreamer는 픽셀을 일일이 복원하기보다, 추상적인 공간에서 세계가 어떻게 돌아가는지를 배웁니다. 다른 한쪽은 다음 장면을 직접 만들어 세계를 흉내 내는 길입니다. Sora와 Genie가 그렇습니다.
+
+여기서 오래 머문 질문이 하나 있었습니다. 보는 것과 이해하는 것은 같은 일인가? VLM과 VLA는 그토록 많은 것을 보면서도, 정작 세계를 진짜로 아는 데는 자꾸 걸려 넘어졌습니다.
+
+그래서 다음 AI의 과제는 더 많이 보는 일이 아니라, 본 것을 세계로 엮어 내는 일이 아닐까 싶습니다. 페블러스가 월드 모델을 다룬 글 다섯 편을 한곳에 모은 것도, 같은 질문을 함께 들여다보고 싶어서였습니다.
+
+▶ 전문: https://blog.pebblous.ai/project/WorldModel/ko/
+
+#페블러스 #데이터품질 #월드모델 #JEPA #Sora
+
+---
+
+## Facebook (EN)
+
+Watching a clip Sora had generated, I caught myself wondering whether the model actually knows how water flows or where a shadow should fall.
+
+A self-driving car guesses where a pedestrian will step next.
+
+A robot runs the outcome through its head once before it grasps an object.
+
+These tasks look far apart, yet they all lean on a single idea. AI's attempt to hold the world not as a flat stream of pixels, but as an internal model of how things move and affect one another. A world model.
+
+What stayed with me was that the same name splits into two paths. One tries to understand the world. Yann LeCun's JEPA and DeepMind's Dreamer learn how the world turns in an abstract space rather than reconstructing every pixel. The other builds the next scene directly, imitating the world as it goes. Sora and Genie do this.
+
+One question lingered. Are seeing and understanding the same thing? VLM and VLA see so much, and yet they keep stumbling when it comes to truly knowing the world.
+
+So perhaps the next challenge for AI is not seeing more, but weaving what it sees into a world. Pebblous gathered five pieces on world models in one place because we wanted to sit with that same question.
+
+▶ Read: https://blog.pebblous.ai/project/WorldModel/en/
+
+#Pebblous #DataQuality #WorldModel #JEPA #Sora

--- a/report/sap-prior-labs-tabular-foundation-model/sns/index.md
+++ b/report/sap-prior-labs-tabular-foundation-model/sns/index.md
@@ -1,0 +1,114 @@
+# SNS 홍보 글: 모델은 준비됐다, 그런데 당신의 테이블은?
+
+> 소스: report/sap-prior-labs-tabular-foundation-model/ko/index.html
+> 생성일: 2026-06-20
+> URL: https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/ko/
+> voice: LinkedIn/Twitter = sns-cover, Facebook = reflective
+
+---
+
+## LinkedIn (KO)
+
+세계 최대 ERP 사업자가 창업 18개월 된 독일 스타트업에 4년간 €10억(약 $1.16B) 투자를 약속했다. SAP가 5월 4일 인수한 Prior Labs가 만드는 것은 챗봇도 이미지 모델도 아니다. 표를 다루는 파운데이션 모델이다.
+
+TabPFN은 합성 데이터로 한 번 사전학습한 뒤, 추론 시점에 실제 표를 통째로 읽어 재학습 없이 곧바로 예측한다. 표를 프롬프트처럼 읽는 셈이다. 2025년 Nature는 단일 추론 2.8초가 4시간 튜닝한 앙상블의 정확도를 능가했다고 보고했다. 같은 날 SAP는 데이터 레이크하우스 Dremio도 사들여 모델 레이어와 데이터 레이어를 동시에 확보했다.
+
+다만 이 성능에는 "소~중형 표(대략 1만 행 이하)"라는 단서가 붙는다. 대규모 데이터에서는 0.8% 정확도 향상을 얻으려 최대 4만 배의 추론 지연을 감수할 수도 있다. 모든 곳에서 XGBoost를 대체하는 것이 아니라, 작은 표에서 빠르고 강하다.
+
+그런데 모델이 재학습을 건너뛰는 순간, 입력 표의 결함은 희석되지 않고 예측에 그대로 흐른다. 결측·스키마 드리프트·비표준 코드값·라벨 노이즈가 곧 성능 저하다. 제조 ERP 중 AI-ready 비율은 44%에 불과하고, 불량 데이터는 기업당 연평균 $12.9M의 손실을 부른다.
+
+모델이 강력해질수록 데이터 품질이 덜 중요해지는 것이 아니라 더 중요해진다. 이번 인수가 남기는 진짜 질문이다.
+
+▶ 전문: https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/ko/
+
+#페블러스 #데이터클리닉 #데이터품질 #데이터저널리즘 #AIReadyData #데이터거버넌스 #SAP #TabPFN
+
+---
+
+## LinkedIn (EN)
+
+The world's largest ERP vendor just committed more than €1B (about $1.16B) over four years to an 18-month-old German startup. What Prior Labs, acquired by SAP on May 4, builds is neither a chatbot nor an image model. It is a foundation model for tables.
+
+TabPFN is pretrained once on synthetic data, then reads a real table whole at inference time and predicts immediately, with no retraining — reading the table like a prompt. In 2025 Nature reported that a single 2.8-second inference surpassed the accuracy of an ensemble tuned for four hours. On the same day, SAP also bought the data lakehouse Dremio, securing the model layer and the data layer at once.
+
+That performance carries a qualifier: small-to-mid tables, roughly under 10,000 rows. On large data, a TFM may accept up to a 40,000× latency penalty to gain 0.8% in accuracy. It does not replace XGBoost everywhere; it is fast and strong on small tables.
+
+But the moment a model skips retraining, flaws in the input table are no longer diluted — they flow straight into the prediction. Missing values, schema drift, non-standard code values, and label noise all become degraded performance. Only 44% of manufacturing ERP data is AI-ready, and bad data costs the average company an estimated $12.9M a year.
+
+The stronger the model gets, the more data quality matters, not less. That is the real question this deal leaves behind.
+
+▶ Read: https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/en/
+
+#Pebblous #DataClinic #DataQuality #DataJournalism #AIReadyData #DataGovernance #SAP #TabPFN
+
+---
+
+## Twitter/X (KO)
+
+SAP가 창업 18개월 된 Prior Labs에 4년간 €10억 투자를 약속했다. 챗봇이 아니라 '표를 읽는' 파운데이션 모델 TabPFN이다.
+
+모델은 재학습을 건너뛴다. 그래서 입력 표의 결함이 예측에 그대로 흐른다. 모델이 강해질수록 데이터 품질은 더 중요해진다.
+
+https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/ko/
+
+#페블러스 #데이터품질 #SAP #TabPFN
+
+---
+
+## Twitter/X (EN)
+
+SAP committed €1B+ over four years to the 18-month-old Prior Labs. Not a chatbot — TabPFN, a foundation model that "reads" tables.
+
+The model skips retraining, so flaws in the input table flow straight into the prediction. The stronger the model, the more data quality matters.
+
+https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/en/
+
+#Pebblous #DataQuality #SAP #TabPFN
+
+---
+
+## Facebook (KO)
+
+회사 안의 가장 중요한 숫자들은 대개 문장도 사진도 아니라, 행과 열로 짜인 표 안에 있습니다.
+
+매출 전표, 고객 등급, 재무 원장 같은 것들이요.
+
+지난 몇 해 동안 AI의 화제가 챗봇과 그림으로만 흘러가는 사이, 정작 그 표들은 여전히 XGBoost와 손으로 다듬는 작업의 자리에 남아 있었습니다.
+
+그런데 5월 초, 세계에서 가장 큰 ERP 회사인 SAP가 창업 18개월 된 독일의 작은 연구실 Prior Labs를 인수하고, 4년간 €10억(약 $1.16B) 넘게 투자하겠다고 밝혔습니다. 이들이 만드는 것은 또 하나의 언어 모델이 아니라, 표 자체를 다루는 파운데이션 모델 TabPFN입니다. 합성 데이터로 한 번 학습해 둔 뒤, 실제 표를 통째로 읽어 재학습 없이 예측합니다. 표를 프롬프트처럼 읽는다고 하면 가까울까요.
+
+저는 이 대목에서 한 문장에 오래 머물렀습니다.
+
+모델이 재학습을 건너뛴다는 것은, 표에 담긴 결함이 학습 과정에서 걸러지지 않고 예측에 곧장 흐른다는 뜻이기도 했습니다. 결측, 부서마다 다른 코드값, 잘못 붙은 라벨이 그대로 답을 흔듭니다. 제조업 ERP 가운데 모델에 바로 태울 만큼 준비된 데이터는 절반에도 못 미친다는 집계를 봤습니다.
+
+그렇다면 우리가 오래 되뇌어 온 "데이터가 자산이다"라는 말은, 조건을 하나 빠뜨리고 있었는지도 모르겠습니다. 쌓여 있다고 자산이 되는 것이 아니라, 깨끗할 때에만 자산이 되는 것이었을까요.
+
+모델이 강해질수록 데이터 품질이 덜 중요해지는 게 아니라 더 중요해진다는 문장 앞에서, 한참을 다시 읽게 됩니다.
+
+▶ 전문: https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/ko/
+
+#페블러스 #데이터품질 #데이터저널리즘 #SAP #TabPFN
+
+---
+
+## Facebook (EN)
+
+The most important numbers inside a company usually live not in sentences or photographs, but in tables — rows and columns.
+
+Sales ledgers, customer tiers, financial records.
+
+While the AI conversation drifted toward chatbots and pictures these past few years, those tables stayed where they were: the domain of XGBoost and work done by hand.
+
+Then, in early May, SAP — the largest ERP company in the world — acquired an 18-month-old German lab called Prior Labs and said it would invest more than €1B (about $1.16B) over four years. What they build is not another language model but TabPFN, a foundation model for tables themselves. Pretrained once on synthetic data, it reads a real table whole and predicts with no retraining. Reading the table like a prompt, you might say.
+
+One sentence kept me there for a while.
+
+That a model skips retraining also means the flaws inside a table are no longer filtered out during training; they flow straight into the prediction. Missing values, code values that differ by department, a mislabeled row — each one shakes the answer. Fewer than half of manufacturing ERP datasets, by one count, are ready enough to feed a model directly.
+
+So maybe the line we've repeated for so long, "data is an asset," was missing a condition. Perhaps data isn't an asset because it has piled up, but only while it stays clean.
+
+In front of the sentence that as models grow more powerful, data quality matters more rather than less, I find myself reading slowly again.
+
+▶ Read: https://blog.pebblous.ai/report/sap-prior-labs-tabular-foundation-model/en/
+
+#Pebblous #DataQuality #DataJournalism #SAP #TabPFN


### PR DESCRIPTION
sns-write 단계가 'completed'였지만 sns/ 산출물이 실제로 안 써진 케이스(예: SAP) + 6월 누락분 5편에 SNS 카피를 작성.

각 글 6채널: LinkedIn(KO/EN, sns-cover) · Twitter/X(KO/EN, sns-cover) · Facebook(KO/EN, reflective). 본문 링크 포함, 보이스 자기검증 통과, 기사 실제 사실 기반.

- report/sap-prior-labs-tabular-foundation-model
- blog/ai-ready-data-conditions
- project/WorldModel
- blog/synthetic-data-quality-contribution
- blog/data-freshness-checklist

※ 근본 원인(엔진이 sns-write를 exit-0=completed로 처리, sns/ 산출물 미검증)은 별도 fix 예정(②/③ 계획).