### PR TITLE
auto-sync: 진본 blog-service@7951335

### DIFF
--- a/docs/articles-sharding.md
+++ b/docs/articles-sharding.md
@@ -1,0 +1,63 @@
+# articles.json 샤딩 — 충돌 근절 설계 + 안전 cutover 순서
+
+## 문제
+모든 글 PR이 단일 `articles.json`(610+ 항목)의 배열 끝에 항목을 추가한다. 동시 PR이면
+같은 지점을 편집해 git 충돌이 난다. 임시방편(articles-union 머지 드라이버 + pr-conflict-autoheal
+워크플로)은 GitHub 서버 머지에서 드라이버가 안 돌아 PR이 CONFLICTING으로 뜨는 사각지대가 있다.
+
+## 해결 — 사이드카 + CI 조립
+- 글 하나 = 사이드카 파일 하나: `articles.d/<id>.json` (id는 유일, 610개 검증).
+- 각 PR은 **자기 사이드카 파일만** 추가/수정 → 서로 다른 파일이라 git 충돌 원천 차단.
+- `articles.json` 은 더 이상 직접 편집하지 않는 **CI 생성 산출물**. push 시 `assemble-articles.py`가
+  사이드카에서 재조립해 커밋한다. (sitemap.xml / rss.xml 과 동일한 'CI 생성' 모델)
+- 인덱스(`scripts/index/init.js`)는 클라이언트에서 featured→date desc 재정렬하므로 배열 순서 무관.
+
+### 도구 (Phase 1 — 완료, 동작 변경 없음)
+- `tools/shard-articles.py` — articles.json → `articles.d/<id>.json` × N + `articles.categories.json`
+- `tools/assemble-articles.py` — 사이드카 → articles.json (`--check`로 CI 검증). date desc·id asc 결정적.
+- 검증: 실데이터 610개 round-trip 무손실(엔트리 차이 0), 멱등, byte 안정, validate-articles.js 0 errors.
+
+## ⭐ union(base + overlay) — mass 마이그레이션 불필요·순서 사고 안전
+
+assemble 는 **기존 articles.json(base) ∪ 사이드카(overlay, 같은 id면 사이드카 우선)** 로 동작한다.
+→ 옛 612개는 base에 그대로 carry-forward, **신규 글만 사이드카**로 추가하면 충돌이 사라진다.
+→ 한꺼번에 610개를 옮기는 위험한 원자적 마이그레이션이 **필요 없다**. 배포 순서가 어긋나도
+   base가 받쳐주므로 라이브 인덱스가 비거나 항목이 유실되지 않는다.
+
+이중 안전 가드:
+- **no-op 가드**: `articles.d/`에 사이드카가 하나도 없으면 articles.json 을 건드리지 않는다.
+- **base carry-forward**: 사이드카가 일부만 있어도 나머지는 base에서 유지(유실 0).
+
+## cutover 순서
+
+1. **Phase 1 (완료)** — 샤딩 도구(shard/assemble, union-mode) + 검증. 동작 변경 0.
+
+2. **Phase 2 — assemble 워크플로 추가 (사본)**
+   - `.github/workflows/assemble-articles.yml`: push(main)에서 `articles.d/**`·`articles.json` 변경 시
+     `assemble-articles.py` 실행 → articles.json 갱신을 PR+자체머지(sitemap 워크플로와 동일 패턴, INDEX_PUSH_TOKEN).
+   - no-op 가드 덕에 사이드카가 없는 동안엔 아무 일도 안 한다 → 지금 추가해도 안전.
+
+3. **Phase 3 — 발행 스킬을 사이드카 작성으로 전환** (충돌이 실제로 사라지는 단계)
+   쓰기 지점만 변경(읽기 전용 스킬은 그대로):
+   - `.claude/skills/blog-publish/skill.md`, `dc-publish/skill.md`, `report-produce/skill.md`,
+     `report-produce-express/skill.md`, `pb-story-produce/SKILL.md`, `dc-story-produce/SKILL.md`,
+     `story-style-guide/SKILL.md`, `review-dataclinic-story/SKILL.md`
+   - 변경: "articles.json 배열에 항목 추가" → "`articles.d/<id>.json` 파일 생성(글당 1, ko/en 각각)".
+     articles.json 은 **PR에서 직접 편집하지 않음** → CI(Phase 2)가 base∪사이드카로 생성.
+   - `tools/scan-articles-meta.py`: 사이드카(publisher/wordCount/modified)도 갱신하도록 적응(점진).
+
+4. **Phase 4 — (선택, 신뢰 확보 후) 옛 612개 사이드카로 마이그레이션 + 임시방편 폐기**
+   - `shard-articles.py --force` 로 base를 전부 사이드카화(완전 샤딩). 그 후 base 의존 제거 가능.
+   - `.gitattributes` articles-union 드라이버 + `pr-conflict-autoheal.yml` 폐기(충돌 소멸).
+
+## Phase 2b(옛 글 일괄 마이그레이션)는 union 모델에선 **선택 사항** — 신규 글만 사이드카로도 충돌이 사라진다.
+
+## 롤백
+- 어느 단계든 articles.json 자체는 항상 유효한 산출물로 남는다. 문제 시 Phase 2a 워크플로를 끄고
+  (가드 덕에 자동 무력화) `shard`/`assemble` 없이 직접 articles.json 편집 모델로 즉시 복귀 가능.
+
+## 상태
+- [x] Phase 1 — 도구(shard/assemble union-mode) + 검증
+- [ ] Phase 2 — assemble 워크플로(사본)
+- [ ] Phase 3 — 발행 스킬 사이드카 전환 + scan-articles-meta 적응
+- [ ] Phase 4 — (선택) 옛 글 일괄 샤딩 + union 드라이버/autoheal 폐기

--- a/tools/assemble-articles.py
+++ b/tools/assemble-articles.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+assemble-articles.py — 사이드카(articles.d/<id>.json)를 articles.json 에 병합한다.
+
+샤딩 모델(articles.json 단일 핫스팟 충돌 근절):
+  - 신규/수정 글 = 사이드카 파일 하나(articles.d/<id>.json). 각 PR은 자기 사이드카만 추가
+    → 서로 다른 파일이라 git 충돌이 원천적으로 발생하지 않는다.
+  - articles.json 은 CI가 생성하는 산출물. push 시 이 스크립트가(=CI가) 재조립해 커밋한다.
+
+⭐ union(base + overlay) 모델 — mass 마이그레이션 불필요·순서 사고 안전:
+  - base = 기존 articles.json 의 articles (있으면). 기존 612개는 base에 그대로 carry-forward.
+  - overlay = 사이드카들. 같은 id면 사이드카가 base를 덮어쓴다(수정 반영).
+  - 결과 = (base ∪ 사이드카) 를 date desc·id asc 로 결정적 정렬해 articles.json 으로 출력.
+  → 옛 글을 한꺼번에 옮기지 않아도 된다. 신규 글만 사이드카로 추가하면 충돌이 사라진다.
+  → 어떤 순서로 배포돼도 base가 받쳐주므로 라이브 인덱스가 비거나 항목이 유실되지 않는다.
+
+categories: articles.categories.json 이 있으면 그걸, 없으면 기존 articles.json 의 categories 사용.
+
+사용:
+  python3 tools/assemble-articles.py            # 사이드카를 articles.json 에 병합(갱신)
+  python3 tools/assemble-articles.py --check     # 갱신 없이, 현재 articles.json 과 차이 있으면 exit 1 (CI)
+  python3 tools/assemble-articles.py --root <경로>
+"""
+import argparse, json, sys, glob, os
+
+CATEGORIES_FILE = "articles.categories.json"
+SIDECAR_DIR = "articles.d"
+OUTPUT = "articles.json"
+
+
+def sidecar_paths(root):
+    return sorted(glob.glob(os.path.join(root, SIDECAR_DIR, "*.json")))
+
+
+def load_sidecars(root):
+    arts, seen = [], {}
+    for p in sidecar_paths(root):
+        with open(p, encoding="utf-8") as f:
+            try:
+                obj = json.load(f)
+            except json.JSONDecodeError as e:
+                sys.exit(f"❌ 사이드카 파싱 실패 {p}: {e}")
+        aid = obj.get("id")
+        if not aid:
+            sys.exit(f"❌ 사이드카에 id 없음: {p}")
+        if aid in seen:
+            sys.exit(f"❌ 중복 id '{aid}': {p} vs {seen[aid]}")
+        seen[aid] = p
+        arts.append(obj)
+    return arts
+
+
+def load_base(root):
+    """기존 articles.json 에서 (categories, {id: article}) 를 읽는다. 없으면 (None, {})."""
+    p = os.path.join(root, OUTPUT)
+    if not os.path.exists(p):
+        return None, {}
+    with open(p, encoding="utf-8") as f:
+        d = json.load(f)
+    base = {a["id"]: a for a in d.get("articles", []) if a.get("id")}
+    return d.get("categories"), base
+
+
+def assemble(root):
+    base_categories, base = load_base(root)
+    # categories 우선순위: 별도 파일 > 기존 articles.json
+    cat_path = os.path.join(root, CATEGORIES_FILE)
+    if os.path.exists(cat_path):
+        with open(cat_path, encoding="utf-8") as f:
+            categories = json.load(f)
+    elif base_categories is not None:
+        categories = base_categories
+    else:
+        sys.exit(f"❌ categories 출처 없음 ({CATEGORIES_FILE} 도 기존 articles.json 도 없음).")
+
+    merged = dict(base)                       # base 먼저
+    for s in load_sidecars(root):             # 사이드카가 덮어씀(수정 반영)
+        merged[s["id"]] = s
+    arts = list(merged.values())
+    arts.sort(key=lambda a: (a.get("id") or ""))                 # 안정성: id asc
+    arts.sort(key=lambda a: (a.get("date") or ""), reverse=True) # 1순위: date desc
+    return {"categories": categories, "articles": arts}
+
+
+def dump(obj):
+    return json.dumps(obj, ensure_ascii=False, indent=2) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--check", action="store_true", help="갱신하지 않고 현재 articles.json 과 비교 (CI)")
+    args = ap.parse_args()
+
+    # ⛔ 안전 가드 — 사이드카가 하나도 없으면 articles.json 을 건드리지 않는다(no-op).
+    # (마이그레이션/스킬 전환 전 워크플로가 먼저 돌아도 기존 인덱스를 재정렬·변경하지 않게.)
+    if not sidecar_paths(args.root):
+        print(f"⏭️  {SIDECAR_DIR}/ 에 사이드카 없음 — no-op (articles.json 미변경).")
+        return 0
+
+    assembled = dump(assemble(args.root))
+    out_path = os.path.join(args.root, OUTPUT)
+
+    if args.check:
+        current = open(out_path, encoding="utf-8").read() if os.path.exists(out_path) else ""
+        if current != assembled:
+            print("❌ articles.json 이 사이드카와 불일치 — `python3 tools/assemble-articles.py` 재실행 필요")
+            return 1
+        print(f"✅ articles.json 이 사이드카와 일치 ({len(json.loads(assembled)['articles'])} articles)")
+        return 0
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(assembled)
+    n = len(json.loads(assembled)["articles"])
+    print(f"✅ articles.json 재조립 완료 ({n} articles = base ∪ {SIDECAR_DIR}/)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/generate-og-image.js
+++ b/tools/generate-og-image.js
@@ -421,31 +421,17 @@ async function generateOGImage(title, subtitle, outputPath, category, projectRoo
 
     const browser = await puppeteer.launch({
         headless: 'new',
-        args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-gpu',
-            '--disable-software-rasterizer',
-            '--disable-extensions',
-            '--disable-background-networking',
-            '--mute-audio'
-        ],
-        protocolTimeout: 300000
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
     });
 
     try {
         const page = await browser.newPage();
-        page.setDefaultTimeout(120000);
         await page.setViewport({ width: 1200, height: 630 });
         await page.setContent(html, { waitUntil: 'domcontentloaded' });
 
-        // Wait for embedded fonts to render (with 5s fallback)
-        await Promise.race([
-            page.evaluate(() => document.fonts.ready),
-            new Promise(resolve => setTimeout(resolve, 5000))
-        ]);
-        await new Promise(resolve => setTimeout(resolve, 500));
+        // Wait for embedded fonts to render
+        await page.evaluate(() => document.fonts.ready);
+        await new Promise(resolve => setTimeout(resolve, 200));
 
         // Ensure output directory exists
         const outputDir = path.dirname(outputPath);

--- a/tools/shard-articles.py
+++ b/tools/shard-articles.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+shard-articles.py — articles.json(단일 모놀리식)을 사이드카로 분해한다.
+
+  articles.json
+    → articles.categories.json        (categories 블록, 거의 안 변함)
+    → articles.d/<id>.json × N         (글 하나당 한 파일)
+
+일회성 마이그레이션 + 엔진/도구가 articles.json 을 직접 쓰던 과거 항목을 재분해할 때 사용.
+분해 후 tools/assemble-articles.py 로 재조립하면 원본과 의미적으로 동일해야 한다(round-trip 검증).
+
+사용:
+  python3 tools/shard-articles.py [--root <경로>] [--force]
+    --force: 기존 articles.d/ 사이드카를 모두 지우고 새로 생성(고아 제거).
+"""
+import argparse, json, sys, os, glob, re
+
+CATEGORIES_FILE = "articles.categories.json"
+SIDECAR_DIR = "articles.d"
+SOURCE = "articles.json"
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9._\-]+$")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--force", action="store_true", help="기존 사이드카 전체 삭제 후 재생성")
+    args = ap.parse_args()
+    root = args.root
+
+    with open(os.path.join(root, SOURCE), encoding="utf-8") as f:
+        data = json.load(f)
+    if "categories" not in data or "articles" not in data:
+        sys.exit("❌ articles.json 래퍼({categories, articles}) 아님 — 중단")
+
+    # categories
+    with open(os.path.join(root, CATEGORIES_FILE), "w", encoding="utf-8") as f:
+        f.write(json.dumps(data["categories"], ensure_ascii=False, indent=2) + "\n")
+
+    sidecar_dir = os.path.join(root, SIDECAR_DIR)
+    os.makedirs(sidecar_dir, exist_ok=True)
+    if args.force:
+        for p in glob.glob(os.path.join(sidecar_dir, "*.json")):
+            os.remove(p)
+
+    seen = {}
+    for a in data["articles"]:
+        aid = a.get("id")
+        if not aid:
+            sys.exit(f"❌ id 없는 article: {a.get('path') or a.get('title')}")
+        if not SAFE_ID.match(aid):
+            sys.exit(f"❌ 파일명으로 부적합한 id '{aid}' — 슬러그 정규화 필요")
+        if aid in seen:
+            sys.exit(f"❌ 중복 id '{aid}'")
+        seen[aid] = True
+        with open(os.path.join(sidecar_dir, f"{aid}.json"), "w", encoding="utf-8") as f:
+            f.write(json.dumps(a, ensure_ascii=False, indent=2) + "\n")
+
+    print(f"✅ {len(seen)} 사이드카 생성 → {SIDECAR_DIR}/  + {CATEGORIES_FILE}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@7951335

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서
- .gitattributes — 머지 드라이버 매핑

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
