### PR TITLE
auto-sync: 진본 blog-service@1512941

### DIFF
--- a/docs/blog-service/openapi.yaml
+++ b/docs/blog-service/openapi.yaml
@@ -531,6 +531,24 @@ components:
           type: string
           maxLength: 10000
           description: Additional context or instructions for the pipeline
+        mode:
+          type: string
+          enum: [attended, unattended]
+          description: >-
+            attended (default): pause at human gates. unattended: auto-pass gates
+            (fully autonomous). (Request body field name: `mode`.)
+        holdForPublish:
+          type: boolean
+          default: false
+          description: If true, pause right before publish-prep (PR creation) for human go-ahead.
+        autoMerge:
+          type: boolean
+          default: false
+          description: >-
+            opt-in: after the PR is created, wait for CI to pass and auto-merge it
+            live (no human click). On CI failure the PR is left open (safe).
+            Combine with mode=unattended + holdForPublish=false for fully hands-off
+            publish-to-live. Default false (PR only).
 
     PhaseDef:
       type: object


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@1512941

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서
- .gitattributes — 머지 드라이버 매핑

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
