### PR TITLE
feat(worldmodel): 허브에 Genie 3 글 추가 (KO/EN)

### DIFF
--- a/project/WorldModel/en/index.html
+++ b/project/WorldModel/en/index.html
@@ -123,6 +123,10 @@
                     <a href="/project/AgenticAI/world-model-rise/en/" class="text-lg font-semibold" style="color: #F86825;">Eyes Without Understanding — Beyond VLM·VLA</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">Seeing and understanding are not the same. This piece examines the limits of VLM and VLA — processing visual information without truly understanding the world — and explains why world models are emerging as the next step.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/project/AgenticAI/moltbot-genie3-metaverse-for-agent/en/" class="text-lg font-semibold" style="color: #F86825;">Moltbot + Genie 3 = a Metaverse for Agents?</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">The frontier of the generative branch of world models. DeepMind's Genie 3 generates explorable worlds in real time, simulating the stage on which agents can learn and act.</p>
+                </div>
             </div>
         </div>
 
@@ -154,7 +158,8 @@
                 'blog/yann-lecun-jepa-world-models',
                 'project/World Model/world-model-comparison',
                 'project/AgenticAI/world-model-rise',
-                'pebblopedia/world-model'
+                'pebblopedia/world-model',
+                'project/AgenticAI/moltbot-genie3-metaverse-for-agent'
             ],
             language: 'en'
         });

--- a/project/WorldModel/ko/index.html
+++ b/project/WorldModel/ko/index.html
@@ -123,6 +123,10 @@
                     <a href="/project/AgenticAI/world-model-rise/ko/" class="text-lg font-semibold" style="color: #F86825;">눈이 있어도 세계를 모른다 — VLM·VLA를 넘어</a>
                     <p class="themeable-text text-sm mt-1 leading-relaxed">보는 것과 이해하는 것은 다릅니다. VLM·VLA가 시각 정보를 처리하면서도 세계를 진짜로 이해하지 못하는 한계를 짚고, 월드 모델이 왜 다음 단계로 떠오르는지 설명합니다.</p>
                 </div>
+                <div class="themeable-card-bg rounded-lg p-4 border themeable-border">
+                    <a href="/project/AgenticAI/moltbot-genie3-metaverse-for-agent/ko/" class="text-lg font-semibold" style="color: #F86825;">Moltbot + Genie 3 = 에이전트를 위한 메타버스?</a>
+                    <p class="themeable-text text-sm mt-1 leading-relaxed">생성 계열 월드 모델의 최전선. DeepMind의 Genie 3가 탐험 가능한 세계를 실시간으로 만들어 내며, 에이전트가 학습하고 행동할 무대를 직접 시뮬레이션하는 가능성을 짚습니다.</p>
+                </div>
             </div>
         </div>
 
@@ -154,7 +158,8 @@
                 'blog/yann-lecun-jepa-world-models',
                 'project/World Model/world-model-comparison',
                 'project/AgenticAI/world-model-rise',
-                'pebblopedia/world-model'
+                'pebblopedia/world-model',
+                'project/AgenticAI/moltbot-genie3-metaverse-for-agent'
             ],
             language: 'ko'
         });


### PR DESCRIPTION
월드모델 허브에 누락됐던 생성 계열 글(Moltbot + Genie 3)을 추가. Genie 3는 DeepMind의 월드 모델이라 허브에 포함되는 게 맞음. 시리즈 가이드 카드 + extraPaths 등록(KO/EN). articles.json 미변경.