### PR TITLE
fix(svg): 도식 회색 텍스트·선 대비 개선 (테마 변수화, 23글)

### DIFF
--- a/blog/agibot-world-failure-annotation/en/index.html
+++ b/blog/agibot-world-failure-annotation/en/index.html
@@ -170,12 +170,12 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 700 200" xmlns="http://www.w3.org/2000/svg" class="w-full max-h-[220px] rounded-xl" role="img" aria-label="SayCan's 95% discard pipeline vs AgiBotWorld's full-annotation pipeline">
                             <!-- SayCan side -->
-                            <rect x="10" y="20" width="300" height="160" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="10" y="20" width="300" height="160" rx="10" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="160" y="48" text-anchor="middle" font-size="13" font-weight="600" fill="#64748b">SayCan Approach</text>
-                            <rect x="30" y="60" width="260" height="36" rx="6" fill="#94a3b8"/>
+                            <rect x="30" y="60" width="260" height="36" rx="6" fill="var(--text-secondary)"/>
                             <text x="160" y="82" text-anchor="middle" font-size="12" fill="white">Collect: 276,000 episodes</text>
                             <rect x="30" y="108" width="200" height="28" rx="6" fill="#e2e8f0"/>
-                            <text x="130" y="126" text-anchor="middle" font-size="11" fill="#94a3b8">Discard: 264,000 (95%+)</text>
+                            <text x="130" y="126" text-anchor="middle" font-size="11" fill="var(--text-secondary)">Discard: 264,000 (95%+)</text>
                             <rect x="30" y="148" width="80" height="24" rx="6" fill="#475569"/>
                             <text x="70" y="163" text-anchor="middle" font-size="11" fill="white">Keep 12k</text>
                             <!-- Arrow -->
@@ -183,7 +183,7 @@
                             <!-- AgiBotWorld side -->
                             <rect x="390" y="20" width="300" height="160" rx="10" fill="#fff7ed" stroke="#F86825" stroke-width="1.5"/>
                             <text x="540" y="48" text-anchor="middle" font-size="13" font-weight="600" fill="#F86825">AgiBotWorld Approach</text>
-                            <rect x="410" y="60" width="260" height="36" rx="6" fill="#94a3b8"/>
+                            <rect x="410" y="60" width="260" height="36" rx="6" fill="var(--text-secondary)"/>
                             <text x="540" y="82" text-anchor="middle" font-size="12" fill="white">Collect: 1M+ trajectories</text>
                             <rect x="410" y="108" width="260" height="28" rx="6" fill="#F86825" opacity="0.15"/>
                             <text x="540" y="126" text-anchor="middle" font-size="11" fill="#c2410c">Annotate: error_cause · restorable</text>
@@ -273,15 +273,15 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 700 180" xmlns="http://www.w3.org/2000/svg" class="w-full max-h-[200px] rounded-xl" role="img" aria-label="Shift in clean data definition: from success-only filtering to full task-coverage annotation">
                             <!-- Old definition -->
-                            <rect x="10" y="20" width="300" height="140" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="10" y="20" width="300" height="140" rx="10" fill="#f8fafc" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="160" y="46" text-anchor="middle" font-size="13" font-weight="600" fill="#64748b">Old Definition</text>
-                            <text x="160" y="62" text-anchor="middle" font-size="11" fill="#94a3b8">Clean = successful demos only</text>
-                            <circle cx="60" cy="110" r="28" fill="#94a3b8" opacity="0.3"/>
+                            <text x="160" y="62" text-anchor="middle" font-size="11" fill="var(--text-secondary)">Clean = successful demos only</text>
+                            <circle cx="60" cy="110" r="28" fill="var(--text-secondary)" opacity="0.3"/>
                             <text x="60" y="115" text-anchor="middle" font-size="10" fill="#64748b">Success</text>
-                            <circle cx="130" cy="110" r="22" fill="#94a3b8" opacity="0.15"/>
-                            <text x="130" y="115" text-anchor="middle" font-size="9" fill="#94a3b8" opacity="0.5">Failure</text>
-                            <circle cx="200" cy="110" r="18" fill="#94a3b8" opacity="0.1"/>
-                            <text x="200" y="115" text-anchor="middle" font-size="9" fill="#94a3b8" opacity="0.3">Recovery</text>
+                            <circle cx="130" cy="110" r="22" fill="var(--text-secondary)" opacity="0.15"/>
+                            <text x="130" y="115" text-anchor="middle" font-size="9" fill="var(--text-secondary)" opacity="0.5">Failure</text>
+                            <circle cx="200" cy="110" r="18" fill="var(--text-secondary)" opacity="0.1"/>
+                            <text x="200" y="115" text-anchor="middle" font-size="9" fill="var(--text-secondary)" opacity="0.3">Recovery</text>
                             <rect x="30" y="142" width="80" height="4" rx="2" fill="#475569"/>
                             <text x="70" y="160" text-anchor="middle" font-size="10" fill="#64748b">Filter, then keep</text>
                             <!-- Arrow -->

--- a/blog/agibot-world-failure-annotation/ko/index.html
+++ b/blog/agibot-world-failure-annotation/ko/index.html
@@ -170,12 +170,12 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 700 200" xmlns="http://www.w3.org/2000/svg" class="w-full max-h-[220px] rounded-xl" role="img" aria-label="SayCan의 95% 폐기 파이프라인과 AgiBotWorld의 전체 주석 파이프라인 비교">
                             <!-- SayCan side -->
-                            <rect x="10" y="20" width="300" height="160" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="10" y="20" width="300" height="160" rx="10" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="160" y="48" text-anchor="middle" font-size="13" font-weight="600" fill="#64748b">SayCan 방식</text>
-                            <rect x="30" y="60" width="260" height="36" rx="6" fill="#94a3b8"/>
+                            <rect x="30" y="60" width="260" height="36" rx="6" fill="var(--text-secondary)"/>
                             <text x="160" y="82" text-anchor="middle" font-size="12" fill="white">수집: 276,000개 에피소드</text>
                             <rect x="30" y="108" width="200" height="28" rx="6" fill="#e2e8f0"/>
-                            <text x="130" y="126" text-anchor="middle" font-size="11" fill="#94a3b8">폐기: 264,000개 (95%+)</text>
+                            <text x="130" y="126" text-anchor="middle" font-size="11" fill="var(--text-secondary)">폐기: 264,000개 (95%+)</text>
                             <rect x="30" y="148" width="80" height="24" rx="6" fill="#475569"/>
                             <text x="70" y="163" text-anchor="middle" font-size="11" fill="white">12k 유지</text>
                             <!-- Arrow -->
@@ -183,7 +183,7 @@
                             <!-- AgiBotWorld side -->
                             <rect x="390" y="20" width="300" height="160" rx="10" fill="#fff7ed" stroke="#F86825" stroke-width="1.5"/>
                             <text x="540" y="48" text-anchor="middle" font-size="13" font-weight="600" fill="#F86825">AgiBotWorld 방식</text>
-                            <rect x="410" y="60" width="260" height="36" rx="6" fill="#94a3b8"/>
+                            <rect x="410" y="60" width="260" height="36" rx="6" fill="var(--text-secondary)"/>
                             <text x="540" y="82" text-anchor="middle" font-size="12" fill="white">수집: 1M+ 트라젝토리</text>
                             <rect x="410" y="108" width="260" height="28" rx="6" fill="#F86825" opacity="0.15"/>
                             <text x="540" y="126" text-anchor="middle" font-size="11" fill="#c2410c">주석: error_cause · restorable</text>
@@ -273,15 +273,15 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 700 180" xmlns="http://www.w3.org/2000/svg" class="w-full max-h-[200px] rounded-xl" role="img" aria-label="클린 데이터 정의의 전환: 성공 시연 선별 방식에서 태스크 전체 커버리지 방식으로">
                             <!-- Old definition -->
-                            <rect x="10" y="20" width="300" height="140" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="10" y="20" width="300" height="140" rx="10" fill="#f8fafc" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="160" y="46" text-anchor="middle" font-size="13" font-weight="600" fill="#64748b">기존 정의</text>
-                            <text x="160" y="62" text-anchor="middle" font-size="11" fill="#94a3b8">클린 = 성공 시연</text>
-                            <circle cx="60" cy="110" r="28" fill="#94a3b8" opacity="0.3"/>
+                            <text x="160" y="62" text-anchor="middle" font-size="11" fill="var(--text-secondary)">클린 = 성공 시연</text>
+                            <circle cx="60" cy="110" r="28" fill="var(--text-secondary)" opacity="0.3"/>
                             <text x="60" y="115" text-anchor="middle" font-size="10" fill="#64748b">성공</text>
-                            <circle cx="130" cy="110" r="22" fill="#94a3b8" opacity="0.15"/>
-                            <text x="130" y="115" text-anchor="middle" font-size="9" fill="#94a3b8" opacity="0.5">실패</text>
-                            <circle cx="200" cy="110" r="18" fill="#94a3b8" opacity="0.1"/>
-                            <text x="200" y="115" text-anchor="middle" font-size="9" fill="#94a3b8" opacity="0.3">회복</text>
+                            <circle cx="130" cy="110" r="22" fill="var(--text-secondary)" opacity="0.15"/>
+                            <text x="130" y="115" text-anchor="middle" font-size="9" fill="var(--text-secondary)" opacity="0.5">실패</text>
+                            <circle cx="200" cy="110" r="18" fill="var(--text-secondary)" opacity="0.1"/>
+                            <text x="200" y="115" text-anchor="middle" font-size="9" fill="var(--text-secondary)" opacity="0.3">회복</text>
                             <rect x="30" y="142" width="80" height="4" rx="2" fill="#475569"/>
                             <text x="70" y="160" text-anchor="middle" font-size="10" fill="#64748b">선별 후 유지</text>
                             <!-- Arrow -->

--- a/blog/ai-agent-cfaa-criminal-liability/en/index.html
+++ b/blog/ai-agent-cfaa-criminal-liability/en/index.html
@@ -238,25 +238,25 @@
                           </defs>
                           <rect width="660" height="260" fill="#f8fafc" rx="12"/>
                           <text x="330" y="26" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#334155">Accountability Attribution When an Autonomous Agent Acts</text>
-                          <rect x="18" y="48" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="48" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="71" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#334155">Developer</text>
-                          <rect x="18" y="96" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="96" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="119" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#334155">Deployer</text>
-                          <rect x="18" y="144" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="144" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="167" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#334155">Operator</text>
-                          <rect x="18" y="192" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="192" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="215" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#334155">End User</text>
-                          <line x1="158" y1="66" x2="298" y2="130" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
-                          <line x1="158" y1="114" x2="298" y2="138" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
-                          <line x1="158" y1="162" x2="298" y2="148" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
-                          <line x1="158" y1="210" x2="298" y2="158" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
+                          <line x1="158" y1="66" x2="298" y2="130" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
+                          <line x1="158" y1="114" x2="298" y2="138" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
+                          <line x1="158" y1="162" x2="298" y2="148" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
+                          <line x1="158" y1="210" x2="298" y2="158" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#en-fwd)"/>
                           <text x="228" y="94" text-anchor="middle" font-family="Outfit,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="226" y="125" text-anchor="middle" font-family="Outfit,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="226" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="228" y="192" text-anchor="middle" font-family="Outfit,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <rect x="295" y="118" width="130" height="48" rx="10" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="360" y="139" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#F86825">AI Agent</text>
-                          <text x="360" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">autonomous action</text>
+                          <text x="360" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">autonomous action</text>
                           <line x1="425" y1="142" x2="480" y2="142" stroke="#ef4444" stroke-width="2" marker-end="url(#en-red)"/>
                           <rect x="480" y="118" width="162" height="48" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
                           <text x="561" y="137" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#dc2626">Unauthorized Access</text>
@@ -303,26 +303,26 @@
                           <text x="330" y="24" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#334155">Action Provenance Graph</text>
                           <rect x="15" y="42" width="100" height="44" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="65" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" font-weight="700" fill="#F86825">Prompt</text>
-                          <text x="65" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">human instruction</text>
-                          <line x1="115" y1="64" x2="148" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#en-apg)"/>
-                          <rect x="150" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="65" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">human instruction</text>
+                          <line x1="115" y1="64" x2="148" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-apg)"/>
+                          <rect x="150" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="200" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#334155">Plan</text>
-                          <text x="200" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">agent-generated</text>
-                          <line x1="250" y1="64" x2="283" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#en-apg)"/>
-                          <rect x="285" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="200" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">agent-generated</text>
+                          <line x1="250" y1="64" x2="283" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-apg)"/>
+                          <rect x="285" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="335" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#334155">Tool Call</text>
-                          <text x="335" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">external system access</text>
-                          <line x1="385" y1="64" x2="418" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#en-apg)"/>
-                          <rect x="420" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="335" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">external system access</text>
+                          <line x1="385" y1="64" x2="418" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-apg)"/>
+                          <rect x="420" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="470" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#334155">Reasoning</text>
-                          <text x="470" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">intermediate state</text>
-                          <line x1="520" y1="64" x2="543" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#en-apg)"/>
+                          <text x="470" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">intermediate state</text>
+                          <line x1="520" y1="64" x2="543" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-apg)"/>
                           <rect x="545" y="42" width="100" height="44" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="595" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" font-weight="700" fill="#F86825">Result</text>
-                          <text x="595" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">action complete</text>
+                          <text x="595" y="78" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">action complete</text>
                           <line x1="612" y1="106" x2="48" y2="106" stroke="#F86825" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#en-apg-back)"/>
                           <text x="330" y="124" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#F86825">← causal path traceable backward (the basis for accountability attribution)</text>
-                          <text x="330" y="168" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Contemporaneous, complete, immutable records preserve this chain | Pebblous original diagram (APG concept reinterpretation)</text>
+                          <text x="330" y="168" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Contemporaneous, complete, immutable records preserve this chain | Pebblous original diagram (APG concept reinterpretation)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ The Action Provenance Graph preserves the causal chain from prompt to result, making it possible to trace "whose decision this action originated from" after the fact. | Pebblous original diagram (APG concept reinterpretation)

--- a/blog/ai-agent-cfaa-criminal-liability/ko/index.html
+++ b/blog/ai-agent-cfaa-criminal-liability/ko/index.html
@@ -238,25 +238,25 @@
                           </defs>
                           <rect width="660" height="260" fill="#f8fafc" rx="12"/>
                           <text x="330" y="26" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="700" fill="#334155">자율 에이전트 작동 시 책임의 귀속 지점</text>
-                          <rect x="18" y="48" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="48" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="71" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#334155">설계자 (Developer)</text>
-                          <rect x="18" y="96" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="96" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="119" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#334155">배포자 (Deployer)</text>
-                          <rect x="18" y="144" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="144" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="167" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#334155">운영자 (Operator)</text>
-                          <rect x="18" y="192" width="140" height="36" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <rect x="18" y="192" width="140" height="36" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="88" y="215" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#334155">최종 이용자 (End User)</text>
-                          <line x1="158" y1="66" x2="298" y2="130" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
-                          <line x1="158" y1="114" x2="298" y2="138" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
-                          <line x1="158" y1="162" x2="298" y2="148" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
-                          <line x1="158" y1="210" x2="298" y2="158" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
+                          <line x1="158" y1="66" x2="298" y2="130" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
+                          <line x1="158" y1="114" x2="298" y2="138" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
+                          <line x1="158" y1="162" x2="298" y2="148" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
+                          <line x1="158" y1="210" x2="298" y2="158" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#ko-fwd)"/>
                           <text x="228" y="94" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="226" y="125" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="226" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <text x="228" y="192" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="16" font-weight="800" fill="#F86825">?</text>
                           <rect x="295" y="118" width="130" height="48" rx="10" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="360" y="139" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="700" fill="#F86825">AI 에이전트</text>
-                          <text x="360" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">자율 실행</text>
+                          <text x="360" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">자율 실행</text>
                           <line x1="425" y1="142" x2="480" y2="142" stroke="#ef4444" stroke-width="2" marker-end="url(#ko-red)"/>
                           <rect x="480" y="118" width="162" height="48" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
                           <text x="561" y="137" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" font-weight="600" fill="#dc2626">무단 시스템 접근</text>
@@ -303,26 +303,26 @@
                           <text x="330" y="24" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="700" fill="#334155">행동 출처 그래프 (Action Provenance Graph)</text>
                           <rect x="15" y="42" width="100" height="44" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="65" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" font-weight="700" fill="#F86825">프롬프트</text>
-                          <text x="65" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">사람의 지시</text>
-                          <line x1="115" y1="64" x2="148" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#ko-apg)"/>
-                          <rect x="150" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="65" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">사람의 지시</text>
+                          <line x1="115" y1="64" x2="148" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-apg)"/>
+                          <rect x="150" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="200" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#334155">계획</text>
-                          <text x="200" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">에이전트 생성</text>
-                          <line x1="250" y1="64" x2="283" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#ko-apg)"/>
-                          <rect x="285" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="200" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">에이전트 생성</text>
+                          <line x1="250" y1="64" x2="283" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-apg)"/>
+                          <rect x="285" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="335" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#334155">도구 호출</text>
-                          <text x="335" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">외부 시스템 접근</text>
-                          <line x1="385" y1="64" x2="418" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#ko-apg)"/>
-                          <rect x="420" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                          <text x="335" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">외부 시스템 접근</text>
+                          <line x1="385" y1="64" x2="418" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-apg)"/>
+                          <rect x="420" y="42" width="100" height="44" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                           <text x="470" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#334155">추론 상태</text>
-                          <text x="470" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">중간 과정</text>
-                          <line x1="520" y1="64" x2="543" y2="64" stroke="#475569" stroke-width="1.5" marker-end="url(#ko-apg)"/>
+                          <text x="470" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">중간 과정</text>
+                          <line x1="520" y1="64" x2="543" y2="64" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-apg)"/>
                           <rect x="545" y="42" width="100" height="44" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="2"/>
                           <text x="595" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" font-weight="700" fill="#F86825">최종 결과</text>
-                          <text x="595" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">행위 완료</text>
+                          <text x="595" y="78" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">행위 완료</text>
                           <line x1="612" y1="106" x2="48" y2="106" stroke="#F86825" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#ko-apg-back)"/>
                           <text x="330" y="124" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#F86825">← 인과 경로 역추적 가능 (책임 귀속의 근거)</text>
-                          <text x="330" y="168" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">동시적·완전·불변 기록이 이 사슬을 보존한다 | 페블러스 원본 도식 (APG 개념 재해석)</text>
+                          <text x="330" y="168" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">동시적·완전·불변 기록이 이 사슬을 보존한다 | 페블러스 원본 도식 (APG 개념 재해석)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ 행동 출처 그래프: 프롬프트에서 최종 결과까지 인과 사슬을 보존해 '누가 무엇을 왜 했는지' 사후 추적을 가능하게 한다. | 페블러스 원본 도식 (APG 개념 재해석)

--- a/blog/ai-personality-measurement-artifact/en/index.html
+++ b/blog/ai-personality-measurement-artifact/en/index.html
@@ -193,19 +193,19 @@
                     <!-- Pebblous original diagram: forward–reverse response correlation -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 195" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" aria-label="Comparison of forward–reverse item response correlations between humans and LLMs">
-                            <line x1="60" y1="105" x2="600" y2="105" stroke="#94a3b8" stroke-width="1.5"/>
+                            <line x1="60" y1="105" x2="600" y2="105" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <line x1="330" y1="55" x2="330" y2="145" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="4,4"/>
-                            <line x1="60" y1="100" x2="60" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <line x1="195" y1="102" x2="195" y2="108" stroke="#cbd5e1" stroke-width="1"/>
-                            <line x1="330" y1="100" x2="330" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <line x1="465" y1="102" x2="465" y2="108" stroke="#cbd5e1" stroke-width="1"/>
-                            <line x1="600" y1="100" x2="600" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="60" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#94a3b8">&#x2212;1.0</text>
+                            <line x1="60" y1="100" x2="60" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <line x1="195" y1="102" x2="195" y2="108" stroke="var(--text-muted)" stroke-width="1"/>
+                            <line x1="330" y1="100" x2="330" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <line x1="465" y1="102" x2="465" y2="108" stroke="var(--text-muted)" stroke-width="1"/>
+                            <line x1="600" y1="100" x2="600" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="60" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="var(--text-secondary)">&#x2212;1.0</text>
                             <text x="195" y="123" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#cbd5e1">&#x2212;0.5</text>
-                            <text x="330" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#94a3b8">0</text>
+                            <text x="330" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="var(--text-secondary)">0</text>
                             <text x="465" y="123" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#cbd5e1">+0.5</text>
-                            <text x="600" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#94a3b8">+1.0</text>
-                            <line x1="109" y1="105" x2="144" y2="105" stroke="#475569" stroke-width="8" stroke-linecap="round"/>
+                            <text x="600" y="124" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="var(--text-secondary)">+1.0</text>
+                            <line x1="109" y1="105" x2="144" y2="105" stroke="var(--text-muted)" stroke-width="8" stroke-linecap="round"/>
                             <circle cx="126" cy="105" r="11" fill="#475569"/>
                             <text x="126" y="68" text-anchor="middle" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#334155">Humans</text>
                             <text x="126" y="82" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#64748b">&#x2212;0.69 to &#x2212;0.82</text>
@@ -217,7 +217,7 @@
                             <text x="126" y="160" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#475569">&#x2192; Consistent personality</text>
                             <text x="522" y="147" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#F86825">Responses go the same way</text>
                             <text x="522" y="160" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#c2410c">&#x2192; Consistent response habit</text>
-                            <text x="330" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#94a3b8">Pearson r: forward &#xD7; reverse item responses</text>
+                            <text x="330" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="var(--text-secondary)">Pearson r: forward &#xD7; reverse item responses</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             &#x25B2; Pebblous original diagram (reinterpretation of Fig. 2) &#x2014; Humans: negative correlation (personality consistent); LLMs: positive correlation (response habit consistent) | Source: <a href="https://arxiv.org/abs/2606.20205" target="_blank" rel="noopener" class="underline">Meyer et al. (2026)</a>
@@ -234,7 +234,7 @@
                             <text x="330" y="26" text-anchor="middle" font-family="Outfit, sans-serif" font-size="13" font-weight="600" fill="#475569">What Drives Between-Model Personality Differences</text>
                             <text x="110" y="84" text-anchor="end" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#F86825">LLM</text>
                             <rect x="118" y="70" width="391" height="24" rx="3" fill="#F86825" opacity="0.88"/>
-                            <rect x="509" y="70" width="69" height="24" rx="3" fill="#94a3b8" opacity="0.65"/>
+                            <rect x="509" y="70" width="69" height="24" rx="3" fill="var(--text-secondary)" opacity="0.65"/>
                             <text x="313" y="86" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="600" fill="white">Response bias 81&#x2013;90%</text>
                             <text x="543" y="86" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="white">Trait</text>
                             <text x="110" y="134" text-anchor="end" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#334155">Humans</text>
@@ -244,11 +244,11 @@
                             <text x="375" y="136" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="white">Genuine trait 84&#x2013;91%</text>
                             <text x="330" y="168" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#F86825">81&#x2013;90% of LLM differences are bias &#x2014; only 9&#x2013;16% for humans</text>
                             <line x1="118" y1="153" x2="578" y2="153" stroke="#e2e8f0" stroke-width="0.5"/>
-                            <text x="118" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#94a3b8">0%</text>
-                            <text x="578" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#94a3b8">100%</text>
+                            <text x="118" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="var(--text-secondary)">0%</text>
+                            <text x="578" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="var(--text-secondary)">100%</text>
                             <rect x="225" y="185" width="12" height="8" rx="2" fill="#F86825" opacity="0.88"/>
                             <text x="243" y="193" font-family="Outfit, sans-serif" font-size="10" fill="#64748b">Response bias</text>
-                            <rect x="355" y="185" width="12" height="8" rx="2" fill="#94a3b8" opacity="0.65"/>
+                            <rect x="355" y="185" width="12" height="8" rx="2" fill="var(--text-secondary)" opacity="0.65"/>
                             <text x="373" y="193" font-family="Outfit, sans-serif" font-size="10" fill="#64748b">Genuine trait</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
@@ -277,22 +277,22 @@
                     <!-- Pebblous original diagram: profile divergence under item direction change -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 195" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" aria-label="The same model measured with forward-only vs reverse-only items drifts up to 0.99 standard deviations apart">
-                            <rect x="240" y="118" width="180" height="50" rx="8" fill="rgba(71,85,105,0.10)" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="240" y="118" width="180" height="50" rx="8" fill="rgba(71,85,105,0.10)" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="139" text-anchor="middle" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#475569">Same model</text>
                             <text x="330" y="156" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#64748b">Depending on which items are chosen</text>
-                            <rect x="30" y="20" width="200" height="50" rx="8" fill="rgba(148,163,184,0.08)" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="30" y="20" width="200" height="50" rx="8" fill="rgba(148,163,184,0.08)" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="130" y="42" text-anchor="middle" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#475569">Forward items only</text>
                             <text x="130" y="58" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#64748b">Profile A</text>
                             <rect x="430" y="20" width="200" height="50" rx="8" fill="rgba(248,104,37,0.07)" stroke="#F86825" stroke-width="1.5"/>
                             <text x="530" y="42" text-anchor="middle" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#F86825">Reverse items only</text>
                             <text x="530" y="58" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" fill="#c2410c">Profile B</text>
-                            <line x1="265" y1="120" x2="180" y2="72" stroke="#94a3b8" stroke-width="1.5"/>
+                            <line x1="265" y1="120" x2="180" y2="72" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <line x1="395" y1="120" x2="480" y2="72" stroke="#F86825" stroke-width="1.5"/>
                             <polygon points="230,96 242,90 242,102" fill="#F86825"/>
                             <polygon points="430,96 418,90 418,102" fill="#F86825"/>
                             <line x1="242" y1="96" x2="418" y2="96" stroke="#F86825" stroke-width="1.5" stroke-dasharray="5,3"/>
                             <text x="330" y="88" text-anchor="middle" font-family="Outfit, sans-serif" font-size="12" font-weight="700" fill="#F86825">Up to 0.99 SD apart</text>
-                            <text x="330" y="183" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="#94a3b8">Same model &#xB7; same trait &#xB7; different item direction &#x2192; different score</text>
+                            <text x="330" y="183" text-anchor="middle" font-family="Outfit, sans-serif" font-size="10" fill="var(--text-secondary)">Same model &#xB7; same trait &#xB7; different item direction &#x2192; different score</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             &#x25B2; Pebblous original diagram (reinterpretation of Fig. 4) &#x2014; Measuring the same model with forward-only vs. reverse-only items produces profiles up to 0.99 SD apart | Source: <a href="https://arxiv.org/abs/2606.20205" target="_blank" rel="noopener" class="underline">Meyer et al. (2026)</a>

--- a/blog/ai-personality-measurement-artifact/ko/index.html
+++ b/blog/ai-personality-measurement-artifact/ko/index.html
@@ -193,19 +193,19 @@
                     <!-- 페블러스 원본 도식: 정반향 응답 상관 비교 -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 195" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" aria-label="인간과 LLM의 순방향-역방향 문항 응답 상관 비교">
-                            <line x1="60" y1="105" x2="600" y2="105" stroke="#94a3b8" stroke-width="1.5"/>
+                            <line x1="60" y1="105" x2="600" y2="105" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <line x1="330" y1="55" x2="330" y2="145" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="4,4"/>
-                            <line x1="60" y1="100" x2="60" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <line x1="195" y1="102" x2="195" y2="108" stroke="#cbd5e1" stroke-width="1"/>
-                            <line x1="330" y1="100" x2="330" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <line x1="465" y1="102" x2="465" y2="108" stroke="#cbd5e1" stroke-width="1"/>
-                            <line x1="600" y1="100" x2="600" y2="110" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="60" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#94a3b8">&#x2212;1.0</text>
+                            <line x1="60" y1="100" x2="60" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <line x1="195" y1="102" x2="195" y2="108" stroke="var(--text-muted)" stroke-width="1"/>
+                            <line x1="330" y1="100" x2="330" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <line x1="465" y1="102" x2="465" y2="108" stroke="var(--text-muted)" stroke-width="1"/>
+                            <line x1="600" y1="100" x2="600" y2="110" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="60" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="var(--text-secondary)">&#x2212;1.0</text>
                             <text x="195" y="123" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#cbd5e1">&#x2212;0.5</text>
-                            <text x="330" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#94a3b8">0</text>
+                            <text x="330" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="var(--text-secondary)">0</text>
                             <text x="465" y="123" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#cbd5e1">+0.5</text>
-                            <text x="600" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#94a3b8">+1.0</text>
-                            <line x1="109" y1="105" x2="144" y2="105" stroke="#475569" stroke-width="8" stroke-linecap="round"/>
+                            <text x="600" y="124" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="var(--text-secondary)">+1.0</text>
+                            <line x1="109" y1="105" x2="144" y2="105" stroke="var(--text-muted)" stroke-width="8" stroke-linecap="round"/>
                             <circle cx="126" cy="105" r="11" fill="#475569"/>
                             <text x="126" y="68" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#334155">&#xC778;&#xAC04;</text>
                             <text x="126" y="82" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#64748b">&#x2212;0.69 ~ &#x2212;0.82</text>
@@ -217,7 +217,7 @@
                             <text x="126" y="160" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#475569">&#x2192; &#xC131;&#xD5A5;&#xC774; &#xC77C;&#xAD00;&#xB428;</text>
                             <text x="522" y="147" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#F86825">&#xC751;&#xB2F5;&#xC774; &#xAC19;&#xC740; &#xBC29;&#xD5A5;&#xC73C;&#xB85C; &#xAC04;&#xB2E4;</text>
                             <text x="522" y="160" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#c2410c">&#x2192; &#xC751;&#xB2F5; &#xC2B5;&#xAD00;&#xC774; &#xC77C;&#xAD00;&#xB428;</text>
-                            <text x="330" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#94a3b8">&#xC21C;&#xBC29;&#xD5A5;&#xB294;&#xC5ED;&#xBC29;&#xD5A5; &#xBB38;&#xD56D; &#xC751;&#xB2F5; &#xC0C1;&#xAD00;&#xACC4;&#xC218; r</text>
+                            <text x="330" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="var(--text-secondary)">&#xC21C;&#xBC29;&#xD5A5;&#xB294;&#xC5ED;&#xBC29;&#xD5A5; &#xBB38;&#xD56D; &#xC751;&#xB2F5; &#xC0C1;&#xAD00;&#xACC4;&#xC218; r</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             &#x25B2; &#xD398;&#xBE14;&#xB7EC;&#xC2A4; &#xC6D0;&#xBCF8; &#xB3C4;&#xC2DD; (Fig. 2 &#xC7AC;&#xD574;&#xC11D;) &#x2014; &#xC778;&#xAC04;&#xC740; &#xC74C;&#xC758; &#xC0C1;&#xAD00;(&#xC131;&#xD5A5; &#xC77C;&#xAD00;), LLM&#xC740; &#xC591;&#xC758; &#xC0C1;&#xAD00;(&#xC751;&#xB2F5; &#xC2B5;&#xAD00; &#xC77C;&#xAD00;) | &#xCD9C;&#xCC98;: <a href="https://arxiv.org/abs/2606.20205" target="_blank" rel="noopener" class="underline">Meyer et al. (2026)</a>
@@ -234,7 +234,7 @@
                             <text x="330" y="26" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="13" font-weight="600" fill="#475569">LLM vs. &#xC778;&#xAC04; &#xC131;&#xACA9; &#xCC28;&#xC774;&#xC758; &#xAD6C;&#xC131;</text>
                             <text x="110" y="84" text-anchor="end" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#F86825">LLM</text>
                             <rect x="118" y="70" width="391" height="24" rx="3" fill="#F86825" opacity="0.88"/>
-                            <rect x="509" y="70" width="69" height="24" rx="3" fill="#94a3b8" opacity="0.65"/>
+                            <rect x="509" y="70" width="69" height="24" rx="3" fill="var(--text-secondary)" opacity="0.65"/>
                             <text x="313" y="86" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" font-weight="600" fill="white">&#xC751;&#xB2F5; &#xD3B8;&#xD5A5; 81~90%</text>
                             <text x="543" y="86" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="white">&#xC131;&#xD5A5;</text>
                             <text x="110" y="134" text-anchor="end" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#334155">&#xC778;&#xAC04;</text>
@@ -244,11 +244,11 @@
                             <text x="375" y="136" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="white">&#xC131;&#xD5A5;(&#xC9C4;&#xC131; &#xD2B9;&#xC131;) 84~91%</text>
                             <text x="330" y="168" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#F86825">LLM &#xCC28;&#xC774;&#xC758; 81~90%&#xAC00; &#xD3B8;&#xD5A5; &#x2014; &#xC778;&#xAC04;&#xC740; 9~16%&#xB9CC; &#xD3B8;&#xD5A5;</text>
                             <line x1="118" y1="153" x2="578" y2="153" stroke="#e2e8f0" stroke-width="0.5"/>
-                            <text x="118" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#94a3b8">0%</text>
-                            <text x="578" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#94a3b8">100%</text>
+                            <text x="118" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="var(--text-secondary)">0%</text>
+                            <text x="578" y="182" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="var(--text-secondary)">100%</text>
                             <rect x="240" y="185" width="12" height="8" rx="2" fill="#F86825" opacity="0.88"/>
                             <text x="258" y="193" font-family="Pretendard, sans-serif" font-size="10" fill="#64748b">&#xC751;&#xB2F5; &#xD3B8;&#xD5A5;</text>
-                            <rect x="340" y="185" width="12" height="8" rx="2" fill="#94a3b8" opacity="0.65"/>
+                            <rect x="340" y="185" width="12" height="8" rx="2" fill="var(--text-secondary)" opacity="0.65"/>
                             <text x="358" y="193" font-family="Pretendard, sans-serif" font-size="10" fill="#64748b">&#xC131;&#xD5A5;</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
@@ -277,22 +277,22 @@
                     <!-- 페블러스 원본 도식: 문항 방향 선택에 따른 프로파일 분기 -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 195" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" aria-label="동일 모델에 순방향 문항만 vs 역방향 문항만 사용했을 때 최대 0.99 표준편차 프로파일 분기">
-                            <rect x="240" y="118" width="180" height="50" rx="8" fill="rgba(71,85,105,0.10)" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="240" y="118" width="180" height="50" rx="8" fill="rgba(71,85,105,0.10)" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="139" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#475569">&#xAC19;&#xC740; &#xBAA8;&#xB378;</text>
                             <text x="330" y="156" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#64748b">&#xC5B4;&#xB5A4; &#xBB38;&#xD56D;&#xC744; &#xACE0;&#xB974;&#xB290;&#xB0D0;&#xC5D0; &#xB530;&#xB77C;</text>
-                            <rect x="30" y="20" width="200" height="50" rx="8" fill="rgba(148,163,184,0.08)" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="30" y="20" width="200" height="50" rx="8" fill="rgba(148,163,184,0.08)" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="130" y="42" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#475569">&#xC21C;&#xBC29;&#xD5A5; &#xBB38;&#xD56D;&#xB9CC;</text>
                             <text x="130" y="58" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#64748b">&#xD504;&#xB85C;&#xD30C;&#xC77C; A</text>
                             <rect x="430" y="20" width="200" height="50" rx="8" fill="rgba(248,104,37,0.07)" stroke="#F86825" stroke-width="1.5"/>
                             <text x="530" y="42" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#F86825">&#xC5ED;&#xBC29;&#xD5A5; &#xBB38;&#xD56D;&#xB9CC;</text>
                             <text x="530" y="58" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="11" fill="#c2410c">&#xD504;&#xB85C;&#xD30C;&#xC77C; B</text>
-                            <line x1="265" y1="120" x2="180" y2="72" stroke="#94a3b8" stroke-width="1.5"/>
+                            <line x1="265" y1="120" x2="180" y2="72" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <line x1="395" y1="120" x2="480" y2="72" stroke="#F86825" stroke-width="1.5"/>
                             <polygon points="230,96 242,90 242,102" fill="#F86825"/>
                             <polygon points="430,96 418,90 418,102" fill="#F86825"/>
                             <line x1="242" y1="96" x2="418" y2="96" stroke="#F86825" stroke-width="1.5" stroke-dasharray="5,3"/>
                             <text x="330" y="88" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="12" font-weight="700" fill="#F86825">&#xCD5C;&#xB300; 0.99 &#xD45C;&#xC900;&#xD3B8;&#xCC28; &#xCC28;&#xC774;</text>
-                            <text x="330" y="183" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="#94a3b8">&#xAC19;&#xC740; &#xBAA8;&#xB378; &#xB300;&#xC2DC; &#xAC19;&#xC740; &#xD2B9;&#xC131; &#xB300;&#xC2DC; &#xB2E4;&#xB978; &#xBB38;&#xD56D; &#xBC29;&#xD5A5; &#x2192; &#xB2E4;&#xB978; &#xCE21;&#xC815;&#xAC12;</text>
+                            <text x="330" y="183" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="10" fill="var(--text-secondary)">&#xAC19;&#xC740; &#xBAA8;&#xB378; &#xB300;&#xC2DC; &#xAC19;&#xC740; &#xD2B9;&#xC131; &#xB300;&#xC2DC; &#xB2E4;&#xB978; &#xBB38;&#xD56D; &#xBC29;&#xD5A5; &#x2192; &#xB2E4;&#xB978; &#xCE21;&#xC815;&#xAC12;</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             &#x25B2; &#xD398;&#xBE14;&#xB7EC;&#xC2A4; &#xC6D0;&#xBCF8; &#xB3C4;&#xC2DD; (Fig. 4 &#xC7AC;&#xD574;&#xC11D;) &#x2014; &#xB3D9;&#xC77C; &#xBAA8;&#xB378;&#xC744; &#xC21C;&#xBC29;&#xD5A5;&#xB290;&#xC5ED;&#xBC29;&#xD5A5; &#xBB38;&#xD56D;&#xB9CC;&#xC73C;&#xB85C; &#xCE21;&#xC815;&#xD558;&#xBA74; &#xD504;&#xB85C;&#xD30C;&#xC77C;&#xC774; &#xCD5C;&#xB300; 0.99 SD &#xB2EC;&#xB77C;&#xC9C4;&#xB2E4; | &#xCD9C;&#xCC98;: <a href="https://arxiv.org/abs/2606.20205" target="_blank" rel="noopener" class="underline">Meyer et al. (2026)</a>

--- a/blog/anthropic-fable-mythos-export-control-model-risk/en/index.html
+++ b/blog/anthropic-fable-mythos-export-control-model-risk/en/index.html
@@ -273,28 +273,28 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="210" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">The three risks of a 'model subscription' — all triggered outside the enterprise's control</text>
+                            <text x="330" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">The three risks of a 'model subscription' — all triggered outside the enterprise's control</text>
                             <rect x="18" y="40" width="200" height="150" rx="8" fill="white" stroke="#F86825" stroke-width="2"/>
                             <text x="118" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#F86825" font-weight="700">① Regulatory · Geopolitical</text>
                             <text x="118" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">This event</text>
                             <text x="118" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Export controls · sanctions</text>
                             <text x="118" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Data-residency rules</text>
                             <text x="118" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Regional licensing</text>
-                            <text x="118" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">No notice · zero prep time</text>
-                            <rect x="230" y="40" width="200" height="150" rx="8" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <text x="118" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">No notice · zero prep time</text>
+                            <rect x="230" y="40" width="200" height="150" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#475569" font-weight="700">② Operational</text>
                             <text x="330" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">Provider dependence</text>
                             <text x="330" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Outages · capacity limits</text>
                             <text x="330" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Pricing changes</text>
                             <text x="330" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">SLA shortfalls</text>
-                            <text x="330" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">Provider's schedule · no user control</text>
-                            <rect x="442" y="40" width="200" height="150" rx="8" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <text x="330" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">Provider's schedule · no user control</text>
+                            <rect x="442" y="40" width="200" height="150" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="542" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#475569" font-weight="700">③ Model Lifecycle</text>
                             <text x="542" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">Version retirement</text>
                             <text x="542" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">End of model support</text>
                             <text x="542" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Forced version migration</text>
                             <text x="542" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">Behavior drift</text>
-                            <text x="542" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">You're notified and adapt</text>
+                            <text x="542" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">You're notified and adapt</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ The three risks of a 'model subscription.' This shutdown belongs to ①, but all three share one trait: they trigger regardless of the enterprise's compliance or usage. | Pebblous original diagram

--- a/blog/anthropic-fable-mythos-export-control-model-risk/ko/index.html
+++ b/blog/anthropic-fable-mythos-export-control-model-risk/ko/index.html
@@ -273,28 +273,28 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="210" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">'모델 구독'의 세 가지 리스크 — 모두 기업의 통제 밖에서 발동한다</text>
+                            <text x="330" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">'모델 구독'의 세 가지 리스크 — 모두 기업의 통제 밖에서 발동한다</text>
                             <rect x="18" y="40" width="200" height="150" rx="8" fill="white" stroke="#F86825" stroke-width="2"/>
                             <text x="118" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#F86825" font-weight="700">① 규제 · 지정학</text>
                             <text x="118" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">이번 사건</text>
                             <text x="118" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">수출 통제 · 제재</text>
                             <text x="118" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">데이터 거주지 규정</text>
                             <text x="118" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">지역 라이선싱</text>
-                            <text x="118" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">예고 없음 · 준비 시간 0</text>
-                            <rect x="230" y="40" width="200" height="150" rx="8" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <text x="118" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">예고 없음 · 준비 시간 0</text>
+                            <rect x="230" y="40" width="200" height="150" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#475569" font-weight="700">② 운영</text>
                             <text x="330" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">공급자 의존</text>
                             <text x="330" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">장애 · 용량 제한</text>
                             <text x="330" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">요금 정책 변경</text>
                             <text x="330" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">SLA 미달</text>
-                            <text x="330" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">공급자 일정 · 사용자 제어 불가</text>
-                            <rect x="442" y="40" width="200" height="150" rx="8" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <text x="330" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">공급자 일정 · 사용자 제어 불가</text>
+                            <rect x="442" y="40" width="200" height="150" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="542" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#475569" font-weight="700">③ 모델 라이프사이클</text>
                             <text x="542" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">버전 폐기</text>
                             <text x="542" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">모델 지원 종료</text>
                             <text x="542" y="130" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">강제 버전 전환</text>
                             <text x="542" y="148" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">동작 변화(drift)</text>
-                            <text x="542" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">알림 받고 적응할 뿐</text>
+                            <text x="542" y="174" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">알림 받고 적응할 뿐</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ '모델 구독'의 세 가지 리스크. 이번 차단은 ①에 속하지만, 셋 모두 기업의 준수 여부·사용량과 무관하게 발동한다는 공통점을 가진다. | 페블러스 원본 도식

--- a/blog/data-curation-bottleneck-foundation-models/en/index.html
+++ b/blog/data-curation-bottleneck-foundation-models/en/index.html
@@ -189,14 +189,14 @@
                              class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border"
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="26" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="600" fill="#64748b">Over-training ratio progression (log scale, relative to Chinchilla optimal 20:1)</text>
-                            <text x="133" y="70" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#94a3b8">Chinchilla</text>
+                            <text x="133" y="70" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">Chinchilla</text>
                             <rect x="140" y="52" width="131" height="30" fill="#cbd5e1" rx="4"/>
                             <text x="279" y="72" font-family="Outfit,sans-serif" font-size="11" fill="#475569" font-weight="700">20:1</text>
-                            <text x="133" y="114" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#94a3b8">Llama 1 (7B)</text>
-                            <rect x="140" y="96" width="216" height="30" fill="#94a3b8" rx="4"/>
+                            <text x="133" y="114" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">Llama 1 (7B)</text>
+                            <rect x="140" y="96" width="216" height="30" fill="var(--text-secondary)" rx="4"/>
                             <text x="248" y="116" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#fff" font-weight="700">142:1</text>
-                            <text x="133" y="158" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#94a3b8">Llama 2 (7B)</text>
-                            <rect x="140" y="140" width="247" height="30" fill="#94a3b8" rx="4"/>
+                            <text x="133" y="158" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">Llama 2 (7B)</text>
+                            <rect x="140" y="140" width="247" height="30" fill="var(--text-secondary)" rx="4"/>
                             <text x="264" y="160" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#fff" font-weight="700">284:1</text>
                             <text x="133" y="202" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#64748b">Llama 3 (8B)</text>
                             <rect x="140" y="184" width="329" height="30" fill="#F86825" rx="4"/>
@@ -204,9 +204,9 @@
                             <text x="133" y="246" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#64748b">Qwen3-0.6B</text>
                             <rect x="140" y="228" width="480" height="30" fill="#F86825" rx="4" opacity="0.8"/>
                             <text x="380" y="248" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#fff" font-weight="700">60,000:1</text>
-                            <line x1="271" y1="42" x2="271" y2="270" stroke="#94a3b8" stroke-dasharray="5 3" stroke-width="1.5"/>
-                            <text x="275" y="47" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">← Chinchilla optimum</text>
-                            <text x="330" y="272" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Bar length = log₁₀(tokens per parameter)</text>
+                            <line x1="271" y1="42" x2="271" y2="270" stroke="var(--text-muted)" stroke-dasharray="5 3" stroke-width="1.5"/>
+                            <text x="275" y="47" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">← Chinchilla optimum</text>
+                            <text x="330" y="272" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Bar length = log₁₀(tokens per parameter)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ Original Pebblous diagram — generational acceleration of over-training ratios vs. Chinchilla optimum (20:1) | Source: respective model technical reports
@@ -261,12 +261,12 @@
                              class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border"
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="26" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="600" fill="#64748b">FineWeb-Edu: 9× Less Data, Same Performance</text>
-                            <text x="240" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">Data volume</text>
-                            <text x="533" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">Benchmark performance</text>
-                            <text x="87" y="90" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#94a3b8">Unfiltered</text>
+                            <text x="240" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">Data volume</text>
+                            <text x="533" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">Benchmark performance</text>
+                            <text x="87" y="90" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">Unfiltered</text>
                             <rect x="92" y="72" width="296" height="32" fill="#cbd5e1" rx="4"/>
                             <text x="240" y="93" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#475569" font-weight="700">350B tokens</text>
-                            <rect x="415" y="72" width="213" height="32" fill="#94a3b8" rx="4"/>
+                            <rect x="415" y="72" width="213" height="32" fill="var(--text-secondary)" rx="4"/>
                             <text x="522" y="93" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#fff" font-weight="700">Baseline perf.</text>
                             <text x="87" y="144" text-anchor="end" font-family="Outfit,sans-serif" font-size="12" fill="#64748b">Curated</text>
                             <rect x="92" y="125" width="32" height="32" fill="#F86825" rx="4"/>
@@ -274,9 +274,9 @@
                             <rect x="415" y="125" width="213" height="32" fill="#F86825" rx="4"/>
                             <text x="522" y="146" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#fff" font-weight="700">Same perf. ✓</text>
                             <text x="52" y="113" text-anchor="middle" font-family="Outfit,sans-serif" font-size="18" fill="#F86825" font-weight="700">9×</text>
-                            <text x="52" y="127" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">efficiency</text>
+                            <text x="52" y="127" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">efficiency</text>
                             <text x="400" y="115" text-anchor="middle" font-family="Outfit,sans-serif" font-size="26" fill="#F86825" font-weight="300">≈</text>
-                            <text x="330" y="184" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Both bars achieve equivalent benchmark scores — curation delivers 9× data efficiency (HuggingFace FineWeb-Edu, 2024)</text>
+                            <text x="330" y="184" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Both bars achieve equivalent benchmark scores — curation delivers 9× data efficiency (HuggingFace FineWeb-Edu, 2024)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ Original Pebblous diagram (FineWeb-Edu results reinterpreted) | Source: Penedo et al., HuggingFace, 2024
@@ -319,21 +319,21 @@
                              class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border"
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="24" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="600" fill="#64748b">Llama 3 Data Curation Pipeline</text>
-                            <rect x="20" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <rect x="20" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="68" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Raw</text>
                             <text x="68" y="76" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Web Crawl</text>
-                            <text x="68" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">Tens of T tokens</text>
-                            <path d="M116,68 L136,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowEn)"/>
-                            <rect x="136" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <text x="68" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">Tens of T tokens</text>
+                            <path d="M116,68 L136,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowEn)"/>
+                            <rect x="136" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="184" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Heuristic</text>
                             <text x="184" y="76" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Filter · NSFW</text>
-                            <text x="184" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">Remove obvious noise</text>
-                            <path d="M232,68 L252,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowEn)"/>
-                            <rect x="252" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <text x="184" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">Remove obvious noise</text>
+                            <path d="M232,68 L252,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowEn)"/>
+                            <rect x="252" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="300" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Semantic</text>
                             <text x="300" y="76" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Deduplication</text>
-                            <text x="300" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">Remove duplicates</text>
-                            <path d="M348,68 L368,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowEn)"/>
+                            <text x="300" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">Remove duplicates</text>
+                            <path d="M348,68 L368,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowEn)"/>
                             <rect x="368" y="42" width="110" height="52" fill="#fff3ed" rx="6" stroke="#F86825" stroke-width="1.5"/>
                             <text x="423" y="60" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825" font-weight="600">Quality Classifier</text>
                             <text x="423" y="74" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#F86825">(Llama 2 trained)</text>
@@ -347,7 +347,7 @@
                             <text x="490" y="150" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#F86825">Llama 2 curates Llama 3's training data (recursive)</text>
                             <defs>
                                 <marker id="arrowEn" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-                                    <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+                                    <polygon points="0 0, 8 3, 0 6" fill="var(--text-secondary)"/>
                                 </marker>
                                 <marker id="arrowOrangeEn" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
                                     <polygon points="0 0, 8 3, 0 6" fill="#F86825"/>
@@ -393,10 +393,10 @@
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="26" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="600" fill="#64748b">Distribution Collapse Under Repeated Synthetic Training (Model Collapse)</text>
                             <text x="88" y="63" text-anchor="end" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">Gen 1</text>
-                            <rect x="95" y="48" width="340" height="26" fill="#94a3b8" rx="4"/>
+                            <rect x="95" y="48" width="340" height="26" fill="var(--text-secondary)" rx="4"/>
                             <text x="265" y="66" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#fff">Human-data based — rich tail distribution</text>
                             <text x="88" y="105" text-anchor="end" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">Gen 2</text>
-                            <rect x="130" y="90" width="268" height="26" fill="#94a3b8" rx="4" opacity="0.85"/>
+                            <rect x="130" y="90" width="268" height="26" fill="var(--text-secondary)" rx="4" opacity="0.85"/>
                             <text x="264" y="108" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#fff">Tail patterns begin to erode</text>
                             <text x="88" y="147" text-anchor="end" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">Gen 3</text>
                             <rect x="165" y="132" width="198" height="26" fill="#F86825" rx="4" opacity="0.7"/>

--- a/blog/data-curation-bottleneck-foundation-models/ko/index.html
+++ b/blog/data-curation-bottleneck-foundation-models/ko/index.html
@@ -189,14 +189,14 @@
                              class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border"
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="26" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="600" fill="#64748b">over-training 비율 진화 (로그 스케일, Chinchilla 최적 20:1 기준)</text>
-                            <text x="133" y="70" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#94a3b8">Chinchilla</text>
+                            <text x="133" y="70" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">Chinchilla</text>
                             <rect x="140" y="52" width="131" height="30" fill="#cbd5e1" rx="4"/>
                             <text x="279" y="72" font-family="Pretendard,sans-serif" font-size="11" fill="#475569" font-weight="700">20:1</text>
-                            <text x="133" y="114" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#94a3b8">Llama 1 (7B)</text>
-                            <rect x="140" y="96" width="216" height="30" fill="#94a3b8" rx="4"/>
+                            <text x="133" y="114" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">Llama 1 (7B)</text>
+                            <rect x="140" y="96" width="216" height="30" fill="var(--text-secondary)" rx="4"/>
                             <text x="248" y="116" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#fff" font-weight="700">142:1</text>
-                            <text x="133" y="158" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#94a3b8">Llama 2 (7B)</text>
-                            <rect x="140" y="140" width="247" height="30" fill="#94a3b8" rx="4"/>
+                            <text x="133" y="158" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">Llama 2 (7B)</text>
+                            <rect x="140" y="140" width="247" height="30" fill="var(--text-secondary)" rx="4"/>
                             <text x="264" y="160" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#fff" font-weight="700">284:1</text>
                             <text x="133" y="202" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#64748b">Llama 3 (8B)</text>
                             <rect x="140" y="184" width="329" height="30" fill="#F86825" rx="4"/>
@@ -204,9 +204,9 @@
                             <text x="133" y="246" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#64748b">Qwen3-0.6B</text>
                             <rect x="140" y="228" width="480" height="30" fill="#F86825" rx="4" opacity="0.8"/>
                             <text x="380" y="248" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#fff" font-weight="700">60,000:1</text>
-                            <line x1="271" y1="42" x2="271" y2="270" stroke="#94a3b8" stroke-dasharray="5 3" stroke-width="1.5"/>
-                            <text x="275" y="47" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">← Chinchilla 최적</text>
-                            <text x="330" y="272" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">막대 길이 = log₁₀(토큰/파라미터 비율) 기준</text>
+                            <line x1="271" y1="42" x2="271" y2="270" stroke="var(--text-muted)" stroke-dasharray="5 3" stroke-width="1.5"/>
+                            <text x="275" y="47" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">← Chinchilla 최적</text>
+                            <text x="330" y="272" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">막대 길이 = log₁₀(토큰/파라미터 비율) 기준</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ 페블러스 원본 도식 — Chinchilla 최적(20:1) 대비 over-training 비율의 세대별 가속 | 수치 출처: 각 모델 기술보고서
@@ -261,12 +261,12 @@
                              class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border"
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="26" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="600" fill="#64748b">FineWeb-Edu: 9배 적은 데이터로 동일한 성능</text>
-                            <text x="240" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">데이터 양</text>
-                            <text x="533" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">벤치마크 성능</text>
-                            <text x="87" y="90" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#94a3b8">미필터</text>
+                            <text x="240" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">데이터 양</text>
+                            <text x="533" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">벤치마크 성능</text>
+                            <text x="87" y="90" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">미필터</text>
                             <rect x="92" y="72" width="296" height="32" fill="#cbd5e1" rx="4"/>
                             <text x="240" y="93" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#475569" font-weight="700">350B 토큰</text>
-                            <rect x="415" y="72" width="213" height="32" fill="#94a3b8" rx="4"/>
+                            <rect x="415" y="72" width="213" height="32" fill="var(--text-secondary)" rx="4"/>
                             <text x="522" y="93" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#fff" font-weight="700">기준 성능</text>
                             <text x="87" y="144" text-anchor="end" font-family="Pretendard,sans-serif" font-size="12" fill="#64748b">큐레이션</text>
                             <rect x="92" y="125" width="32" height="32" fill="#F86825" rx="4"/>
@@ -274,9 +274,9 @@
                             <rect x="415" y="125" width="213" height="32" fill="#F86825" rx="4"/>
                             <text x="522" y="146" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#fff" font-weight="700">동급 성능 ✓</text>
                             <text x="52" y="113" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="18" fill="#F86825" font-weight="700">9×</text>
-                            <text x="52" y="127" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">효율</text>
+                            <text x="52" y="127" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">효율</text>
                             <text x="400" y="115" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="26" fill="#F86825" font-weight="300">≈</text>
-                            <text x="330" y="184" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">두 막대의 벤치마크 성능은 동급 — 큐레이션이 9배 데이터 효율 달성 (HuggingFace FineWeb-Edu, 2024)</text>
+                            <text x="330" y="184" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">두 막대의 벤치마크 성능은 동급 — 큐레이션이 9배 데이터 효율 달성 (HuggingFace FineWeb-Edu, 2024)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ 페블러스 원본 도식 (FineWeb-Edu 결과 재해석) | 출처: Penedo et al., HuggingFace, 2024
@@ -320,26 +320,26 @@
                              style="background:rgba(248,104,37,0.03)">
                             <text x="330" y="24" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="600" fill="#64748b">Llama 3 데이터 큐레이션 파이프라인</text>
                             <!-- Box 1: Raw web -->
-                            <rect x="20" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <rect x="20" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="68" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">원본</text>
                             <text x="68" y="76" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">웹 크롤</text>
-                            <text x="68" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">수십 T 토큰</text>
+                            <text x="68" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">수십 T 토큰</text>
                             <!-- Arrow -->
-                            <path d="M116,68 L136,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowKo)"/>
+                            <path d="M116,68 L136,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowKo)"/>
                             <!-- Box 2: Heuristic+NSFW -->
-                            <rect x="136" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <rect x="136" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="184" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">휴리스틱</text>
                             <text x="184" y="76" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">필터·NSFW</text>
-                            <text x="184" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">명백한 노이즈 제거</text>
+                            <text x="184" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">명백한 노이즈 제거</text>
                             <!-- Arrow -->
-                            <path d="M232,68 L252,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowKo)"/>
+                            <path d="M232,68 L252,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowKo)"/>
                             <!-- Box 3: Dedup -->
-                            <rect x="252" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="#cbd5e1" stroke-width="1"/>
+                            <rect x="252" y="42" width="96" height="52" fill="#e2e8f0" rx="6" stroke="var(--text-muted)" stroke-width="1"/>
                             <text x="300" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">의미 기반</text>
                             <text x="300" y="76" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">중복 제거</text>
-                            <text x="300" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">동일 내용 솎아내기</text>
+                            <text x="300" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">동일 내용 솎아내기</text>
                             <!-- Arrow -->
-                            <path d="M348,68 L368,68" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowKo)"/>
+                            <path d="M348,68 L368,68" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrowKo)"/>
                             <!-- Box 4: Quality classifier (Llama 2) — highlighted -->
                             <rect x="368" y="42" width="110" height="52" fill="#fff3ed" rx="6" stroke="#F86825" stroke-width="1.5"/>
                             <text x="423" y="60" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825" font-weight="600">품질 분류기</text>
@@ -358,7 +358,7 @@
                             <!-- Arrow markers -->
                             <defs>
                                 <marker id="arrowKo" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-                                    <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+                                    <polygon points="0 0, 8 3, 0 6" fill="var(--text-secondary)"/>
                                 </marker>
                                 <marker id="arrowOrangeKo" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
                                     <polygon points="0 0, 8 3, 0 6" fill="#F86825"/>
@@ -405,11 +405,11 @@
                             <text x="330" y="26" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="600" fill="#64748b">합성 데이터 반복 학습 시 분포 붕괴 (Model Collapse)</text>
                             <!-- Gen 1 -->
                             <text x="88" y="63" text-anchor="end" font-family="Pretendard,sans-serif" font-size="11" fill="#64748b">세대 1</text>
-                            <rect x="95" y="48" width="340" height="26" fill="#94a3b8" rx="4"/>
+                            <rect x="95" y="48" width="340" height="26" fill="var(--text-secondary)" rx="4"/>
                             <text x="265" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#fff">인간 데이터 기반 — 꼬리 분포 풍부</text>
                             <!-- Gen 2 -->
                             <text x="88" y="105" text-anchor="end" font-family="Pretendard,sans-serif" font-size="11" fill="#64748b">세대 2</text>
-                            <rect x="130" y="90" width="268" height="26" fill="#94a3b8" rx="4" opacity="0.85"/>
+                            <rect x="130" y="90" width="268" height="26" fill="var(--text-secondary)" rx="4" opacity="0.85"/>
                             <text x="264" y="108" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#fff">꼬리 패턴 일부 소실 시작</text>
                             <!-- Gen 3 -->
                             <text x="88" y="147" text-anchor="end" font-family="Pretendard,sans-serif" font-size="11" fill="#64748b">세대 3</text>

--- a/blog/eu-ai-act-transparency-august-2026/en/index.html
+++ b/blog/eu-ai-act-transparency-august-2026/en/index.html
@@ -260,32 +260,32 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:var(--card-bg,rgba(120,120,120,0.04))">
                             <line x1="40" y1="108" x2="318" y2="108" stroke="#F86825" stroke-width="3"/>
-                            <line x1="318" y1="108" x2="636" y2="108" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6,3"/>
-                            <polygon points="631,103 641,108 631,113" fill="#94a3b8"/>
+                            <line x1="318" y1="108" x2="636" y2="108" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="6,3"/>
+                            <polygon points="631,103 641,108 631,113" fill="var(--text-secondary)"/>
                             <circle cx="88" cy="108" r="7" fill="#F86825"/>
                             <line x1="88" y1="101" x2="88" y2="65" stroke="#F86825" stroke-width="1.5"/>
                             <text x="88" y="57" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" font-weight="700" fill="#F86825">Jul 22</text>
-                            <text x="88" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">CoP signing deadline</text>
+                            <text x="88" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">CoP signing deadline</text>
                             <circle cx="195" cy="108" r="10" fill="#F86825"/>
                             <line x1="195" y1="118" x2="195" y2="153" stroke="#F86825" stroke-width="1.5"/>
                             <text x="195" y="166" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="13" font-weight="700" fill="#F86825">Aug 2</text>
-                            <text x="195" y="181" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">Transparency duties active</text>
+                            <text x="195" y="181" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">Transparency duties active</text>
                             <circle cx="318" cy="108" r="7" fill="#F86825"/>
                             <line x1="318" y1="101" x2="318" y2="65" stroke="#F86825" stroke-width="1.5"/>
                             <text x="318" y="57" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" font-weight="600" fill="#F86825">Dec 2</text>
-                            <text x="318" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">Synthetic marking grace ends</text>
-                            <circle cx="468" cy="108" r="7" fill="#94a3b8"/>
-                            <line x1="468" y1="118" x2="468" y2="153" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="468" y="166" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" fill="#94a3b8">Dec 2027</text>
-                            <text x="468" y="181" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">High-risk AI (Annex III)</text>
-                            <circle cx="588" cy="108" r="7" fill="#94a3b8"/>
-                            <line x1="588" y1="101" x2="588" y2="65" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="588" y="57" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" fill="#94a3b8">Aug 2028</text>
-                            <text x="588" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">High-risk AI (Annex I)</text>
+                            <text x="318" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">Synthetic marking grace ends</text>
+                            <circle cx="468" cy="108" r="7" fill="var(--text-secondary)"/>
+                            <line x1="468" y1="118" x2="468" y2="153" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="468" y="166" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">Dec 2027</text>
+                            <text x="468" y="181" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">High-risk AI (Annex III)</text>
+                            <circle cx="588" cy="108" r="7" fill="var(--text-secondary)"/>
+                            <line x1="588" y1="101" x2="588" y2="65" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="588" y="57" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="12" fill="var(--text-secondary)">Aug 2028</text>
+                            <text x="588" y="43" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">High-risk AI (Annex I)</text>
                             <rect x="32" y="197" width="8" height="8" rx="2" fill="#F86825"/>
-                            <text x="46" y="205" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">On schedule</text>
-                            <rect x="150" y="197" width="8" height="8" rx="2" fill="#94a3b8"/>
-                            <text x="164" y="205" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="#94a3b8">Extended by AI Omnibus</text>
+                            <text x="46" y="205" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">On schedule</text>
+                            <rect x="150" y="197" width="8" height="8" rx="2" fill="var(--text-secondary)"/>
+                            <text x="164" y="205" font-family="Outfit,Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">Extended by AI Omnibus</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ EU AI Act key implementation dates (Pebblous original diagram) | Source: <a href="https://artificialintelligenceact.eu/implementation-timeline/" target="_blank" rel="noopener" class="underline">artificialintelligenceact.eu</a>
@@ -396,27 +396,27 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 180" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:var(--card-bg,rgba(120,120,120,0.04))">
                             <defs>
-                                <marker id="en-arr-g" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="#94a3b8"/></marker>
+                                <marker id="en-arr-g" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="var(--text-secondary)"/></marker>
                                 <marker id="en-arr-o" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="#F86825"/></marker>
                             </defs>
                             <rect x="20" y="32" width="140" height="48" rx="8" fill="none" stroke="#F86825" stroke-width="1.5"/>
                             <text x="90" y="52" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="14" font-weight="700" fill="#F86825">Korean Company</text>
-                            <text x="90" y="70" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="#94a3b8">No EU entity</text>
+                            <text x="90" y="70" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">No EU entity</text>
                             <rect x="20" y="100" width="140" height="48" rx="8" fill="none" stroke="#F86825" stroke-width="1.5"/>
                             <text x="90" y="120" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="14" font-weight="700" fill="#F86825">US Company</text>
-                            <text x="90" y="138" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="#94a3b8">No EU entity</text>
-                            <line x1="162" y1="56" x2="218" y2="86" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#en-arr-g)"/>
-                            <line x1="162" y1="124" x2="218" y2="94" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#en-arr-g)"/>
-                            <rect x="222" y="62" width="148" height="56" rx="8" fill="none" stroke="#cbd5e1" stroke-width="1"/>
-                            <text x="296" y="84" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="#94a3b8">Service / output</text>
-                            <text x="296" y="101" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="#94a3b8">reaches EU users</text>
+                            <text x="90" y="138" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">No EU entity</text>
+                            <line x1="162" y1="56" x2="218" y2="86" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-arr-g)"/>
+                            <line x1="162" y1="124" x2="218" y2="94" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#en-arr-g)"/>
+                            <rect x="222" y="62" width="148" height="56" rx="8" fill="none" stroke="var(--text-muted)" stroke-width="1"/>
+                            <text x="296" y="84" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">Service / output</text>
+                            <text x="296" y="101" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">reaches EU users</text>
                             <line x1="373" y1="90" x2="430" y2="90" stroke="#F86825" stroke-width="2" marker-end="url(#en-arr-o)"/>
-                            <text x="402" y="83" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="9" fill="#94a3b8">same as</text>
-                            <text x="402" y="100" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="9" fill="#94a3b8">GDPR</text>
+                            <text x="402" y="83" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">same as</text>
+                            <text x="402" y="100" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">GDPR</text>
                             <rect x="434" y="60" width="186" height="60" rx="8" fill="rgba(248,104,37,0.08)" stroke="#F86825" stroke-width="2"/>
                             <text x="527" y="85" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="14" font-weight="700" fill="#F86825">EU AI Act</text>
                             <text x="527" y="106" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="14" font-weight="700" fill="#F86825">Extraterritorial</text>
-                            <text x="330" y="168" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="#94a3b8">Regardless of company location — applies when AI output is used within the EU</text>
+                            <text x="330" y="168" text-anchor="middle" font-family="Outfit,Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">Regardless of company location — applies when AI output is used within the EU</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ EU AI Act extraterritorial reach — location is irrelevant; what matters is where the AI output lands (Pebblous original diagram)

--- a/blog/eu-ai-act-transparency-august-2026/ko/index.html
+++ b/blog/eu-ai-act-transparency-august-2026/ko/index.html
@@ -260,32 +260,32 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:var(--card-bg,rgba(120,120,120,0.04))">
                             <line x1="40" y1="108" x2="318" y2="108" stroke="#F86825" stroke-width="3"/>
-                            <line x1="318" y1="108" x2="636" y2="108" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6,3"/>
-                            <polygon points="631,103 641,108 631,113" fill="#94a3b8"/>
+                            <line x1="318" y1="108" x2="636" y2="108" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="6,3"/>
+                            <polygon points="631,103 641,108 631,113" fill="var(--text-secondary)"/>
                             <circle cx="88" cy="108" r="7" fill="#F86825"/>
                             <line x1="88" y1="101" x2="88" y2="65" stroke="#F86825" stroke-width="1.5"/>
                             <text x="88" y="57" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" font-weight="700" fill="#F86825">7월 22일</text>
-                            <text x="88" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">CoP 서명 마감</text>
+                            <text x="88" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">CoP 서명 마감</text>
                             <circle cx="195" cy="108" r="10" fill="#F86825"/>
                             <line x1="195" y1="118" x2="195" y2="153" stroke="#F86825" stroke-width="1.5"/>
                             <text x="195" y="166" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="13" font-weight="700" fill="#F86825">8월 2일</text>
-                            <text x="195" y="181" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">챗봇·딥페이크 의무 시행</text>
+                            <text x="195" y="181" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">챗봇·딥페이크 의무 시행</text>
                             <circle cx="318" cy="108" r="7" fill="#F86825"/>
                             <line x1="318" y1="101" x2="318" y2="65" stroke="#F86825" stroke-width="1.5"/>
                             <text x="318" y="57" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" font-weight="600" fill="#F86825">12월 2일</text>
-                            <text x="318" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">합성 콘텐츠 유예 종료</text>
-                            <circle cx="468" cy="108" r="7" fill="#94a3b8"/>
-                            <line x1="468" y1="118" x2="468" y2="153" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="468" y="166" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" fill="#94a3b8">2027년 12월</text>
-                            <text x="468" y="181" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">고위험 AI (Annex III)</text>
-                            <circle cx="588" cy="108" r="7" fill="#94a3b8"/>
-                            <line x1="588" y1="101" x2="588" y2="65" stroke="#94a3b8" stroke-width="1.5"/>
-                            <text x="588" y="57" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" fill="#94a3b8">2028년 8월</text>
-                            <text x="588" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">고위험 AI (Annex I)</text>
+                            <text x="318" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">합성 콘텐츠 유예 종료</text>
+                            <circle cx="468" cy="108" r="7" fill="var(--text-secondary)"/>
+                            <line x1="468" y1="118" x2="468" y2="153" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="468" y="166" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">2027년 12월</text>
+                            <text x="468" y="181" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">고위험 AI (Annex III)</text>
+                            <circle cx="588" cy="108" r="7" fill="var(--text-secondary)"/>
+                            <line x1="588" y1="101" x2="588" y2="65" stroke="var(--text-muted)" stroke-width="1.5"/>
+                            <text x="588" y="57" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="12" fill="var(--text-secondary)">2028년 8월</text>
+                            <text x="588" y="43" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">고위험 AI (Annex I)</text>
                             <rect x="32" y="197" width="8" height="8" rx="2" fill="#F86825"/>
-                            <text x="46" y="205" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">예정대로 시행</text>
-                            <rect x="170" y="197" width="8" height="8" rx="2" fill="#94a3b8"/>
-                            <text x="184" y="205" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="#94a3b8">AI Omnibus 연장</text>
+                            <text x="46" y="205" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">예정대로 시행</text>
+                            <rect x="170" y="197" width="8" height="8" rx="2" fill="var(--text-secondary)"/>
+                            <text x="184" y="205" font-family="Pretendard,Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">AI Omnibus 연장</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ EU AI법 주요 시행 일정 (페블러스 원본 도식) | Source: <a href="https://artificialintelligenceact.eu/implementation-timeline/" target="_blank" rel="noopener" class="underline">artificialintelligenceact.eu</a>
@@ -396,27 +396,27 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 180" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:var(--card-bg,rgba(120,120,120,0.04))">
                             <defs>
-                                <marker id="ko-arr-g" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="#94a3b8"/></marker>
+                                <marker id="ko-arr-g" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="var(--text-secondary)"/></marker>
                                 <marker id="ko-arr-o" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0,8 3,0 6" fill="#F86825"/></marker>
                             </defs>
                             <rect x="20" y="32" width="140" height="48" rx="8" fill="none" stroke="#F86825" stroke-width="1.5"/>
                             <text x="90" y="52" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="14" font-weight="700" fill="#F86825">한국 기업</text>
-                            <text x="90" y="70" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="#94a3b8">EU 법인 없음</text>
+                            <text x="90" y="70" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">EU 법인 없음</text>
                             <rect x="20" y="100" width="140" height="48" rx="8" fill="none" stroke="#F86825" stroke-width="1.5"/>
                             <text x="90" y="120" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="14" font-weight="700" fill="#F86825">미국 기업</text>
-                            <text x="90" y="138" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="#94a3b8">EU 법인 없음</text>
-                            <line x1="162" y1="56" x2="218" y2="86" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ko-arr-g)"/>
-                            <line x1="162" y1="124" x2="218" y2="94" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ko-arr-g)"/>
-                            <rect x="222" y="62" width="148" height="56" rx="8" fill="none" stroke="#cbd5e1" stroke-width="1"/>
-                            <text x="296" y="84" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="#94a3b8">EU 이용자에게</text>
-                            <text x="296" y="101" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="#94a3b8">서비스·출력물 도달</text>
+                            <text x="90" y="138" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">EU 법인 없음</text>
+                            <line x1="162" y1="56" x2="218" y2="86" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-arr-g)"/>
+                            <line x1="162" y1="124" x2="218" y2="94" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#ko-arr-g)"/>
+                            <rect x="222" y="62" width="148" height="56" rx="8" fill="none" stroke="var(--text-muted)" stroke-width="1"/>
+                            <text x="296" y="84" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">EU 이용자에게</text>
+                            <text x="296" y="101" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">서비스·출력물 도달</text>
                             <line x1="373" y1="90" x2="430" y2="90" stroke="#F86825" stroke-width="2" marker-end="url(#ko-arr-o)"/>
-                            <text x="402" y="83" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="9" fill="#94a3b8">GDPR과</text>
-                            <text x="402" y="100" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="9" fill="#94a3b8">동일 구조</text>
+                            <text x="402" y="83" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">GDPR과</text>
+                            <text x="402" y="100" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">동일 구조</text>
                             <rect x="434" y="60" width="186" height="60" rx="8" fill="rgba(248,104,37,0.08)" stroke="#F86825" stroke-width="2"/>
                             <text x="527" y="85" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="15" font-weight="700" fill="#F86825">EU AI법</text>
                             <text x="527" y="106" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="15" font-weight="700" fill="#F86825">역외 적용</text>
-                            <text x="330" y="168" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="#94a3b8">기업 소재지 무관 — AI 출력물이 EU 안에서 쓰이면 적용</text>
+                            <text x="330" y="168" text-anchor="middle" font-family="Pretendard,Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">기업 소재지 무관 — AI 출력물이 EU 안에서 쓰이면 적용</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ EU AI법 역외 적용 구조 — 소재지 무관, EU 이용자에 서비스가 닿으면 적용 (페블러스 원본 도식)

--- a/blog/gaaia-ivo-ai-audit-license/en/index.html
+++ b/blog/gaaia-ivo-ai-audit-license/en/index.html
@@ -168,11 +168,11 @@
                             <!-- CAISI (top) -->
                             <rect x="220" y="20" width="220" height="54" rx="10" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="1.5"/>
                             <text x="330" y="44" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#F86825">CAISI</text>
-                            <text x="330" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="#94a3b8">(Under NIST — issues &amp; oversees licenses)</text>
+                            <text x="330" y="62" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="var(--text-secondary)">(Under NIST — issues &amp; oversees licenses)</text>
 
                             <!-- Arrow CAISI → IVO -->
                             <line x1="330" y1="74" x2="330" y2="108" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrow-en)"/>
-                            <text x="342" y="95" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">licenses</text>
+                            <text x="342" y="95" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">licenses</text>
                             <defs>
                                 <marker id="arrow-en" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
                                     <polygon points="0,0 7,3.5 0,7" fill="#F86825"/>
@@ -183,24 +183,24 @@
                             </defs>
 
                             <!-- IVO (middle) -->
-                            <rect x="180" y="108" width="300" height="54" rx="10" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="180" y="108" width="300" height="54" rx="10" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="132" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#cbd5e1">IVO</text>
-                            <text x="330" y="151" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="#94a3b8">(Independent Verification Org — audits once licensed)</text>
+                            <text x="330" y="151" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="var(--text-secondary)">(Independent Verification Org — audits once licensed)</text>
 
                             <!-- Arrows IVO → Developers -->
-                            <line x1="255" y1="162" x2="175" y2="196" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow-en2)"/>
-                            <line x1="405" y1="162" x2="485" y2="196" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow-en2)"/>
-                            <text x="178" y="185" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">regular audit</text>
-                            <text x="408" y="185" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">regular audit</text>
+                            <line x1="255" y1="162" x2="175" y2="196" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrow-en2)"/>
+                            <line x1="405" y1="162" x2="485" y2="196" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrow-en2)"/>
+                            <text x="178" y="185" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">regular audit</text>
+                            <text x="408" y="185" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">regular audit</text>
 
                             <!-- Developer A (large, $500M+) -->
-                            <rect x="60" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.15" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="60" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.15" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="175" y="218" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">Large Frontier Developer</text>
-                            <text x="175" y="235" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Revenue &gt; $500M — IVO audit required</text>
+                            <text x="175" y="235" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Revenue &gt; $500M — IVO audit required</text>
 
                             <!-- Developer B (general, $50M+) -->
-                            <rect x="370" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.10" stroke="#475569" stroke-width="1" stroke-dasharray="5,3"/>
-                            <text x="485" y="218" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#94a3b8">General Frontier Developer</text>
+                            <rect x="370" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.10" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="5,3"/>
+                            <text x="485" y="218" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="var(--text-secondary)">General Frontier Developer</text>
                             <text x="485" y="235" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Revenue &gt; $50M — transparency report only</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
@@ -313,25 +313,25 @@
                                 </marker>
                             </defs>
                             <!-- Box 1: Training Data -->
-                            <rect x="20" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="79" y="57" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">Training Data</text>
-                            <text x="79" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">provenance &amp; quality docs</text>
+                            <text x="79" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">provenance &amp; quality docs</text>
                             <line x1="138" y1="60" x2="158" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow-en)"/>
                             <!-- Box 2: Model Training -->
-                            <rect x="158" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="158" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="217" y="57" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">Model Training</text>
-                            <text x="217" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">eval &amp; red-team records</text>
+                            <text x="217" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">eval &amp; red-team records</text>
                             <line x1="276" y1="60" x2="296" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow-en)"/>
                             <!-- Box 3: Risk Assessment -->
-                            <rect x="296" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="296" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="355" y="57" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">Risk Assessment</text>
-                            <text x="355" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">mitigation history</text>
+                            <text x="355" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">mitigation history</text>
                             <line x1="414" y1="60" x2="434" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow-en)"/>
                             <!-- Box 4: IVO Audit -->
                             <rect x="434" y="28" width="136" height="64" rx="8" fill="#F86825" opacity="0.12" stroke="#F86825" stroke-width="1.5"/>
                             <text x="502" y="54" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="700" fill="#F86825">IVO Audit</text>
                             <text x="502" y="70" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#F86825">"Is there evidence?"</text>
-                            <text x="502" y="84" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">Untraceable → audit fails</text>
+                            <text x="502" y="84" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">Untraceable → audit fails</text>
                             <!-- Labels top -->
                             <text x="79" y="22" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">traceable record →</text>
                             <text x="217" y="22" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">verifiable record →</text>
@@ -378,30 +378,30 @@
                             <!-- Center target -->
                             <rect x="225" y="80" width="210" height="60" rx="12" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="2"/>
                             <text x="330" y="107" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13.5" font-weight="700" fill="#F86825">Licensed AI Audit</text>
-                            <text x="330" y="127" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="#94a3b8">verifiable data &amp; model evidence</text>
+                            <text x="330" y="127" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10.5" fill="var(--text-secondary)">verifiable data &amp; model evidence</text>
 
                             <!-- EU AI Act (top-left) -->
-                            <rect x="20" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="94" y="35" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">EU AI Act</text>
-                            <text x="94" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">training-data governance</text>
+                            <text x="94" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">training-data governance</text>
                             <line x1="168" y1="48" x2="222" y2="92" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv-en)" opacity="0.7"/>
 
                             <!-- NIST AI RMF (bottom-left) -->
-                            <rect x="20" y="160" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="160" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="94" y="181" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">NIST AI RMF</text>
-                            <text x="94" y="198" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">federal procurement standard</text>
+                            <text x="94" y="198" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">federal procurement standard</text>
                             <line x1="168" y1="172" x2="222" y2="128" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv-en)" opacity="0.7"/>
 
                             <!-- ISO 42001 (top-right) -->
-                            <rect x="492" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="492" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="566" y="35" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">ISO 42001</text>
-                            <text x="566" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">enterprise verification benchmark</text>
+                            <text x="566" y="52" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">enterprise verification benchmark</text>
                             <line x1="492" y1="48" x2="438" y2="92" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv-en)" opacity="0.7"/>
 
                             <!-- GAAIA (bottom-right) -->
                             <rect x="492" y="160" width="148" height="46" rx="8" fill="#F86825" opacity="0.10" stroke="#F86825" stroke-width="1.2"/>
                             <text x="566" y="181" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11.5" font-weight="600" fill="#F86825">GAAIA (draft)</text>
-                            <text x="566" y="198" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="#94a3b8">federal licensed audit (IVO)</text>
+                            <text x="566" y="198" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9.5" fill="var(--text-secondary)">federal licensed audit (IVO)</text>
                             <line x1="492" y1="172" x2="438" y2="128" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv-en)" opacity="0.7"/>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">

--- a/blog/gaaia-ivo-ai-audit-license/ko/index.html
+++ b/blog/gaaia-ivo-ai-audit-license/ko/index.html
@@ -168,11 +168,11 @@
                             <!-- CAISI (top) -->
                             <rect x="220" y="20" width="220" height="54" rx="10" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="1.5"/>
                             <text x="330" y="44" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="700" fill="#F86825">CAISI</text>
-                            <text x="330" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="#94a3b8">(NIST 산하 — 면허 발급·감독)</text>
+                            <text x="330" y="62" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="var(--text-secondary)">(NIST 산하 — 면허 발급·감독)</text>
 
                             <!-- Arrow CAISI → IVO -->
                             <line x1="330" y1="74" x2="330" y2="108" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrow-ko)"/>
-                            <text x="342" y="95" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">면허 발급</text>
+                            <text x="342" y="95" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">면허 발급</text>
                             <defs>
                                 <marker id="arrow-ko" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
                                     <polygon points="0,0 7,3.5 0,7" fill="#F86825"/>
@@ -183,24 +183,24 @@
                             </defs>
 
                             <!-- IVO (middle) -->
-                            <rect x="180" y="108" width="300" height="54" rx="10" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="180" y="108" width="300" height="54" rx="10" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="330" y="132" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" font-weight="700" fill="#cbd5e1">IVO</text>
-                            <text x="330" y="151" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="#94a3b8">(독립 검증기관 — 면허 취득 후 감사 수행)</text>
+                            <text x="330" y="151" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="var(--text-secondary)">(독립 검증기관 — 면허 취득 후 감사 수행)</text>
 
                             <!-- Arrow IVO → Developers -->
-                            <line x1="255" y1="162" x2="175" y2="196" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow-ko2)"/>
-                            <line x1="405" y1="162" x2="485" y2="196" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow-ko2)"/>
-                            <text x="195" y="185" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">정기 감사</text>
-                            <text x="415" y="185" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">정기 감사</text>
+                            <line x1="255" y1="162" x2="175" y2="196" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrow-ko2)"/>
+                            <line x1="405" y1="162" x2="485" y2="196" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrow-ko2)"/>
+                            <text x="195" y="185" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">정기 감사</text>
+                            <text x="415" y="185" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">정기 감사</text>
 
                             <!-- Developer A (large, $500M+) -->
-                            <rect x="60" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.15" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="60" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.15" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="175" y="218" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">대형 프런티어 개발사</text>
-                            <text x="175" y="235" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">연매출 $500M 초과 — IVO 감사 의무</text>
+                            <text x="175" y="235" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">연매출 $500M 초과 — IVO 감사 의무</text>
 
                             <!-- Developer B (general, $50M+) -->
-                            <rect x="370" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.10" stroke="#475569" stroke-width="1" stroke-dasharray="5,3"/>
-                            <text x="485" y="218" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#94a3b8">일반 프런티어 개발사</text>
+                            <rect x="370" y="196" width="230" height="50" rx="10" fill="#334155" opacity="0.10" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="5,3"/>
+                            <text x="485" y="218" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="var(--text-secondary)">일반 프런티어 개발사</text>
                             <text x="485" y="235" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">연매출 $50M+ — 투명성 보고만</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
@@ -313,28 +313,28 @@
                                 </marker>
                             </defs>
                             <!-- Box 1: 훈련 데이터 -->
-                            <rect x="20" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="79" y="57" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">훈련 데이터</text>
-                            <text x="79" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">출처·품질 문서화</text>
+                            <text x="79" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">출처·품질 문서화</text>
                             <!-- Arrow -->
                             <line x1="138" y1="60" x2="158" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow)"/>
                             <!-- Box 2: 모델 훈련 -->
-                            <rect x="158" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="158" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="217" y="57" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">모델 훈련</text>
-                            <text x="217" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">평가·레드팀 기록</text>
+                            <text x="217" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">평가·레드팀 기록</text>
                             <!-- Arrow -->
                             <line x1="276" y1="60" x2="296" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow)"/>
                             <!-- Box 3: 위험 평가 -->
-                            <rect x="296" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="296" y="38" width="118" height="44" rx="8" fill="#334155" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="355" y="57" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" font-weight="600" fill="#cbd5e1">위험 평가</text>
-                            <text x="355" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">완화 이력 문서</text>
+                            <text x="355" y="73" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">완화 이력 문서</text>
                             <!-- Arrow -->
                             <line x1="414" y1="60" x2="434" y2="60" stroke="#F86825" stroke-width="1.4" marker-end="url(#arr-flow)"/>
                             <!-- Box 4: IVO 감사 -->
                             <rect x="434" y="28" width="136" height="64" rx="8" fill="#F86825" opacity="0.12" stroke="#F86825" stroke-width="1.5"/>
                             <text x="502" y="54" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" font-weight="700" fill="#F86825">IVO 감사</text>
                             <text x="502" y="70" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#F86825">"근거가 있는가?"</text>
-                            <text x="502" y="84" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">추적 불가 → 감사 불성립</text>
+                            <text x="502" y="84" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">추적 불가 → 감사 불성립</text>
                             <!-- Label top -->
                             <text x="79" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">추적 가능한 기록 →</text>
                             <text x="217" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">검증 가능한 기록 →</text>
@@ -381,30 +381,30 @@
                             <!-- Center target -->
                             <rect x="238" y="80" width="184" height="60" rx="12" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="2"/>
                             <text x="330" y="107" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13.5" font-weight="700" fill="#F86825">면허받은 AI 감사</text>
-                            <text x="330" y="127" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="#94a3b8">검증 가능한 데이터·모델 근거</text>
+                            <text x="330" y="127" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10.5" fill="var(--text-secondary)">검증 가능한 데이터·모델 근거</text>
 
                             <!-- EU AI Act (top-left) -->
-                            <rect x="20" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="94" y="35" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">EU AI Act</text>
-                            <text x="94" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">훈련 데이터 거버넌스</text>
+                            <text x="94" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">훈련 데이터 거버넌스</text>
                             <line x1="168" y1="48" x2="235" y2="92" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv)" opacity="0.7"/>
 
                             <!-- NIST AI RMF (bottom-left) -->
-                            <rect x="20" y="160" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="20" y="160" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="94" y="181" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">NIST AI RMF</text>
-                            <text x="94" y="198" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">연방 조달 기준</text>
+                            <text x="94" y="198" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">연방 조달 기준</text>
                             <line x1="168" y1="172" x2="235" y2="128" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv)" opacity="0.7"/>
 
                             <!-- ISO 42001 (top-right) -->
-                            <rect x="492" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="492" y="14" width="148" height="46" rx="8" fill="#334155" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="566" y="35" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#cbd5e1">ISO 42001</text>
-                            <text x="566" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">기업 조달 검증 기준</text>
+                            <text x="566" y="52" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">기업 조달 검증 기준</text>
                             <line x1="492" y1="48" x2="425" y2="92" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv)" opacity="0.7"/>
 
                             <!-- GAAIA (bottom-right) -->
                             <rect x="492" y="160" width="148" height="46" rx="8" fill="#F86825" opacity="0.10" stroke="#F86825" stroke-width="1.2"/>
                             <text x="566" y="181" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11.5" font-weight="600" fill="#F86825">GAAIA (초안)</text>
-                            <text x="566" y="198" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="#94a3b8">연방 면허 감사 (IVO)</text>
+                            <text x="566" y="198" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9.5" fill="var(--text-secondary)">연방 면허 감사 (IVO)</text>
                             <line x1="492" y1="172" x2="425" y2="128" stroke="#F86825" stroke-width="1.2" marker-end="url(#arr-conv)" opacity="0.7"/>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">

--- a/blog/robinhood-agentic-trading-mcp/en/index.html
+++ b/blog/robinhood-agentic-trading-mcp/en/index.html
@@ -214,8 +214,8 @@
                                     <polygon points="0 0, 8 3, 0 6" fill="#F86825"/>
                                 </marker>
                             </defs>
-                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">MCP Connection — from AI agent client to live trade</text>
-                            <rect x="18" y="42" width="158" height="84" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">MCP Connection — from AI agent client to live trade</text>
+                            <rect x="18" y="42" width="158" height="84" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="97" y="71" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#1e293b" font-weight="600">AI Agent Client</text>
                             <text x="97" y="88" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">Claude · ChatGPT · Cursor</text>
                             <text x="97" y="103" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">Codex · Grok + MCP-capable</text>
@@ -228,11 +228,11 @@
                             <text x="330" y="110" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825">Auth · permission gating</text>
                             <line x1="416" y1="84" x2="484" y2="84" stroke="#F86825" stroke-width="2" marker-end="url(#arr-en-mcp)"/>
                             <text x="450" y="76" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#F86825" font-weight="600">order execution</text>
-                            <rect x="484" y="42" width="158" height="84" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="484" y="42" width="158" height="84" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="563" y="71" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#1e293b" font-weight="600">Agentic Account</text>
                             <text x="563" y="88" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">Isolated, trade-only</text>
                             <text x="563" y="103" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#64748b">Autonomous stock trades</text>
-                            <text x="330" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">An interface that read code became an interface that moves money (May 2026)</text>
+                            <text x="330" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">An interface that read code became an interface that moves money (May 2026)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ MCP connection flow — from AI agent client through Robinhood's MCP server to the isolated agentic account. | Pebblous original diagram
@@ -367,7 +367,7 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 215" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="215" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">Agentic AI in Finance — Two Camps (H1 2026)</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">Agentic AI in Finance — Two Camps (H1 2026)</text>
                             <rect x="18" y="28" width="300" height="172" rx="8" fill="white" stroke="#F86825" stroke-width="2"/>
                             <text x="168" y="51" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#F86825" font-weight="700">⚡ Execution-first</text>
                             <text x="168" y="66" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">AI executes trades and payments directly</text>
@@ -380,10 +380,10 @@
                             <line x1="38" y1="157" x2="298" y2="157" stroke="#e2e8f0" stroke-width="0.5"/>
                             <text x="38" y="176" font-family="Outfit,sans-serif" font-size="12" fill="#1e293b" font-weight="600">Public.com</text>
                             <text x="38" y="190" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Dedicated AI investment agents</text>
-                            <rect x="342" y="28" width="300" height="172" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="342" y="28" width="300" height="172" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="492" y="51" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#475569" font-weight="700">💼 Advisory-only</text>
                             <text x="492" y="66" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">AI advises; human executes</text>
-                            <line x1="362" y1="73" x2="622" y2="73" stroke="#cbd5e1" stroke-width="0.5" stroke-dasharray="4,2"/>
+                            <line x1="362" y1="73" x2="622" y2="73" stroke="var(--text-muted)" stroke-width="0.5" stroke-dasharray="4,2"/>
                             <text x="362" y="93" font-family="Outfit,sans-serif" font-size="12" fill="#1e293b" font-weight="600">Charles Schwab</text>
                             <text x="362" y="107" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">AI insights · explains portfolio, no execution</text>
                             <line x1="362" y1="115" x2="622" y2="115" stroke="#e2e8f0" stroke-width="0.5"/>
@@ -473,17 +473,17 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="210" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">Three data layers determine agent trust</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">Three data layers determine agent trust</text>
                             <rect x="200" y="28" width="260" height="44" rx="8" fill="#1e293b" stroke="#F86825" stroke-width="2"/>
                             <text x="330" y="55" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="white" font-weight="600">AI Agent Judgment · Execution</text>
                             <text x="330" y="88" text-anchor="middle" font-family="Outfit,sans-serif" font-size="16" fill="#F86825">↕</text>
                             <rect x="45" y="96" width="570" height="34" rx="6" fill="white" stroke="#F86825" stroke-width="1.5"/>
                             <text x="130" y="119" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#F86825" font-weight="700">① Data Provenance</text>
                             <text x="390" y="119" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#475569">Traceable record of what data was fetched when → Auditability</text>
-                            <rect x="45" y="138" width="570" height="34" rx="6" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="45" y="138" width="570" height="34" rx="6" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="130" y="161" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569" font-weight="700">② Verified Market Data</text>
                             <text x="390" y="161" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#475569">Accuracy and timeliness of quotes, fills, availability → Domain trust</text>
-                            <rect x="45" y="180" width="570" height="24" rx="6" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="45" y="180" width="570" height="24" rx="6" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="130" y="197" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569" font-weight="700">③ Permission &amp; Leakage Governance</text>
                             <text x="400" y="197" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#475569">Consent and constraints on data flow → Sensitivity control</text>
                         </svg>

--- a/blog/robinhood-agentic-trading-mcp/ko/index.html
+++ b/blog/robinhood-agentic-trading-mcp/ko/index.html
@@ -214,8 +214,8 @@
                                     <polygon points="0 0, 8 3, 0 6" fill="#F86825"/>
                                 </marker>
                             </defs>
-                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">MCP 연결 구조 — AI 에이전트에서 실제 거래까지</text>
-                            <rect x="18" y="42" width="158" height="84" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">MCP 연결 구조 — AI 에이전트에서 실제 거래까지</text>
+                            <rect x="18" y="42" width="158" height="84" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="97" y="71" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#1e293b" font-weight="600">AI 에이전트 클라이언트</text>
                             <text x="97" y="88" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">Claude · ChatGPT · Cursor</text>
                             <text x="97" y="103" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">Codex · Grok + MCP 지원</text>
@@ -228,11 +228,11 @@
                             <text x="330" y="110" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825">인증 · 권한 게이팅</text>
                             <line x1="416" y1="84" x2="484" y2="84" stroke="#F86825" stroke-width="2" marker-end="url(#arr-ko-mcp)"/>
                             <text x="450" y="76" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#F86825" font-weight="600">주문 실행</text>
-                            <rect x="484" y="42" width="158" height="84" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="484" y="42" width="158" height="84" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="563" y="71" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#1e293b" font-weight="600">에이전틱 계좌</text>
                             <text x="563" y="88" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">격리된 거래 전용</text>
                             <text x="563" y="103" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#64748b">주식 자율 매매</text>
-                            <text x="330" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="#94a3b8">코드를 읽던 프로토콜이 자금을 이동시키는 인터페이스로 전환됐다 (2026년 5월)</text>
+                            <text x="330" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="9" fill="var(--text-secondary)">코드를 읽던 프로토콜이 자금을 이동시키는 인터페이스로 전환됐다 (2026년 5월)</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ MCP 연결 구조 — AI 에이전트 클라이언트에서 로빈후드 MCP 서버를 거쳐 에이전틱 계좌 거래까지의 흐름. | 페블러스 원본 도식
@@ -367,7 +367,7 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 215" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="215" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">에이전틱 AI 도입 방향 — 업계 두 갈래 (2026년 상반기)</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">에이전틱 AI 도입 방향 — 업계 두 갈래 (2026년 상반기)</text>
                             <rect x="18" y="28" width="300" height="172" rx="8" fill="white" stroke="#F86825" stroke-width="2"/>
                             <text x="168" y="51" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#F86825" font-weight="700">⚡ 실행형 (Execution-first)</text>
                             <text x="168" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">AI가 직접 거래·결제 실행</text>
@@ -380,10 +380,10 @@
                             <line x1="38" y1="157" x2="298" y2="157" stroke="#e2e8f0" stroke-width="0.5"/>
                             <text x="38" y="176" font-family="Pretendard,sans-serif" font-size="12" fill="#1e293b" font-weight="600">Public.com</text>
                             <text x="38" y="190" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">투자 전용 AI 에이전트 운영</text>
-                            <rect x="342" y="28" width="300" height="172" rx="8" fill="white" stroke="#cbd5e1" stroke-width="1.5"/>
+                            <rect x="342" y="28" width="300" height="172" rx="8" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="492" y="51" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#475569" font-weight="700">💼 보조·전통형 (Advisory)</text>
                             <text x="492" y="66" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">AI는 조언, 실행은 사람이</text>
-                            <line x1="362" y1="73" x2="622" y2="73" stroke="#cbd5e1" stroke-width="0.5" stroke-dasharray="4,2"/>
+                            <line x1="362" y1="73" x2="622" y2="73" stroke="var(--text-muted)" stroke-width="0.5" stroke-dasharray="4,2"/>
                             <text x="362" y="93" font-family="Pretendard,sans-serif" font-size="12" fill="#1e293b" font-weight="600">찰스 슈왑</text>
                             <text x="362" y="107" font-family="Pretendard,sans-serif" font-size="10" fill="#64748b">AI 인사이트 · 투자 설명만, 실행은 사람</text>
                             <line x1="362" y1="115" x2="622" y2="115" stroke="#e2e8f0" stroke-width="0.5"/>
@@ -473,17 +473,17 @@
                     <figure class="my-8">
                         <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border">
                             <rect width="660" height="210" fill="#f8fafc" rx="12"/>
-                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">에이전트의 신뢰는 데이터 3층이 결정한다</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">에이전트의 신뢰는 데이터 3층이 결정한다</text>
                             <rect x="200" y="28" width="260" height="44" rx="8" fill="#1e293b" stroke="#F86825" stroke-width="2"/>
                             <text x="330" y="55" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="white" font-weight="600">AI 에이전트 판단 · 실행</text>
                             <text x="330" y="88" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="16" fill="#F86825">↕</text>
                             <rect x="45" y="96" width="570" height="34" rx="6" fill="white" stroke="#F86825" stroke-width="1.5"/>
                             <text x="135" y="119" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#F86825" font-weight="700">① 데이터 계보</text>
                             <text x="390" y="119" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">어떤 데이터를 언제·어디서 판단에 썼는지 추적 → 감사가능성</text>
-                            <rect x="45" y="138" width="570" height="34" rx="6" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="45" y="138" width="570" height="34" rx="6" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="135" y="161" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#475569" font-weight="700">② 검증된 시장 데이터</text>
                             <text x="390" y="161" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">시세·체결·가용성 정확성·적시성 보장 → 도메인 신뢰성</text>
-                            <rect x="45" y="180" width="570" height="24" rx="6" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+                            <rect x="45" y="180" width="570" height="24" rx="6" fill="white" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="135" y="197" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#475569" font-weight="700">③ 권한·이탈 거버넌스</text>
                             <text x="390" y="197" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#475569">데이터 경로에 동의·제약 → 데이터 민감성 제어</text>
                         </svg>

--- a/report/diffusion-low-dim-distributions-jmlr/en/index.html
+++ b/report/diffusion-low-dim-distributions-jmlr/en/index.html
@@ -340,8 +340,8 @@
                     <!-- Original diagram: union of low-dim subspaces in ambient space -->
                     <figure class="my-8">
                         <svg viewBox="0 0 720 340" role="img" aria-label="Data clustering near a union of low-dimensional subspaces inside a high-dimensional ambient space" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:#fbfaf8;">
-                            <rect x="24" y="22" width="672" height="262" rx="16" fill="none" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="7 7"/>
-                            <text x="44" y="50" font-family="Outfit, sans-serif" font-size="15" fill="#94a3b8">High-dimensional ambient space ℝⁿ — almost empty (n ≈ hundreds of thousands)</text>
+                            <rect x="24" y="22" width="672" height="262" rx="16" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="7 7"/>
+                            <text x="44" y="50" font-family="Outfit, sans-serif" font-size="15" fill="var(--text-secondary)">High-dimensional ambient space ℝⁿ — almost empty (n ≈ hundreds of thousands)</text>
                             <g transform="rotate(-19 250 175)">
                                 <rect x="70" y="150" width="360" height="50" rx="25" fill="#F86825" opacity="0.12"/>
                                 <line x1="90" y1="175" x2="410" y2="175" stroke="#F86825" stroke-width="3"/>
@@ -355,7 +355,7 @@
                                 <text x="610" y="156" font-family="Outfit, sans-serif" font-size="15" font-weight="600" fill="#F86825">U₂ (d-dim)</text>
                             </g>
                             <circle cx="110" cy="250" r="3.5" fill="#cbd5e1"/><circle cx="640" cy="70" r="3.5" fill="#cbd5e1"/><circle cx="600" cy="245" r="3.5" fill="#cbd5e1"/><circle cx="90" cy="95" r="3.5" fill="#cbd5e1"/>
-                            <text x="360" y="312" text-anchor="middle" font-family="Outfit, sans-serif" font-size="13" fill="#94a3b8">Data (●) concentrates only near the low-dim subspaces U₁·U₂ — the rest of the space (○) is empty</text>
+                            <text x="360" y="312" text-anchor="middle" font-family="Outfit, sans-serif" font-size="13" fill="var(--text-secondary)">Data (●) concentrates only near the low-dim subspaces U₁·U₂ — the rest of the space (○) is empty</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ Data leaves the high-dimensional pixel space almost empty and clusters near a union of several low-dimensional subspaces (planar patches) — a local linear approximation of the union-of-manifolds structure. (Original Pebblous diagram)

--- a/report/diffusion-low-dim-distributions-jmlr/ko/index.html
+++ b/report/diffusion-low-dim-distributions-jmlr/ko/index.html
@@ -340,8 +340,8 @@
                     <!-- Original diagram: union of low-dim subspaces in ambient space -->
                     <figure class="my-8">
                         <svg viewBox="0 0 720 340" role="img" aria-label="고차원 ambient 공간 안에서 여러 저차원 부분공간의 합집합 근방에 모여 사는 데이터 구조" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:#fbfaf8;">
-                            <rect x="24" y="22" width="672" height="262" rx="16" fill="none" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="7 7"/>
-                            <text x="44" y="50" font-family="Pretendard, sans-serif" font-size="15" fill="#94a3b8">고차원 ambient 공간 ℝⁿ — 거의 비어 있다 (n ≈ 수십만)</text>
+                            <rect x="24" y="22" width="672" height="262" rx="16" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="7 7"/>
+                            <text x="44" y="50" font-family="Pretendard, sans-serif" font-size="15" fill="var(--text-secondary)">고차원 ambient 공간 ℝⁿ — 거의 비어 있다 (n ≈ 수십만)</text>
                             <!-- 부분공간 U1 -->
                             <g transform="rotate(-19 250 175)">
                                 <rect x="70" y="150" width="360" height="50" rx="25" fill="#F86825" opacity="0.12"/>
@@ -358,7 +358,7 @@
                             </g>
                             <!-- ambient 빈 공간의 희박한 점 -->
                             <circle cx="110" cy="250" r="3.5" fill="#cbd5e1"/><circle cx="640" cy="70" r="3.5" fill="#cbd5e1"/><circle cx="600" cy="245" r="3.5" fill="#cbd5e1"/><circle cx="90" cy="95" r="3.5" fill="#cbd5e1"/>
-                            <text x="360" y="312" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="13" fill="#94a3b8">데이터(●)는 저차원 부분공간 U₁·U₂ 근방에만 밀집 — 나머지 공간(○)은 텅 비어 있다</text>
+                            <text x="360" y="312" text-anchor="middle" font-family="Pretendard, sans-serif" font-size="13" fill="var(--text-secondary)">데이터(●)는 저차원 부분공간 U₁·U₂ 근방에만 밀집 — 나머지 공간(○)은 텅 비어 있다</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">
                             ▲ 데이터는 고차원 픽셀 공간을 거의 비워 둔 채, 여러 저차원 부분공간(평면 조각)의 합집합 근방에 모여 산다 — union-of-manifolds 구조의 국소 선형 근사 (페블러스 원본 도식)

--- a/report/openevidence-medical-ai-data-moat/en/index.html
+++ b/report/openevidence-medical-ai-data-moat/en/index.html
@@ -230,14 +230,14 @@
                                 <text x="83" y="149" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#F86825" font-weight="600">Cochrane · NCCN</text>
                             </g>
                             <g>
-                                <rect x="18" y="174" width="130" height="36" rx="8" fill="#94a3b8" opacity="0.18" stroke="#94a3b8" stroke-width="1.5"/>
-                                <text x="83" y="193" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">270+ more journals</text>
-                                <text x="83" y="205" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">35M+ papers indexed</text>
+                                <rect x="18" y="174" width="130" height="36" rx="8" fill="var(--text-secondary)" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.5"/>
+                                <text x="83" y="193" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">270+ more journals</text>
+                                <text x="83" y="205" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">35M+ papers indexed</text>
                             </g>
-                            <text x="83" y="18" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#94a3b8">Licensed Literature</text>
+                            <text x="83" y="18" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="var(--text-secondary)">Licensed Literature</text>
 
                             <!-- Arrow → RAG Index -->
-                            <line x1="150" y1="115" x2="220" y2="115" stroke="#475569" stroke-width="1.5" marker-end="url(#arrEN)"/>
+                            <line x1="150" y1="115" x2="220" y2="115" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrEN)"/>
                             <defs>
                                 <marker id="arrEN" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto">
                                     <polygon points="0 0, 7 3.5, 0 7" fill="#475569"/>
@@ -245,24 +245,24 @@
                             </defs>
 
                             <!-- RAG Index -->
-                            <rect x="222" y="75" width="148" height="80" rx="10" fill="#1e293b" opacity="0.7" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="222" y="75" width="148" height="80" rx="10" fill="#1e293b" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="296" y="107" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#e2e8f0" font-weight="700">RAG Index</text>
-                            <text x="296" y="124" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Vector search + semantic mapping</text>
-                            <text x="296" y="140" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Access: licensed lit only</text>
+                            <text x="296" y="124" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Vector search + semantic mapping</text>
+                            <text x="296" y="140" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Access: licensed lit only</text>
 
                             <!-- Doctor query (top) -->
-                            <rect x="440" y="24" width="148" height="42" rx="8" fill="#334155" opacity="0.7" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="440" y="24" width="148" height="42" rx="8" fill="#334155" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="514" y="43" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#cbd5e1">Physician's clinical query</text>
-                            <text x="514" y="58" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">"Drug interaction for X+Y?"</text>
-                            <line x1="514" y1="67" x2="514" y2="90" stroke="#475569" stroke-width="1.2" marker-end="url(#arrEN)"/>
+                            <text x="514" y="58" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">"Drug interaction for X+Y?"</text>
+                            <line x1="514" y1="67" x2="514" y2="90" stroke="var(--text-muted)" stroke-width="1.2" marker-end="url(#arrEN)"/>
 
                             <!-- Arrow → LLM -->
-                            <line x1="372" y1="115" x2="438" y2="115" stroke="#475569" stroke-width="1.5" marker-end="url(#arrEN)"/>
+                            <line x1="372" y1="115" x2="438" y2="115" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrEN)"/>
 
                             <!-- LLM -->
-                            <rect x="440" y="88" width="148" height="54" rx="10" fill="#1e293b" opacity="0.7" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="440" y="88" width="148" height="54" rx="10" fill="#1e293b" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="514" y="112" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#e2e8f0" font-weight="700">Frontier LLM</text>
-                            <text x="514" y="129" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">OpenAI / Anthropic</text>
+                            <text x="514" y="129" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">OpenAI / Anthropic</text>
 
                             <!-- Arrow → Final answer -->
                             <line x1="514" y1="144" x2="514" y2="170" stroke="#F86825" stroke-width="2" marker-end="url(#arrOrangeEN)"/>
@@ -276,7 +276,7 @@
                             <rect x="418" y="172" width="190" height="56" rx="10" fill="#F86825" opacity="0.12" stroke="#F86825" stroke-width="2"/>
                             <text x="513" y="196" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#F86825" font-weight="700">Answer + Source Citation</text>
                             <text x="513" y="212" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825">"NEJM 2024;391:1234, Fig.3"</text>
-                            <text x="513" y="224" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Verifiable · Provenance-tracked</text>
+                            <text x="513" y="224" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Verifiable · Provenance-tracked</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ Pebblous original diagram — OpenEvidence RAG pipeline: every answer is generated from licensed literature and carries a traceable citation</figcaption>
                     </figure>
@@ -342,12 +342,12 @@
                     <!-- SVG: Triple Moat -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 240" class="w-full max-w-[560px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="Triple moat diagram — three structural barriers a general LLM cannot provide">
-                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#94a3b8">A general-purpose LLM provides none of the three by construction</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="var(--text-secondary)">A general-purpose LLM provides none of the three by construction</text>
                             <!-- Outer: legal licensing barrier -->
-                            <ellipse cx="330" cy="140" rx="300" ry="88" fill="none" stroke="#475569" stroke-width="2" stroke-dasharray="6,3"/>
+                            <ellipse cx="330" cy="140" rx="300" ry="88" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="6,3"/>
                             <rect x="24" y="52" width="190" height="30" rx="6" fill="#334155" opacity="0.85"/>
                             <text x="119" y="72" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#cbd5e1" font-weight="600">① Legal licensing barrier</text>
-                            <text x="119" y="86" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Latecomer must re-negotiate same agreements</text>
+                            <text x="119" y="86" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Latecomer must re-negotiate same agreements</text>
                             <!-- Middle: clinical trust -->
                             <ellipse cx="330" cy="140" rx="210" ry="60" fill="none" stroke="#F86825" stroke-width="1.5" stroke-dasharray="5,3" opacity="0.6"/>
                             <rect x="408" y="64" width="178" height="30" rx="6" fill="#3d1f0a" opacity="0.9"/>
@@ -358,10 +358,10 @@
                             <text x="330" y="140" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#F86825" font-weight="700">③ Liability cover</text>
                             <text x="330" y="156" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825" opacity="0.9">Verifiable citation = legal defense</text>
                             <!-- General LLM marker -->
-                            <circle cx="540" cy="192" r="18" fill="#475569" opacity="0.2" stroke="#475569" stroke-width="1.5" stroke-dasharray="4,2"/>
-                            <text x="540" y="192" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">General</text>
-                            <text x="540" y="203" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">LLM</text>
-                            <line x1="524" y1="185" x2="460" y2="170" stroke="#475569" stroke-width="1" stroke-dasharray="3,2"/>
+                            <circle cx="540" cy="192" r="18" fill="#475569" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="4,2"/>
+                            <text x="540" y="192" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">General</text>
+                            <text x="540" y="203" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">LLM</text>
+                            <line x1="524" y1="185" x2="460" y2="170" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="3,2"/>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ Pebblous original diagram — OpenEvidence's three-layer structural moat: barriers a general-purpose LLM cannot provide by construction</figcaption>
                     </figure>
@@ -381,20 +381,20 @@
                     <!-- SVG: Business Model Flywheel -->
                     <figure class="my-8">
                         <svg viewBox="0 0 600 300" class="w-full max-w-[560px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="OpenEvidence business model flywheel — free product to ~90% gross margin">
-                            <text x="300" y="22" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#94a3b8">Free for doctors → ~90% gross margin flywheel</text>
+                            <text x="300" y="22" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="var(--text-secondary)">Free for doctors → ~90% gross margin flywheel</text>
                             <!-- Center -->
                             <circle cx="300" cy="158" r="46" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="2"/>
                             <text x="300" y="153" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#F86825" font-weight="700">OpenEvidence</text>
                             <text x="300" y="168" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825">flywheel</text>
 
                             <!-- Node 1: Free for doctors (top) -->
-                            <rect x="218" y="38" width="164" height="32" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="218" y="38" width="164" height="32" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="300" y="59" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#e2e8f0">Free for physicians</text>
 
                             <!-- Node 2: Physician adoption (top right) -->
-                            <rect x="468" y="80" width="124" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="468" y="80" width="124" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="530" y="97" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#e2e8f0">Physician adoption</text>
-                            <text x="530" y="111" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">~40% of US doctors</text>
+                            <text x="530" y="111" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">~40% of US doctors</text>
 
                             <!-- Node 3: High-CPM pharma ads (bottom right) -->
                             <rect x="468" y="190" width="124" height="40" rx="8" fill="#1e293b" stroke="#F86825" stroke-width="1.5"/>
@@ -406,26 +406,26 @@
                             <text x="300" y="268" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#F86825" font-weight="600">~90% gross margin</text>
 
                             <!-- Node 5: Expand licensing (bottom left) -->
-                            <rect x="8" y="190" width="134" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="8" y="190" width="134" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="75" y="207" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#e2e8f0">Expand licensing</text>
-                            <text x="75" y="221" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Deepen curation</text>
+                            <text x="75" y="221" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Deepen curation</text>
 
                             <!-- Node 6: Clinical trust grows (top left) -->
-                            <rect x="8" y="80" width="134" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="8" y="80" width="134" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="75" y="97" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#e2e8f0">Clinical trust rises</text>
-                            <text x="75" y="111" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Switching costs grow</text>
+                            <text x="75" y="111" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Switching costs grow</text>
 
                             <!-- Arrows (clockwise) -->
                             <defs>
                                 <marker id="arrENfw" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto"><polygon points="0 0, 7 3.5, 0 7" fill="#475569"/></marker>
                                 <marker id="arrOENfw" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto"><polygon points="0 0, 7 3.5, 0 7" fill="#F86825"/></marker>
                             </defs>
-                            <path d="M382 54 Q450 54 468 95" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arrENfw)"/>
-                            <path d="M548 122 Q582 158 552 190" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arrENfw)"/>
+                            <path d="M382 54 Q450 54 468 95" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrENfw)"/>
+                            <path d="M548 122 Q582 158 552 190" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrENfw)"/>
                             <path d="M468 220 Q382 248 382 248" fill="none" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrOENfw)"/>
                             <path d="M218 264 Q140 250 142 232" fill="none" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrOENfw)"/>
-                            <path d="M75 188 Q54 158 75 122" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arrENfw)"/>
-                            <path d="M142 80 Q218 54 218 54" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arrENfw)"/>
+                            <path d="M75 188 Q54 158 75 122" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrENfw)"/>
+                            <path d="M142 80 Q218 54 218 54" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arrENfw)"/>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ Pebblous original diagram — OpenEvidence business model flywheel: free access drives adoption, adoption drives high-CPM pharma revenue</figcaption>
                     </figure>
@@ -507,7 +507,7 @@
                     <!-- SVG: Cross-domain applicability -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 230" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="Cross-domain map: borrow the model, fence in the data">
-                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="#94a3b8">"Borrow the model, fence in the data" — any domain that meets the three conditions</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" fill="var(--text-secondary)">"Borrow the model, fence in the data" — any domain that meets the three conditions</text>
 
                             <!-- Core structure -->
                             <rect x="240" y="34" width="180" height="44" rx="10" fill="#F86825" opacity="0.13" stroke="#F86825" stroke-width="2"/>
@@ -515,22 +515,22 @@
                             <text x="330" y="70" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825" opacity="0.85">+ RAG + mandatory source citation</text>
 
                             <!-- Connector lines -->
-                            <line x1="330" y1="79" x2="100" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
-                            <line x1="330" y1="79" x2="220" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="100" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="220" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
                             <line x1="330" y1="79" x2="340" y2="128" stroke="#F86825" stroke-width="2"/>
-                            <line x1="330" y1="79" x2="460" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
-                            <line x1="330" y1="79" x2="580" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="460" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="580" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
 
                             <!-- Domain cards -->
-                            <rect x="28" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="28" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="100" y="149" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">Law</text>
-                            <text x="100" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Case law · statutes</text>
-                            <text x="100" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Legal database access</text>
+                            <text x="100" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Case law · statutes</text>
+                            <text x="100" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Legal database access</text>
 
-                            <rect x="148" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="148" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="220" y="149" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">Finance</text>
-                            <text x="220" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Regulatory filings · research</text>
-                            <text x="220" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Bloomberg · EDGAR</text>
+                            <text x="220" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Regulatory filings · research</text>
+                            <text x="220" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Bloomberg · EDGAR</text>
 
                             <!-- Healthcare (highlighted) -->
                             <rect x="268" y="122" width="144" height="64" rx="8" fill="#F86825" opacity="0.13" stroke="#F86825" stroke-width="2"/>
@@ -538,17 +538,17 @@
                             <text x="340" y="161" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825" opacity="0.9">NEJM · JAMA · Cochrane</text>
                             <text x="340" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#F86825" opacity="0.8">$12B (OpenEvidence)</text>
 
-                            <rect x="388" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="388" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="460" y="149" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">Science / R&amp;D</text>
-                            <text x="460" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Papers · patents</text>
-                            <text x="460" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Specialist journal access</text>
+                            <text x="460" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Papers · patents</text>
+                            <text x="460" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Specialist journal access</text>
 
-                            <rect x="508" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="508" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="580" y="149" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">Regulation</text>
-                            <text x="580" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Guidelines · codes</text>
-                            <text x="580" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Official doc licensing</text>
+                            <text x="580" y="164" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Guidelines · codes</text>
+                            <text x="580" y="175" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Official doc licensing</text>
 
-                            <text x="330" y="210" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Conditions: ① Licensable proprietary data  ② High cost of being wrong  ③ No free access for general LLMs</text>
+                            <text x="330" y="210" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Conditions: ① Licensable proprietary data  ② High cost of being wrong  ③ No free access for general LLMs</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ Pebblous original diagram — domain map where "borrow the model, fence in the data" applies</figcaption>
                     </figure>

--- a/report/openevidence-medical-ai-data-moat/ko/index.html
+++ b/report/openevidence-medical-ai-data-moat/ko/index.html
@@ -230,14 +230,14 @@
                                 <text x="83" y="149" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#F86825" font-weight="600">코크란·NCCN</text>
                             </g>
                             <g>
-                                <rect x="18" y="174" width="130" height="36" rx="8" fill="#94a3b8" opacity="0.18" stroke="#94a3b8" stroke-width="1.5"/>
-                                <text x="83" y="193" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">기타 270개+ 저널</text>
-                                <text x="83" y="205" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">3,500만건 인덱싱</text>
+                                <rect x="18" y="174" width="130" height="36" rx="8" fill="var(--text-secondary)" opacity="0.18" stroke="var(--text-muted)" stroke-width="1.5"/>
+                                <text x="83" y="193" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">기타 270개+ 저널</text>
+                                <text x="83" y="205" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">3,500만건 인덱싱</text>
                             </g>
-                            <text x="83" y="18" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#94a3b8">라이선스 문헌</text>
+                            <text x="83" y="18" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="var(--text-secondary)">라이선스 문헌</text>
 
                             <!-- 화살표 → RAG 인덱스 -->
-                            <line x1="150" y1="115" x2="220" y2="115" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+                            <line x1="150" y1="115" x2="220" y2="115" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr)"/>
                             <defs>
                                 <marker id="arr" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto">
                                     <polygon points="0 0, 7 3.5, 0 7" fill="#475569"/>
@@ -245,24 +245,24 @@
                             </defs>
 
                             <!-- RAG 인덱스 -->
-                            <rect x="222" y="75" width="148" height="80" rx="10" fill="#1e293b" opacity="0.7" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="222" y="75" width="148" height="80" rx="10" fill="#1e293b" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="296" y="107" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#e2e8f0" font-weight="700">RAG 인덱스</text>
-                            <text x="296" y="124" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">벡터 검색 + 의미 매핑</text>
-                            <text x="296" y="140" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">동료심사 문헌만 접근</text>
+                            <text x="296" y="124" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">벡터 검색 + 의미 매핑</text>
+                            <text x="296" y="140" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">동료심사 문헌만 접근</text>
 
                             <!-- 의사 질의 (위에서) -->
-                            <rect x="440" y="24" width="138" height="42" rx="8" fill="#334155" opacity="0.7" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="440" y="24" width="138" height="42" rx="8" fill="#334155" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="509" y="43" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#cbd5e1">의사의 임상 질의</text>
-                            <text x="509" y="58" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">"이 약물 상호작용은?"</text>
-                            <line x1="509" y1="67" x2="509" y2="90" stroke="#475569" stroke-width="1.2" marker-end="url(#arr)"/>
+                            <text x="509" y="58" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">"이 약물 상호작용은?"</text>
+                            <line x1="509" y1="67" x2="509" y2="90" stroke="var(--text-muted)" stroke-width="1.2" marker-end="url(#arr)"/>
 
                             <!-- 화살표 → LLM -->
-                            <line x1="372" y1="115" x2="438" y2="115" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+                            <line x1="372" y1="115" x2="438" y2="115" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr)"/>
 
                             <!-- LLM -->
-                            <rect x="440" y="88" width="138" height="54" rx="10" fill="#1e293b" opacity="0.7" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="440" y="88" width="138" height="54" rx="10" fill="#1e293b" opacity="0.7" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="509" y="112" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#e2e8f0" font-weight="700">프런티어 LLM</text>
-                            <text x="509" y="129" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">OpenAI / Anthropic</text>
+                            <text x="509" y="129" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">OpenAI / Anthropic</text>
 
                             <!-- 화살표 → 최종 답변 -->
                             <line x1="509" y1="144" x2="509" y2="170" stroke="#F86825" stroke-width="2" marker-end="url(#arrorange)"/>
@@ -276,7 +276,7 @@
                             <rect x="418" y="172" width="182" height="56" rx="10" fill="#F86825" opacity="0.12" stroke="#F86825" stroke-width="2"/>
                             <text x="509" y="196" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#F86825" font-weight="700">출처 인용이 붙은 답변</text>
                             <text x="509" y="212" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825">"NEJM 2024;391:1234, Fig.3"</text>
-                            <text x="509" y="224" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">검증 가능 · 책임 추적 가능</text>
+                            <text x="509" y="224" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">검증 가능 · 책임 추적 가능</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ 페블러스 원본 도식 — OpenEvidence RAG 파이프라인: 라이선스 문헌만을 근거로 출처가 붙은 답변을 생성한다</figcaption>
                     </figure>
@@ -342,12 +342,12 @@
                     <!-- SVG: 세 겹 해자 -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 240" class="w-full max-w-[560px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="세 겹 해자 도식">
-                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#94a3b8">범용 LLM은 세 겹 중 어느 것도 구조적으로 제공하지 못한다</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="var(--text-secondary)">범용 LLM은 세 겹 중 어느 것도 구조적으로 제공하지 못한다</text>
                             <!-- 외곽: 법적 라이선스 장벽 -->
-                            <ellipse cx="330" cy="140" rx="300" ry="88" fill="none" stroke="#475569" stroke-width="2" stroke-dasharray="6,3"/>
+                            <ellipse cx="330" cy="140" rx="300" ry="88" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="6,3"/>
                             <rect x="30" y="52" width="174" height="30" rx="6" fill="#334155" opacity="0.85"/>
                             <text x="117" y="72" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#cbd5e1" font-weight="600">① 법적 라이선스 장벽</text>
-                            <text x="117" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">재계약 없이 동일 데이터 접근 불가</text>
+                            <text x="117" y="86" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">재계약 없이 동일 데이터 접근 불가</text>
                             <!-- 중간: 임상 신뢰 -->
                             <ellipse cx="330" cy="140" rx="210" ry="60" fill="none" stroke="#F86825" stroke-width="1.5" stroke-dasharray="5,3" opacity="0.6"/>
                             <rect x="420" y="64" width="160" height="30" rx="6" fill="#3d1f0a" opacity="0.9"/>
@@ -358,9 +358,9 @@
                             <text x="330" y="140" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#F86825" font-weight="700">③ 책임 방어선</text>
                             <text x="330" y="156" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825" opacity="0.9">검증 가능한 인용 = 법적 방패</text>
                             <!-- 범용 LLM 표시 -->
-                            <circle cx="540" cy="192" r="18" fill="#475569" opacity="0.2" stroke="#475569" stroke-width="1.5" stroke-dasharray="4,2"/>
-                            <text x="540" y="196" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">범용 LLM</text>
-                            <line x1="524" y1="185" x2="460" y2="170" stroke="#475569" stroke-width="1" stroke-dasharray="3,2"/>
+                            <circle cx="540" cy="192" r="18" fill="#475569" opacity="0.2" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="4,2"/>
+                            <text x="540" y="196" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">범용 LLM</text>
+                            <line x1="524" y1="185" x2="460" y2="170" stroke="var(--text-muted)" stroke-width="1" stroke-dasharray="3,2"/>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ 페블러스 원본 도식 — OpenEvidence의 세 겹 구조적 해자: 범용 LLM이 넘을 수 없는 세 층위</figcaption>
                     </figure>
@@ -380,20 +380,20 @@
                     <!-- SVG: 비즈니스 모델 플라이휠 -->
                     <figure class="my-8">
                         <svg viewBox="0 0 600 300" class="w-full max-w-[560px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="OpenEvidence 비즈니스 모델 플라이휠">
-                            <text x="300" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#94a3b8">의사에게 무료 → 90% 총마진 플라이휠</text>
+                            <text x="300" y="22" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="var(--text-secondary)">의사에게 무료 → 90% 총마진 플라이휠</text>
                             <!-- 중심 -->
                             <circle cx="300" cy="158" r="46" fill="#F86825" opacity="0.15" stroke="#F86825" stroke-width="2"/>
                             <text x="300" y="153" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#F86825" font-weight="700">OpenEvidence</text>
                             <text x="300" y="168" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825">플라이휠</text>
 
                             <!-- 노드 1: 의사에게 무료 (상단) -->
-                            <rect x="218" y="38" width="164" height="32" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="218" y="38" width="164" height="32" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="300" y="59" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#e2e8f0">의사에게 무료 제공</text>
 
                             <!-- 노드 2: 의사 채택 폭증 (우상단) -->
-                            <rect x="468" y="80" width="120" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="468" y="80" width="120" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="528" y="97" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#e2e8f0">의사 채택 폭증</text>
-                            <text x="528" y="111" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">~40% US 의사</text>
+                            <text x="528" y="111" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">~40% US 의사</text>
 
                             <!-- 노드 3: 고CPM 제약 광고 (우하단) -->
                             <rect x="468" y="190" width="120" height="40" rx="8" fill="#1e293b" stroke="#F86825" stroke-width="1.5"/>
@@ -405,22 +405,22 @@
                             <text x="300" y="266" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#F86825" font-weight="600">~90% 총마진 확보</text>
 
                             <!-- 노드 5: 데이터·큐레이션 강화 (좌하단) -->
-                            <rect x="12" y="190" width="130" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="12" y="190" width="130" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="77" y="207" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#e2e8f0">라이선스 확대</text>
-                            <text x="77" y="221" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">큐레이션 강화</text>
+                            <text x="77" y="221" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">큐레이션 강화</text>
 
                             <!-- 노드 6: 신뢰·채택 증가 (좌상단) -->
-                            <rect x="12" y="80" width="130" height="40" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+                            <rect x="12" y="80" width="130" height="40" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.5"/>
                             <text x="77" y="97" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="11" fill="#e2e8f0">임상 신뢰 상승</text>
-                            <text x="77" y="111" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">전환 비용 누적</text>
+                            <text x="77" y="111" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">전환 비용 누적</text>
 
                             <!-- 화살표 (시계방향) -->
-                            <path d="M382 54 Q450 54 468 95" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
-                            <path d="M544 122 Q580 158 548 190" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+                            <path d="M382 54 Q450 54 468 95" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr2)"/>
+                            <path d="M544 122 Q580 158 548 190" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr2)"/>
                             <path d="M468 220 Q382 248 382 248" fill="none" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrorange2)"/>
                             <path d="M218 264 Q142 248 142 230" fill="none" stroke="#F86825" stroke-width="1.5" marker-end="url(#arrorange2)"/>
-                            <path d="M77 188 Q56 158 77 122" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
-                            <path d="M142 80 Q218 54 218 54" fill="none" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+                            <path d="M77 188 Q56 158 77 122" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr2)"/>
+                            <path d="M142 80 Q218 54 218 54" fill="none" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#arr2)"/>
                             <defs>
                                 <marker id="arr2" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto"><polygon points="0 0, 7 3.5, 0 7" fill="#475569"/></marker>
                                 <marker id="arrorange2" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto"><polygon points="0 0, 7 3.5, 0 7" fill="#F86825"/></marker>
@@ -506,7 +506,7 @@
                     <!-- SVG: 도메인 일반화 패턴 -->
                     <figure class="my-8">
                         <svg viewBox="0 0 660 230" class="w-full max-w-[660px] h-auto mx-auto rounded-xl border themeable-border" style="background:rgba(248,248,248,0.04);" aria-label="모델은 빌리고 데이터는 가둔다 — 도메인 일반화">
-                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="#94a3b8">'모델은 빌리고 데이터는 가둔다' — 세 조건이 맞는 모든 도메인</text>
+                            <text x="330" y="20" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="13" fill="var(--text-secondary)">'모델은 빌리고 데이터는 가둔다' — 세 조건이 맞는 모든 도메인</text>
 
                             <!-- 중심 구조 라벨 -->
                             <rect x="240" y="34" width="180" height="44" rx="10" fill="#F86825" opacity="0.13" stroke="#F86825" stroke-width="2"/>
@@ -514,24 +514,24 @@
                             <text x="330" y="70" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825" opacity="0.85">+ RAG + 출처 인용 강제</text>
 
                             <!-- 연결선 -->
-                            <line x1="330" y1="79" x2="100" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
-                            <line x1="330" y1="79" x2="220" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="100" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="220" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
                             <line x1="330" y1="79" x2="340" y2="128" stroke="#F86825" stroke-width="2"/>
-                            <line x1="330" y1="79" x2="460" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
-                            <line x1="330" y1="79" x2="580" y2="128" stroke="#475569" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="460" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
+                            <line x1="330" y1="79" x2="580" y2="128" stroke="var(--text-muted)" stroke-width="1.2" stroke-dasharray="4,2"/>
 
                             <!-- 도메인 카드 -->
                             <!-- 법률 -->
-                            <rect x="28" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="28" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="100" y="149" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">법률</text>
-                            <text x="100" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">판례 · 법령</text>
-                            <text x="100" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">법률 데이터베이스 접근권</text>
+                            <text x="100" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">판례 · 법령</text>
+                            <text x="100" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">법률 데이터베이스 접근권</text>
 
                             <!-- 금융 -->
-                            <rect x="148" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="148" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="220" y="149" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">금융</text>
-                            <text x="220" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">규제 공시 · 리서치</text>
-                            <text x="220" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">블룸버그 · EDGAR</text>
+                            <text x="220" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">규제 공시 · 리서치</text>
+                            <text x="220" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">블룸버그 · EDGAR</text>
 
                             <!-- 헬스케어 (강조) -->
                             <rect x="268" y="122" width="144" height="64" rx="8" fill="#F86825" opacity="0.13" stroke="#F86825" stroke-width="2"/>
@@ -540,19 +540,19 @@
                             <text x="340" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#F86825" opacity="0.8">$12B (OpenEvidence)</text>
 
                             <!-- 과학 -->
-                            <rect x="388" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="388" y="128" width="144" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="460" y="149" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">과학·R&amp;D</text>
-                            <text x="460" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">논문 · 특허</text>
-                            <text x="460" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">전문 저널 접근권</text>
+                            <text x="460" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">논문 · 특허</text>
+                            <text x="460" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">전문 저널 접근권</text>
 
                             <!-- 기타 -->
-                            <rect x="508" y="128" width="136" height="52" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1.2"/>
+                            <rect x="508" y="128" width="136" height="52" rx="8" fill="#1e293b" stroke="var(--text-muted)" stroke-width="1.2"/>
                             <text x="576" y="149" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="12" fill="#e2e8f0" font-weight="600">규제·컴플라이언스</text>
-                            <text x="576" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">가이드라인 · 코드</text>
-                            <text x="576" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">공식 문서 라이선스</text>
+                            <text x="576" y="164" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">가이드라인 · 코드</text>
+                            <text x="576" y="175" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">공식 문서 라이선스</text>
 
                             <!-- 조건 요약 -->
-                            <text x="330" y="210" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="#94a3b8">공통 조건: ① 라이선스 가능한 독점 데이터  ② 높은 오답 비용  ③ 범용 LLM의 합법적 접근 불가</text>
+                            <text x="330" y="210" text-anchor="middle" font-family="Pretendard,sans-serif" font-size="10" fill="var(--text-secondary)">공통 조건: ① 라이선스 가능한 독점 데이터  ② 높은 오답 비용  ③ 범용 LLM의 합법적 접근 불가</text>
                         </svg>
                         <figcaption class="text-xs themeable-muted text-center mt-2">▲ 페블러스 원본 도식 — '모델은 빌리고 데이터는 가둔다' 구조가 적용되는 도메인 지도</figcaption>
                     </figure>

--- a/report/sakana-fugu-ultra/en/index.html
+++ b/report/sakana-fugu-ultra/en/index.html
@@ -152,43 +152,43 @@
                            style="max-width:640px;background:rgba(248,250,252,0.5)">
                         <defs>
                           <marker id="fugu-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-                            <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+                            <polygon points="0 0, 8 3, 0 6" fill="var(--text-secondary)"/>
                           </marker>
                         </defs>
                         <!-- User Task -->
-                        <rect x="10" y="57" width="80" height="60" rx="8" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="10" y="57" width="80" height="60" rx="8" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="50" y="83" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">User</text>
                         <text x="50" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">Task</text>
                         <!-- Arrow: Task → Fugu -->
-                        <line x1="90" y1="87" x2="138" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="90" y1="87" x2="138" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Fugu Ultra coordinator box -->
                         <rect x="140" y="22" width="155" height="130" rx="10" fill="none" stroke="#F86825" stroke-width="2"/>
                         <text x="217" y="47" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#F86825">Fugu Ultra</text>
-                        <text x="217" y="63" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">Learned Coordinator</text>
+                        <text x="217" y="63" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">Learned Coordinator</text>
                         <line x1="155" y1="73" x2="280" y2="73" stroke="#e2e8f0" stroke-width="1"/>
                         <text x="217" y="90" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">① decompose</text>
                         <text x="217" y="106" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">② route (RL policy)</text>
                         <text x="217" y="122" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">③ verify + synthesize</text>
                         <!-- Arrows: Fugu → Sub-models -->
-                        <line x1="295" y1="55" x2="328" y2="42" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="295" y1="87" x2="328" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="295" y1="119" x2="328" y2="132" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="55" x2="328" y2="42" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="87" x2="328" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="119" x2="328" y2="132" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Sub-model A -->
-                        <rect x="330" y="22" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="22" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="38" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">Model A</text>
-                        <text x="390" y="54" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">coding / SWE</text>
+                        <text x="390" y="54" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">coding / SWE</text>
                         <!-- Sub-model B -->
-                        <rect x="330" y="67" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="67" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="83" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">Model B</text>
-                        <text x="390" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">science / reasoning</text>
+                        <text x="390" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">science / reasoning</text>
                         <!-- Sub-model C -->
-                        <rect x="330" y="112" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="112" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="128" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">Model C</text>
-                        <text x="390" y="144" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">long-context / agentic</text>
+                        <text x="390" y="144" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">long-context / agentic</text>
                         <!-- Arrows: Sub-models → Answer -->
-                        <line x1="450" y1="42" x2="488" y2="70" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="450" y1="87" x2="488" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="450" y1="132" x2="488" y2="104" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="42" x2="488" y2="70" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="87" x2="488" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="132" x2="488" y2="104" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Verified Answer -->
                         <rect x="490" y="57" width="130" height="60" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="1.5"/>
                         <text x="555" y="82" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#F86825">Verified</text>
@@ -422,13 +422,13 @@
                         <text x="310" y="55" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="700" fill="#F86825">Tier 1 — Unrestricted Access</text>
                         <text x="310" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#92400e">US + 18 allies: Korea, Japan, Taiwan…</text>
                         <!-- Tier 2: wider, gray, middle -->
-                        <rect x="85" y="101" width="450" height="52" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                        <rect x="85" y="101" width="450" height="52" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="310" y="123" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#475569">Tier 2 — Volume Caps + Verified End-User</text>
                         <text x="310" y="140" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">Most countries — individual model caps, licensing required</text>
                         <!-- Tier 3: widest, bottom -->
-                        <rect x="10" y="168" width="600" height="52" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="10" y="168" width="600" height="52" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="310" y="190" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#334155">Tier 3 — Effectively Export-Banned</text>
-                        <text x="310" y="207" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">China, Russia, Iran, North Korea — frontier models inaccessible</text>
+                        <text x="310" y="207" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">China, Russia, Iran, North Korea — frontier models inaccessible</text>
                       </svg>
                       <figcaption class="text-xs themeable-muted text-center mt-2">▲ The AI Diffusion Rule's three-tier pyramid: Tier 1 allies enjoy unrestricted access; Tier 2 faces volume controls; Tier 3 adversary nations are effectively cut off from frontier models. Fugu's "AI sovereignty" strategy targets the gap between Tier 1 and restricted zones. | Pebblous original diagram</figcaption>
                     </figure>
@@ -461,26 +461,26 @@
                         <!-- Title -->
                         <text x="252" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#64748b">Jevons Paradox: Cheaper Tokens, Higher Total Spend</text>
                         <!-- Y-axis -->
-                        <line x1="55" y1="35" x2="55" y2="155" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <line x1="55" y1="35" x2="55" y2="155" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <!-- X-axis -->
-                        <line x1="55" y1="155" x2="450" y2="155" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <line x1="55" y1="155" x2="450" y2="155" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <!-- Grid lines -->
                         <line x1="55" y1="75" x2="450" y2="75" stroke="#e2e8f0" stroke-width="0.5" stroke-dasharray="3,3"/>
                         <line x1="55" y1="115" x2="450" y2="115" stroke="#e2e8f0" stroke-width="0.5" stroke-dasharray="3,3"/>
                         <!-- Y-axis label -->
-                        <text x="18" y="100" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8" transform="rotate(-90 18 100)">Relative Level</text>
+                        <text x="18" y="100" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)" transform="rotate(-90 18 100)">Relative Level</text>
                         <!-- X labels -->
-                        <text x="55" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2022</text>
-                        <text x="153" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2023</text>
-                        <text x="253" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2024</text>
-                        <text x="352" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2025</text>
-                        <text x="450" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2026</text>
+                        <text x="55" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2022</text>
+                        <text x="153" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2023</text>
+                        <text x="253" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2024</text>
+                        <text x="352" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2025</text>
+                        <text x="450" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2026</text>
                         <!-- Cost per token: falling (orange) -->
                         <polyline points="55,45 153,70 253,105 352,135 450,150" fill="none" stroke="#F86825" stroke-width="2.5"/>
                         <text x="455" y="150" font-family="Outfit,sans-serif" font-size="10" font-weight="600" fill="#F86825">$/token</text>
                         <text x="455" y="163" font-family="Outfit,sans-serif" font-size="9" fill="#F86825">↓ ~10×/yr</text>
                         <!-- Total enterprise spend: rising (slate, dashed) -->
-                        <polyline points="55,148 153,138 253,118 352,82 450,42" fill="none" stroke="#475569" stroke-width="2.5" stroke-dasharray="6,3"/>
+                        <polyline points="55,148 153,138 253,118 352,82 450,42" fill="none" stroke="var(--text-muted)" stroke-width="2.5" stroke-dasharray="6,3"/>
                         <text x="455" y="42" font-family="Outfit,sans-serif" font-size="10" font-weight="600" fill="#475569">Total</text>
                         <text x="455" y="55" font-family="Outfit,sans-serif" font-size="9" fill="#475569">spend ↑</text>
                         <!-- Annotation -->

--- a/report/sakana-fugu-ultra/ko/index.html
+++ b/report/sakana-fugu-ultra/ko/index.html
@@ -152,43 +152,43 @@
                            style="max-width:640px;background:rgba(248,250,252,0.5)">
                         <defs>
                           <marker id="fugu-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-                            <polygon points="0 0, 8 3, 0 6" fill="#94a3b8"/>
+                            <polygon points="0 0, 8 3, 0 6" fill="var(--text-secondary)"/>
                           </marker>
                         </defs>
                         <!-- User Task -->
-                        <rect x="10" y="57" width="80" height="60" rx="8" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="10" y="57" width="80" height="60" rx="8" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="50" y="83" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">사용자</text>
                         <text x="50" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#64748b">작업</text>
                         <!-- Arrow: Task → Fugu -->
-                        <line x1="90" y1="87" x2="138" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="90" y1="87" x2="138" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Fugu Ultra coordinator box -->
                         <rect x="140" y="22" width="155" height="130" rx="10" fill="none" stroke="#F86825" stroke-width="2"/>
                         <text x="217" y="47" text-anchor="middle" font-family="Outfit,sans-serif" font-size="13" font-weight="700" fill="#F86825">Fugu Ultra</text>
-                        <text x="217" y="63" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">학습된 코디네이터</text>
+                        <text x="217" y="63" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">학습된 코디네이터</text>
                         <line x1="155" y1="73" x2="280" y2="73" stroke="#e2e8f0" stroke-width="1"/>
                         <text x="217" y="90" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">① 분해</text>
                         <text x="217" y="106" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">② 라우팅 (RL 정책)</text>
                         <text x="217" y="122" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">③ 검증·합성</text>
                         <!-- Arrows: Fugu → Sub-models -->
-                        <line x1="295" y1="55" x2="328" y2="42" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="295" y1="87" x2="328" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="295" y1="119" x2="328" y2="132" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="55" x2="328" y2="42" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="87" x2="328" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="295" y1="119" x2="328" y2="132" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Sub-model A -->
-                        <rect x="330" y="22" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="22" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="38" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">모델 A</text>
-                        <text x="390" y="54" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">코딩 / SWE</text>
+                        <text x="390" y="54" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">코딩 / SWE</text>
                         <!-- Sub-model B -->
-                        <rect x="330" y="67" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="67" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="83" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">모델 B</text>
-                        <text x="390" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">과학 / 추론</text>
+                        <text x="390" y="99" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">과학 / 추론</text>
                         <!-- Sub-model C -->
-                        <rect x="330" y="112" width="120" height="40" rx="6" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="330" y="112" width="120" height="40" rx="6" fill="none" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="390" y="128" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#475569">모델 C</text>
-                        <text x="390" y="144" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="#94a3b8">장문맥 / 에이전트</text>
+                        <text x="390" y="144" text-anchor="middle" font-family="Outfit,sans-serif" font-size="9" fill="var(--text-secondary)">장문맥 / 에이전트</text>
                         <!-- Arrows: Sub-models → Answer -->
-                        <line x1="450" y1="42" x2="488" y2="70" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="450" y1="87" x2="488" y2="87" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
-                        <line x1="450" y1="132" x2="488" y2="104" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="42" x2="488" y2="70" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="87" x2="488" y2="87" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
+                        <line x1="450" y1="132" x2="488" y2="104" stroke="var(--text-muted)" stroke-width="1.5" marker-end="url(#fugu-arr)"/>
                         <!-- Verified Answer -->
                         <rect x="490" y="57" width="130" height="60" rx="8" fill="#fff7ed" stroke="#F86825" stroke-width="1.5"/>
                         <text x="555" y="82" text-anchor="middle" font-family="Outfit,sans-serif" font-size="11" fill="#F86825">검증된</text>
@@ -422,13 +422,13 @@
                         <text x="310" y="55" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="700" fill="#F86825">Tier 1 — 제한 없는 접근</text>
                         <text x="310" y="73" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#92400e">미국 + 18개 동맹국: 한국·일본·대만…</text>
                         <!-- Tier 2: wider, gray, middle -->
-                        <rect x="85" y="101" width="450" height="52" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+                        <rect x="85" y="101" width="450" height="52" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="310" y="123" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#475569">Tier 2 — 물량 상한 + 검증된 최종사용자</text>
                         <text x="310" y="140" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#64748b">대부분 국가 — 모델별 상한·라이선스 필요</text>
                         <!-- Tier 3: widest, bottom -->
-                        <rect x="10" y="168" width="600" height="52" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <rect x="10" y="168" width="600" height="52" rx="8" fill="#f1f5f9" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <text x="310" y="190" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#334155">Tier 3 — 사실상 수출 금지</text>
-                        <text x="310" y="207" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">중국·러시아·이란·북한 — 프런티어 모델 접근 불가</text>
+                        <text x="310" y="207" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">중국·러시아·이란·북한 — 프런티어 모델 접근 불가</text>
                       </svg>
                       <figcaption class="text-xs themeable-muted text-center mt-2">▲ AI 확산 규칙의 3티어 피라미드. Tier 1 동맹국은 제한 없는 접근을, Tier 2는 물량 통제를 받고, Tier 3 적성국은 프런티어 모델에서 사실상 차단된다. Fugu의 "AI 주권" 전략은 Tier 1과 제한 구역 사이의 틈을 겨냥한다. | 페블러스 자체 제작 다이어그램</figcaption>
                     </figure>
@@ -461,26 +461,26 @@
                         <!-- Title -->
                         <text x="252" y="20" text-anchor="middle" font-family="Outfit,sans-serif" font-size="12" font-weight="600" fill="#64748b">제번스 역설: 토큰은 싸지는데 총지출은 늘어난다</text>
                         <!-- Y-axis -->
-                        <line x1="55" y1="35" x2="55" y2="155" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <line x1="55" y1="35" x2="55" y2="155" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <!-- X-axis -->
-                        <line x1="55" y1="155" x2="450" y2="155" stroke="#cbd5e1" stroke-width="1.5"/>
+                        <line x1="55" y1="155" x2="450" y2="155" stroke="var(--text-muted)" stroke-width="1.5"/>
                         <!-- Grid lines -->
                         <line x1="55" y1="75" x2="450" y2="75" stroke="#e2e8f0" stroke-width="0.5" stroke-dasharray="3,3"/>
                         <line x1="55" y1="115" x2="450" y2="115" stroke="#e2e8f0" stroke-width="0.5" stroke-dasharray="3,3"/>
                         <!-- Y-axis label -->
-                        <text x="18" y="100" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8" transform="rotate(-90 18 100)">상대 수준</text>
+                        <text x="18" y="100" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)" transform="rotate(-90 18 100)">상대 수준</text>
                         <!-- X labels -->
-                        <text x="55" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2022</text>
-                        <text x="153" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2023</text>
-                        <text x="253" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2024</text>
-                        <text x="352" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2025</text>
-                        <text x="450" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="#94a3b8">2026</text>
+                        <text x="55" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2022</text>
+                        <text x="153" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2023</text>
+                        <text x="253" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2024</text>
+                        <text x="352" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2025</text>
+                        <text x="450" y="170" text-anchor="middle" font-family="Outfit,sans-serif" font-size="10" fill="var(--text-secondary)">2026</text>
                         <!-- Cost per token: falling (orange) -->
                         <polyline points="55,45 153,70 253,105 352,135 450,150" fill="none" stroke="#F86825" stroke-width="2.5"/>
                         <text x="455" y="150" font-family="Outfit,sans-serif" font-size="10" font-weight="600" fill="#F86825">$/token</text>
                         <text x="455" y="163" font-family="Outfit,sans-serif" font-size="9" fill="#F86825">↓ ~10배/년</text>
                         <!-- Total enterprise spend: rising (slate, dashed) -->
-                        <polyline points="55,148 153,138 253,118 352,82 450,42" fill="none" stroke="#475569" stroke-width="2.5" stroke-dasharray="6,3"/>
+                        <polyline points="55,148 153,138 253,118 352,82 450,42" fill="none" stroke="var(--text-muted)" stroke-width="2.5" stroke-dasharray="6,3"/>
                         <text x="455" y="42" font-family="Outfit,sans-serif" font-size="10" font-weight="600" fill="#475569">총지출</text>
                         <text x="455" y="55" font-family="Outfit,sans-serif" font-size="9" fill="#475569">↑ 상승</text>
                         <!-- Annotation -->

--- a/story/qr-story-pb/en/index.html
+++ b/story/qr-story-pb/en/index.html
@@ -352,8 +352,8 @@
                 <figure class="my-8">
                     <svg class="qr-anatomy-svg" viewBox="0 0 480 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="QR Code anatomy diagram showing Finder Patterns, Timing Patterns, Data Area, and Error Correction zones">
                         <!-- Background -->
-                        <rect x="20" y="20" width="440" height="440" rx="8" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6"/>
-                        <text x="240" y="14" text-anchor="middle" fill="#94a3b8" font-size="11">Quiet Zone</text>
+                        <rect x="20" y="20" width="440" height="440" rx="8" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-dasharray="6"/>
+                        <text x="240" y="14" text-anchor="middle" fill="var(--text-secondary)" font-size="11">Quiet Zone</text>
 
                         <!-- Grid background -->
                         <rect x="40" y="40" width="400" height="400" rx="4" fill="#f1f5f9"/>


### PR DESCRIPTION
> **무엇**: 인라인 SVG 도식의 흐린 회색(#94a3b8) 텍스트·선을 테마 변수로 → light/beige 테마서 대비 ~2.6:1 → ~7.5:1.
> **왜**: 다크테마 색(#94a3b8)을 하드코딩해 흰 바탕에서 안 보였음(JH 피드백, EU AI Act 글).
> **효과**: `fill=#94a3b8→var(--text-secondary)`, 회색 `stroke→var(--text-muted)`. 다크박스 텍스트·오렌지 강조 보존. 다크테마선 자동 복귀. 23글/465토큰.

근본 원인(스킬 색 규칙)은 진본 별도 PR로 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)