### PR TITLE
fix(ci): autoheal 봇 UNKNOWN mergeability 사각지대 해소

### DIFF
--- a/.github/workflows/pr-conflict-autoheal.yml
+++ b/.github/workflows/pr-conflict-autoheal.yml
@@ -45,6 +45,13 @@ jobs:
           git config user.email "actions@github.com"
           git fetch origin main --quiet
 
+          # GitHub은 mergeability를 lazy하게 계산해, 막 만들어진 PR은 한동안 UNKNOWN으로 남는다.
+          # gh pr list 의 mergeable 필터는 UNKNOWN을 CONFLICTING으로 못 잡아 적체 PR을 놓친다(사각지대).
+          # → 각 열린 PR을 gh pr view로 한 번 찔러 계산을 강제(트리거)한 뒤, 잠깐 기다렸다가 다시 조회한다.
+          mapfile -t allnums < <(gh pr list --base main --state open --json number --jq '.[].number')
+          for n in "${allnums[@]}"; do gh pr view "$n" --json mergeable >/dev/null 2>&1 || true; done
+          sleep 15
+
           # 열린 PR 중 base=main 이고 GitHub이 CONFLICTING 으로 판정한 것만 대상
           mapfile -t rows < <(gh pr list --base main --state open \
             --json number,headRefName,mergeable \


### PR DESCRIPTION
충돌 PR이 적체된 근본: GitHub이 mergeability를 lazy 계산 → 막 만든 PR은 UNKNOWN → 봇의 `mergeable==CONFLICTING` 필터가 못 잡음(봇 로그 '치유 대상 없음'). 각 열린 PR을 `gh pr view`로 찔러 계산을 강제한 뒤 15초 후 재조회하도록 수정 → 이제 충돌이 나도 봇이 자동 치유. (근본책 articles.json 샤딩은 별도)