### PR TITLE
auto-sync: 진본 blog-service@c682afc

### DIFF
--- a/.claude/skills/blog-produce/skill.md
+++ b/.claude/skills/blog-produce/skill.md
@@ -130,6 +130,21 @@ EN 글이면 동일하게 EN 파일에 대해 호출 (영어 추가 패턴 — d
 호출 결과는 `_workspace/03_prose_diagnosis.md`로 저장. 교정 결과가 있으면
 `_workspace/03b_prose_humanized.md`에 보관 후 HTML에 적용.
 
+### Phase 3.6: seo-check (KO + EN, 게이트 — 항상 호출)
+
+Phase 4(퍼블리싱) 전 **반드시** `seo-check` 스킬로 KO·EN 각 파일의 4계층을 검증한다.
+**4계층 전부 PASS여야 Phase 4로 진행** (report-produce·dc-story-produce와 동일한 게이트).
+
+```
+스킬: .claude/skills/seo-check/SKILL.md
+- KO와 EN 각각 실행 (4계층: 메타 · OG/Twitter · JSON-LD&FAQ · 기술)
+- ⛔ FAQ 게이트: config.faqs 가 있는데 <section id="faq"> 가 HTML에 없으면 FAIL →
+  </main> 앞에 <section id="faq" class="mb-16 fade-in-card"></section> 추가 후 재검.
+  (이 게이트 누락이 blog 글에서 FAQ 미렌더의 원인이었다 — 2026-06-22.)
+```
+
+FAIL 항목은 수정 후 통과할 때까지 재검. 결과는 `_workspace/03c_seo_check.md`에 기록.
+
 ### Phase 4: 퍼블리싱
 
 Phase 3.5 통과 후 blog-publisher 서브 에이전트 실행:

--- a/.claude/skills/pb-story-produce/SKILL.md
+++ b/.claude/skills/pb-story-produce/SKILL.md
@@ -27,6 +27,8 @@ argument-hint: "[주제명] e.g. 'Linux', 'GPS', 'WiFi'"
     ↓
 [Phase 2.5] image-reinforce --auto (KO + EN 각각)
     ↓
+[Phase 2.6] seo-check (KO + EN, 4계층 PASS 게이트 — FAQ placeholder 포함)
+    ↓
 [Phase 3] OG 이미지 생성 (KO + EN)
     ↓
 [Phase 4] articles.json 등록
@@ -156,6 +158,21 @@ Args: story/[slug]-story-pb/en/index.html --auto
 - 실패한 슬롯은 조용히 스킵, 결과만 보고
 - 이미지는 `ko/image/` `en/image/` 에 다운로드 (로컬 저장)
 - 완료 후 오케스트레이터에게 결과 보고
+
+### Phase 2.6: seo-check (KO + EN, 게이트 — 항상 호출)
+
+Phase 3(OG)·이후 발행 전 **반드시** `seo-check` 스킬로 KO·EN 각 파일의 4계층을 검증한다.
+**4계층 전부 PASS여야 진행** (report-produce·dc-story-produce와 동일한 게이트).
+
+```
+스킬: .claude/skills/seo-check/SKILL.md
+- KO와 EN 각각 실행 (4계층: 메타 · OG/Twitter · JSON-LD&FAQ · 기술)
+- ⛔ FAQ 게이트: config.faqs 가 있는데 <section id="faq"> 가 HTML에 없으면 FAIL →
+  </main> 앞에 <section id="faq" class="mb-16 fade-in-card"></section> 추가 후 재검.
+  (이 게이트 누락이 story 글에서 FAQ 미렌더의 원인이었다 — 2026-06-22.)
+```
+
+FAIL 항목은 수정 후 통과할 때까지 재검.
 
 ### Phase 3: OG 이미지 생성
 

--- a/.claude/skills/pebblopedia-produce/skill.md
+++ b/.claude/skills/pebblopedia-produce/skill.md
@@ -96,6 +96,21 @@ Agent(
 )
 ```
 
+### Phase 3.5: seo-check (게이트 — 항상 호출)
+
+Phase 4(퍼블리싱) 전 **반드시** `seo-check` 스킬로 작성된 파일(KO, 있으면 EN)의 4계층을 검증한다.
+**4계층 전부 PASS여야 Phase 4로 진행** (report-produce·dc-story-produce와 동일한 게이트).
+
+```
+스킬: .claude/skills/seo-check/SKILL.md
+- 4계층(메타 · OG/Twitter · JSON-LD&FAQ · 기술) 전부 PASS여야 진행
+- ⛔ FAQ 게이트: config.faqs 가 있는데 <section id="faq"> 가 HTML에 없으면 FAIL →
+  </main> 앞에 <section id="faq" class="mb-16 fade-in-card"></section> 추가 후 재검.
+  (이 게이트 누락이 pebblopedia 글에서 FAQ 미렌더의 원인이었다 — 2026-06-22.)
+```
+
+FAIL 항목은 수정 후 통과할 때까지 재검.
+
 ### Phase 4: 퍼블리싱
 
 Phase 3 완료 후 pebblopedia-publisher 서브 에이전트 실행:


### PR DESCRIPTION
## Summary

자동 동기화 — 진본의 자산 2/3 변경을 사본에 반영.

**Source commit**: joohaeng-pbls/blog-service@c682afc

## 대상 경로

- tools/ — 빌드/배포 도구
- .claude/skills/ — 스킬 (메서드론)
- .claude/agents/ — 에이전트 정의
- CLAUDE.md — 협업 정책
- docs/ — 내부 문서
- .gitattributes — 머지 드라이버 매핑

## ⚠️ Reverse-divergence

보수적 모드(rsync without --delete). 사본에만 있는 파일은 보존, 같은 경로는 진본으로 덮어씀.
머지 전 확인: diff가 사본의 비-동기 변경을 덮어쓰지 않는지.

정책: docs/blog-service/sync.md (in joohaeng-pbls/blog-service)

🤖 Generated automatically by sync-to-sabon.yml
