### PR TITLE
fix(faq): 빈 <section id="faq"> 에 가시 FAQ 렌더 (374개 페이지)

### DIFF
--- a/scripts/common-utils.js
+++ b/scripts/common-utils.js
@@ -800,7 +800,18 @@ const PebblousPage = {
      * @param {Array} faqs - Array of {question, answer} objects
      */
     renderFAQ(faqs) {
-        const container = document.getElementById('faq-container');
+        let container = document.getElementById('faq-container');
+        // 표준 패턴은 빈 <section id="faq"></section> (CLAUDE.md). #faq-container 가 없으면
+        // #faq 섹션 안에 heading + container 를 만들어 렌더한다 — 이게 없어서 빈 <section id="faq">
+        // 패턴(374개 페이지)에서 가시 FAQ 가 안 그려지고 JSON-LD 스키마만 주입됐다.
+        // (레거시 페이지는 자체 #faq-container 를 가져 위 getElementById 에서 바로 잡힘.)
+        if (!container) {
+            const section = document.getElementById('faq');
+            if (section) {
+                section.innerHTML = '<h2 class="text-3xl font-bold themeable-heading mb-8">FAQ</h2><div id="faq-container"></div>';
+                container = section.querySelector('#faq-container');
+            }
+        }
         if (!container || !faqs || faqs.length === 0) return;
 
         container.innerHTML = faqs.map((faq, i) => `


### PR DESCRIPTION
> **비유**: FAQ 데이터·SEO 표식은 다 있는데 정작 화면에 FAQ가 안 보이던 문제. 렌더 함수가 옛날 상자(`#faq-container`)만 찾고, 표준이 된 빈 상자(`<section id="faq">`)는 못 채웠다.
>
> **무엇**: `renderFAQ`가 `#faq-container` 부재 시 `#faq` 섹션에 heading+container를 만들어 렌더하도록 폴백 추가.
> **왜**: CLAUDE.md 표준은 빈 `<section id="faq"></section>`인데 renderFAQ는 레거시 `#faq-container`만 조회 → **374개 페이지에서 가시 FAQ 미렌더**(JSON-LD 스키마만 주입). 발견 계기: blog/gaaia-ivo-ai-audit-license.
> **효과**: scripts/common-utils.js 한 곳 수정으로 374개 전부 FAQ가 보이게 됨. 레거시 28개(`faq-container` 자체 보유)는 기존 경로로 영향 없음.

## 검증
미니 DOM 스텁으로 실제 renderFAQ 본문 실행 → 빈 `#faq`에 FAQ heading + 아이템 N개 렌더 확인.

## 주의
- site-wide 파일(common-utils.js) — 머지 중 다른 PR 머지 잠시 보류 권장.
- 캐시: 페이지가 `?v=` 쿼리로 참조 → 신규 방문/미캐시는 즉시 반영, 기존 캐시는 다음 ?v= 범프 시. (전 페이지 ?v= 일괄 범프는 별도 작업.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)