### PR TITLE
auto-sync: 진본 blog-service@a58cbf9

### DIFF
--- a/.claude/skills/new-hub/SKILL.md
+++ b/.claude/skills/new-hub/SKILL.md
@@ -199,12 +199,12 @@ Every hub page MUST follow this exact structure:
 5. **Update root redirect** (if exists):
    - Change `project/{Project}/index.html` to redirect to `./ko/` (or `./en/`)
 
-6. **Register in `articles.json`**:
-   - Add both KO and EN hub entries to the `"articles"` array
+6. **Register via sidecar files** (⛔ do NOT edit `articles.json` — CI-generated; sharding, see `docs/articles-sharding.md`):
+   - Write both KO and EN hub entries as `articles.d/<id>.json` (one object per file). Distinct files → no merge conflicts.
    - **CRITICAL**: Set `"type": "hub"` — this auto-excludes the hub from other hubs' card grids (no `excludePaths` needed)
    - Hub articles typically use `"category": "tech"` or `"business"` depending on topic
    - Set `"published": true`
-   - **CRITICAL**: Preserve `{ "categories": {...}, "articles": [...] }` wrapper
+   - Validate locally: `python3 tools/assemble-articles.py` → `node tools/validate-articles.js` → `git checkout -- articles.json` (don't commit articles.json)
 
 7. **Post-Task Chain** (MUST follow after completion):
    1. **OG image**: `node tools/generate-og-image.js --from-html {hub-html-path} --light`

--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -90,11 +90,11 @@ When this skill is invoked:
    - Output goes to `{html-dir}/image/{html-name}.png`
    - Skips if image already exists (use `--force` to override)
 
-9. **Register** both language versions in `articles.json` with all required fields.
-   - **CRITICAL**: `articles.json` MUST be `{ "categories": {...}, "articles": [...] }` — NEVER a bare array `[...]`.
-   - When adding entries, append to the `"articles"` array inside the wrapper. Do NOT strip the wrapper.
+9. **Register** both language versions via **sidecar files** — write each entry object to `articles.d/<id>.json` (one per language). ⛔ Do NOT edit `articles.json` directly (it is a CI-generated artifact; sharding — see `docs/articles-sharding.md`). Distinct sidecar files mean no merge conflicts.
+   - Each sidecar is a single JSON object with all required fields (`id`, `title`, `path`, `date`, `category`, `published`, `description`, `language`, `tags`).
    - Do NOT set `"type": "hub"` — that field is reserved for hub pages only (see `/new-hub` skill).
-   - **Password-protected pages**: If the page uses `PebblousAuth` / `content-locked`, MUST set `"locked": true` in articles.json. This enables the lock badge icon on blog main page cards. Without it, the card appears unlocked despite requiring a password.
+   - **Password-protected pages**: If the page uses `PebblousAuth` / `content-locked`, MUST set `"locked": true` in the sidecar. This enables the lock badge icon on blog main page cards.
+   - Validate locally: `python3 tools/assemble-articles.py` then `node tools/validate-articles.js`, then `git checkout -- articles.json` (don't commit articles.json).
 
 10. **Reference implementations**:
    - Single-language: `project/DataClinic/data-quality.html`

--- a/.claude/skills/pb-story-produce/SKILL.md
+++ b/.claude/skills/pb-story-produce/SKILL.md
@@ -170,22 +170,20 @@ PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
 
 실패 시: 1회 재시도. 실패해도 계속 진행.
 
-### Phase 4: articles.json 등록
+### Phase 4: 사이드카 등록 (articles.d/<id>.json) — ⛔ articles.json 직접 편집 금지
 
-`_workspace/02_pb_write_meta.json`의 두 항목을 `articles.json` 맨 앞에 삽입:
+샤딩 모델(`docs/articles-sharding.md`): `_workspace/02_pb_write_meta.json`의 두 항목(KO·EN)을
+각각 **사이드카 파일**로 저장한다. articles.json 은 CI 가 생성하므로 직접 편집하지 않는다.
 
 ```python
-import json
-with open('articles.json') as f:
-    data = json.load(f)
-# EN 먼저, KO 두 번째 순서로 insert(0)
-data['articles'].insert(0, ko_entry)
-data['articles'].insert(0, en_entry)
-with open('articles.json', 'w', encoding='utf-8') as f:
-    json.dump(data, f, ensure_ascii=False, indent=2)
+import json, os
+os.makedirs('articles.d', exist_ok=True)
+for entry in (ko_entry, en_entry):
+    with open(f"articles.d/{entry['id']}.json", 'w', encoding='utf-8') as f:
+        json.dump(entry, f, ensure_ascii=False, indent=2)
 ```
 
-CRITICAL: `{"categories": {...}, "articles": [...]}` wrapper 유지.
+⛔ articles.json 을 열어 편집·삽입하지 말 것. 커밋엔 사이드카 파일만(검증·절차는 blog-publish §2.5/2.7).
 
 ### Phase 5: Git Push
 

--- a/.claude/skills/pebblopedia/SKILL.md
+++ b/.claude/skills/pebblopedia/SKILL.md
@@ -163,9 +163,9 @@ PebbloPedia 포스트 리뷰 시:
 - [ ] 캐시 버스팅: CSS/JS에 `?v=YYYYMMDD`
 - [ ] **작성 완료 후 반드시 `/seo-check` 실행** — 4계층 검증
 
-### articles.json
+### articles.json (등록은 사이드카 `articles.d/<id>.json` — ⛔ articles.json 직접편집 금지, 샤딩: `docs/articles-sharding.md`)
 - [ ] category: "tech" (PebbloPedia는 교육 콘텐츠이므로 tech)
-- [ ] cardTitle에 [페블로피디아] 포함
+- [ ] title 에 [페블로피디아] 포함 (필드명은 `title` — `cardTitle` 금지)
 - [ ] image, language 필드 존재
 
 ## 참조 구현

--- a/.claude/skills/story-style-guide/SKILL.md
+++ b/.claude/skills/story-style-guide/SKILL.md
@@ -216,7 +216,7 @@ EN 버전:
 3. `<title>` 태그 수정
 4. `og:title` + `twitter:title` 수정
 5. `og:image:alt` + `twitter:image:alt` 수정
-6. `articles.json` title + description 수정
+6. **사이드카** `articles.d/<id>.json` 의 title + description 수정 (⛔ articles.json 직접편집 금지 — 사이드카가 없으면 그 글의 항목으로 새로 생성. CI가 base에 overlay. 샤딩: `docs/articles-sharding.md`)
 7. OG 이미지 재생성 (`node tools/generate-og-image.js --from-html ... --force`)
 
 ## 7-1. PebblousPage.init


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@a58cbf9

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서
- .gitattributes — 머지 드라이버 매핑

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
