### PR TITLE
fix(hub): VLA 허브 만화 위치 — 인트로 다음으로 이동 (KO+EN)

### DIFF
--- a/project/VLA/en/index.html
+++ b/project/VLA/en/index.html
@@ -76,12 +76,6 @@
             <p class="text-sm themeable-muted">Pebblous Data Communication Team · <a href="/project/VLA/ko/" class="text-orange-400 hover:text-orange-300 transition-colors">한국어</a></p>
         </header>
 
-        <!-- Representative Comic -->
-        <figure class="max-w-3xl mx-auto mb-12">
-            <img src="/project/VLA/en/image/vla-explainer.png" alt="What is a VLA model? An AI that sees (Vision), understands language (Language), and acts with a body (Action). A one-panel comic showing a robot hearing 'put the ball in the cup' and then seeing, understanding, and acting." class="w-full h-auto rounded-2xl border themeable-border" loading="eager">
-            <figcaption class="text-center text-sm themeable-muted mt-3">VLA is AI that sees (Vision) · understands (Language) · and acts (Action).</figcaption>
-        </figure>
-
         <!-- Intro Section -->
         <div class="intro-section">
             <div class="key-insight">
@@ -96,6 +90,12 @@
                 </p>
             </div>
         </div>
+
+        <!-- Representative Comic -->
+        <figure class="max-w-3xl mx-auto mb-12">
+            <img src="/project/VLA/en/image/vla-explainer.png" alt="What is a VLA model? An AI that sees (Vision), understands language (Language), and acts with a body (Action). A one-panel comic showing a robot hearing 'put the ball in the cup' and then seeing, understanding, and acting." class="w-full h-auto rounded-2xl border themeable-border" loading="lazy">
+            <figcaption class="text-center text-sm themeable-muted mt-3">VLA is AI that sees (Vision) · understands (Language) · and acts (Action).</figcaption>
+        </figure>
 
         <!-- Series Guide -->
         <div class="intro-section">

--- a/project/VLA/ko/index.html
+++ b/project/VLA/ko/index.html
@@ -76,12 +76,6 @@
             <p class="text-sm themeable-muted">(주)페블러스 데이터 커뮤니케이션팀 · <a href="/project/VLA/en/" class="text-orange-400 hover:text-orange-300 transition-colors">English</a></p>
         </header>
 
-        <!-- Representative Comic -->
-        <figure class="max-w-3xl mx-auto mb-12">
-            <img src="/project/VLA/ko/image/vla-explainer.png" alt="VLA 모델이란? AI가 눈으로 보고(Vision), 말을 이해하고(Language), 몸으로 행동하는(Action) 모델. 로봇이 '공을 컵에 넣어줘'라는 말을 듣고 보고-이해하고-행동하는 과정을 한 컷 만화로 설명" class="w-full h-auto rounded-2xl border themeable-border" loading="eager">
-            <figcaption class="text-center text-sm themeable-muted mt-3">VLA는 보고(Vision) · 이해하고(Language) · 행동하는(Action) AI입니다.</figcaption>
-        </figure>
-
         <!-- Intro Section -->
         <div class="intro-section">
             <div class="key-insight">
@@ -96,6 +90,12 @@
                 </p>
             </div>
         </div>
+
+        <!-- Representative Comic -->
+        <figure class="max-w-3xl mx-auto mb-12">
+            <img src="/project/VLA/ko/image/vla-explainer.png" alt="VLA 모델이란? AI가 눈으로 보고(Vision), 말을 이해하고(Language), 몸으로 행동하는(Action) 모델. 로봇이 '공을 컵에 넣어줘'라는 말을 듣고 보고-이해하고-행동하는 과정을 한 컷 만화로 설명" class="w-full h-auto rounded-2xl border themeable-border" loading="lazy">
+            <figcaption class="text-center text-sm themeable-muted mt-3">VLA는 보고(Vision) · 이해하고(Language) · 행동하는(Action) AI입니다.</figcaption>
+        </figure>
 
         <!-- Series Guide -->
         <div class="intro-section">


### PR DESCRIPTION
허브 만화 표준 위치(Exec Summary 다음·시리즈 가이드 앞)에 맞춰 VLA 허브 만화를 인트로 앞→다음으로 이동. 합성데이터 허브(#458)와 통일. KO+EN, HTML 2파일만 변경.