### PR TITLE
fix(visuals): 차트·도식 색 브랜드화 (기계적 7글)

### DIFF
--- a/project/CURK/ontology/palantir-vs-classic-ontology/en/index.html
+++ b/project/CURK/ontology/palantir-vs-classic-ontology/en/index.html
@@ -300,7 +300,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #808080;
             --border-color: #334155;
         }
 
@@ -361,7 +361,7 @@
         .timeline-line {
             position: absolute;
             width: 2px;
-            background: linear-gradient(180deg, #6b7280 0%, #3b82f6 33%, #9ca3af 66%, #f97316 100%);
+            background: linear-gradient(180deg, #6b7280 0%, #171719 33%, #9ca3af 66%, #FF9267 100%);
             z-index: 0;
         }
 
@@ -655,9 +655,9 @@
         }
 
         .timeline-badge.bg-gray-500 { background-color: #6b7280; }
-        .timeline-badge.bg-blue-600 { background-color: #2563eb; }
+        .timeline-badge.bg-blue-600 { background-color: #171719; }
         .timeline-badge.bg-gray-400 { background-color: #9ca3af; }
-        .timeline-badge.bg-orange-600 { background-color: #ea580c; }
+        .timeline-badge.bg-orange-600 { background-color: #F86825; }
 
         @media (max-width: 768px) {
             .timeline-line {
@@ -696,7 +696,7 @@
         #scrollProgressBar {
             width: 100%;
             height: 0%;
-            background: linear-gradient(to bottom, #f97316, #ea580c);
+            background: linear-gradient(to bottom, #FF9267, #F86825);
             transition: height 0.1s ease-out;
         }
 
@@ -1125,27 +1125,27 @@
                         <svg viewBox="0 0 300 200" class="w-full h-48 mb-4 flow-diagram">
                             <!-- Step 1: Query -->
                             <g class="linear-step">
-                                <circle cx="50" cy="100" r="35" fill="#2563eb" stroke="#1e40af" stroke-width="3"/>
+                                <circle cx="50" cy="100" r="35" fill="#171719" stroke="#0F0F10" stroke-width="3"/>
                                 <text x="50" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 1</text>
                                 <text x="50" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Query</text>
                             </g>
 
                             <!-- Arrow 1 -->
-                            <path class="linear-arrow" d="M 90 100 L 120 100" stroke="#2563eb" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
+                            <path class="linear-arrow" d="M 90 100 L 120 100" stroke="#171719" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
 
                             <!-- Step 2: Read -->
                             <g class="linear-step">
-                                <circle cx="150" cy="100" r="35" fill="#3b82f6" stroke="#2563eb" stroke-width="3"/>
+                                <circle cx="150" cy="100" r="35" fill="#171719" stroke="#171719" stroke-width="3"/>
                                 <text x="150" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 2</text>
                                 <text x="150" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Reasoning</text>
                             </g>
 
                             <!-- Arrow 2 -->
-                            <path class="linear-arrow" d="M 190 100 L 220 100" stroke="#2563eb" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
+                            <path class="linear-arrow" d="M 190 100 L 220 100" stroke="#171719" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
 
                             <!-- Step 3: Result -->
                             <g class="linear-step">
-                                <circle cx="250" cy="100" r="35" fill="#60a5fa" stroke="#3b82f6" stroke-width="3"/>
+                                <circle cx="250" cy="100" r="35" fill="#808080" stroke="#171719" stroke-width="3"/>
                                 <text x="250" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 3</text>
                                 <text x="250" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Result</text>
                             </g>
@@ -1153,7 +1153,7 @@
                             <!-- Arrow marker definition -->
                             <defs>
                                 <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-                                    <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
+                                    <path d="M0,0 L0,6 L9,3 z" fill="#171719"/>
                                 </marker>
                             </defs>
                         </svg>
@@ -1179,41 +1179,41 @@
                         <svg viewBox="0 0 300 200" class="w-full h-48 mb-4 flow-diagram">
                             <!-- Step 1: Act (Top vertex) -->
                             <g class="circular-step">
-                                <circle cx="150" cy="50" r="35" fill="#ea580c" stroke="#c2410c" stroke-width="3"/>
+                                <circle cx="150" cy="50" r="35" fill="#F86825" stroke="#C64900" stroke-width="3"/>
                                 <text x="150" y="45" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 1</text>
                                 <text x="150" y="60" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Execute</text>
                             </g>
 
                             <!-- Arrow to Write (Top to Bottom-Right) -->
-                            <path class="circular-arrow" d="M 175 75 Q 210 110 215 135" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
+                            <path class="circular-arrow" d="M 175 75 Q 210 110 215 135" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
 
                             <!-- Step 2: Write (Bottom-Right vertex) -->
                             <g class="circular-step">
-                                <circle cx="222" cy="162" r="35" fill="#f97316" stroke="#ea580c" stroke-width="3"/>
+                                <circle cx="222" cy="162" r="35" fill="#FF9267" stroke="#F86825" stroke-width="3"/>
                                 <text x="222" y="157" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 2</text>
                                 <text x="222" y="172" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Write</text>
                             </g>
 
                             <!-- Arrow to Learn (Bottom-Right to Bottom-Left) -->
-                            <path class="circular-arrow" d="M 187 162 L 113 162" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
+                            <path class="circular-arrow" d="M 187 162 L 113 162" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
 
                             <!-- Step 3: Learn (Bottom-Left vertex) -->
                             <g class="circular-step">
-                                <circle cx="78" cy="162" r="35" fill="#fb923c" stroke="#f97316" stroke-width="3"/>
+                                <circle cx="78" cy="162" r="35" fill="#FFB092" stroke="#FF9267" stroke-width="3"/>
                                 <text x="78" y="157" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 3</text>
                                 <text x="78" y="172" text-anchor="middle" fill="white" font-size="14" font-weight="bold">Learn</text>
                             </g>
 
                             <!-- Arrow back to Act (Bottom-Left to Top, completing cycle) -->
-                            <path class="circular-arrow" d="M 93 130 Q 90 90 125 65" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)" stroke-dasharray="5,5"/>
+                            <path class="circular-arrow" d="M 93 130 Q 90 90 125 65" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)" stroke-dasharray="5,5"/>
 
                             <!-- Circular arrow annotation -->
-                            <text class="circular-loop-icon" x="150" y="120" text-anchor="middle" fill="#ea580c" font-size="24" font-weight="bold">↻</text>
+                            <text class="circular-loop-icon" x="150" y="120" text-anchor="middle" fill="#F86825" font-size="24" font-weight="bold">↻</text>
 
                             <!-- Arrow marker definition -->
                             <defs>
                                 <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-                                    <path d="M0,0 L0,6 L9,3 z" fill="#ea580c"/>
+                                    <path d="M0,0 L0,6 L9,3 z" fill="#F86825"/>
                                 </marker>
                             </defs>
                         </svg>
@@ -1459,14 +1459,14 @@
                         {
                             label: 'Semantic Web (Traditional)',
                             data: [5, 5, 1, 1, 3],
-                            color: '#2563EB',
+                            color: '#171719',
                             borderWidth: 4,
                             pointRadius: 6
                         },
                         {
                             label: 'Operational Ontology (Current)',
                             data: [3, 4, 5, 5, 5],
-                            color: '#EA580C',
+                            color: '#F86825',
                             borderWidth: 4,
                             pointRadius: 6
                         }

--- a/project/CURK/ontology/palantir-vs-classic-ontology/ko/index.html
+++ b/project/CURK/ontology/palantir-vs-classic-ontology/ko/index.html
@@ -300,7 +300,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #808080;
             --border-color: #334155;
         }
 
@@ -361,7 +361,7 @@
         .timeline-line {
             position: absolute;
             width: 2px;
-            background: linear-gradient(180deg, #6b7280 0%, #3b82f6 33%, #9ca3af 66%, #f97316 100%);
+            background: linear-gradient(180deg, #6b7280 0%, #171719 33%, #9ca3af 66%, #FF9267 100%);
             z-index: 0;
         }
 
@@ -655,9 +655,9 @@
         }
 
         .timeline-badge.bg-gray-500 { background-color: #6b7280; }
-        .timeline-badge.bg-blue-600 { background-color: #2563eb; }
+        .timeline-badge.bg-blue-600 { background-color: #171719; }
         .timeline-badge.bg-gray-400 { background-color: #9ca3af; }
-        .timeline-badge.bg-orange-600 { background-color: #ea580c; }
+        .timeline-badge.bg-orange-600 { background-color: #F86825; }
 
         @media (max-width: 768px) {
             .timeline-line {
@@ -696,7 +696,7 @@
         #scrollProgressBar {
             width: 100%;
             height: 0%;
-            background: linear-gradient(to bottom, #f97316, #ea580c);
+            background: linear-gradient(to bottom, #FF9267, #F86825);
             transition: height 0.1s ease-out;
         }
 
@@ -1125,27 +1125,27 @@
                         <svg viewBox="0 0 300 200" class="w-full h-48 mb-4 flow-diagram">
                             <!-- Step 1: Query -->
                             <g class="linear-step">
-                                <circle cx="50" cy="100" r="35" fill="#2563eb" stroke="#1e40af" stroke-width="3"/>
+                                <circle cx="50" cy="100" r="35" fill="#171719" stroke="#0F0F10" stroke-width="3"/>
                                 <text x="50" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 1</text>
                                 <text x="50" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">질의</text>
                             </g>
 
                             <!-- Arrow 1 -->
-                            <path class="linear-arrow" d="M 90 100 L 120 100" stroke="#2563eb" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
+                            <path class="linear-arrow" d="M 90 100 L 120 100" stroke="#171719" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
 
                             <!-- Step 2: Read -->
                             <g class="linear-step">
-                                <circle cx="150" cy="100" r="35" fill="#3b82f6" stroke="#2563eb" stroke-width="3"/>
+                                <circle cx="150" cy="100" r="35" fill="#171719" stroke="#171719" stroke-width="3"/>
                                 <text x="150" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 2</text>
                                 <text x="150" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">추론</text>
                             </g>
 
                             <!-- Arrow 2 -->
-                            <path class="linear-arrow" d="M 190 100 L 220 100" stroke="#2563eb" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
+                            <path class="linear-arrow" d="M 190 100 L 220 100" stroke="#171719" stroke-width="3" fill="none" marker-end="url(#arrowBlue)"/>
 
                             <!-- Step 3: Result -->
                             <g class="linear-step">
-                                <circle cx="250" cy="100" r="35" fill="#60a5fa" stroke="#3b82f6" stroke-width="3"/>
+                                <circle cx="250" cy="100" r="35" fill="#808080" stroke="#171719" stroke-width="3"/>
                                 <text x="250" y="95" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 3</text>
                                 <text x="250" y="110" text-anchor="middle" fill="white" font-size="14" font-weight="bold">결과</text>
                             </g>
@@ -1153,7 +1153,7 @@
                             <!-- Arrow marker definition -->
                             <defs>
                                 <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-                                    <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
+                                    <path d="M0,0 L0,6 L9,3 z" fill="#171719"/>
                                 </marker>
                             </defs>
                         </svg>
@@ -1179,41 +1179,41 @@
                         <svg viewBox="0 0 300 200" class="w-full h-48 mb-4 flow-diagram">
                             <!-- Step 1: Act (Top vertex) -->
                             <g class="circular-step">
-                                <circle cx="150" cy="50" r="35" fill="#ea580c" stroke="#c2410c" stroke-width="3"/>
+                                <circle cx="150" cy="50" r="35" fill="#F86825" stroke="#C64900" stroke-width="3"/>
                                 <text x="150" y="45" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 1</text>
                                 <text x="150" y="60" text-anchor="middle" fill="white" font-size="14" font-weight="bold">실행</text>
                             </g>
 
                             <!-- Arrow to Write (Top to Bottom-Right) -->
-                            <path class="circular-arrow" d="M 175 75 Q 210 110 215 135" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
+                            <path class="circular-arrow" d="M 175 75 Q 210 110 215 135" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
 
                             <!-- Step 2: Write (Bottom-Right vertex) -->
                             <g class="circular-step">
-                                <circle cx="222" cy="162" r="35" fill="#f97316" stroke="#ea580c" stroke-width="3"/>
+                                <circle cx="222" cy="162" r="35" fill="#FF9267" stroke="#F86825" stroke-width="3"/>
                                 <text x="222" y="157" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 2</text>
                                 <text x="222" y="172" text-anchor="middle" fill="white" font-size="14" font-weight="bold">쓰기</text>
                             </g>
 
                             <!-- Arrow to Learn (Bottom-Right to Bottom-Left) -->
-                            <path class="circular-arrow" d="M 187 162 L 113 162" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
+                            <path class="circular-arrow" d="M 187 162 L 113 162" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)"/>
 
                             <!-- Step 3: Learn (Bottom-Left vertex) -->
                             <g class="circular-step">
-                                <circle cx="78" cy="162" r="35" fill="#fb923c" stroke="#f97316" stroke-width="3"/>
+                                <circle cx="78" cy="162" r="35" fill="#FFB092" stroke="#FF9267" stroke-width="3"/>
                                 <text x="78" y="157" text-anchor="middle" fill="white" font-size="12" font-weight="bold">STEP 3</text>
                                 <text x="78" y="172" text-anchor="middle" fill="white" font-size="14" font-weight="bold">학습</text>
                             </g>
 
                             <!-- Arrow back to Act (Bottom-Left to Top, completing cycle) -->
-                            <path class="circular-arrow" d="M 93 130 Q 90 90 125 65" stroke="#ea580c" stroke-width="3" fill="none" marker-end="url(#arrowOrange)" stroke-dasharray="5,5"/>
+                            <path class="circular-arrow" d="M 93 130 Q 90 90 125 65" stroke="#F86825" stroke-width="3" fill="none" marker-end="url(#arrowOrange)" stroke-dasharray="5,5"/>
 
                             <!-- Circular arrow annotation -->
-                            <text class="circular-loop-icon" x="150" y="120" text-anchor="middle" fill="#ea580c" font-size="24" font-weight="bold">↻</text>
+                            <text class="circular-loop-icon" x="150" y="120" text-anchor="middle" fill="#F86825" font-size="24" font-weight="bold">↻</text>
 
                             <!-- Arrow marker definition -->
                             <defs>
                                 <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-                                    <path d="M0,0 L0,6 L9,3 z" fill="#ea580c"/>
+                                    <path d="M0,0 L0,6 L9,3 z" fill="#F86825"/>
                                 </marker>
                             </defs>
                         </svg>
@@ -1459,14 +1459,14 @@
                         {
                             label: '시맨틱 웹 (전통)',
                             data: [5, 5, 1, 1, 3],
-                            color: '#2563EB',
+                            color: '#171719',
                             borderWidth: 4,
                             pointRadius: 6
                         },
                         {
                             label: '운영 온톨로지 (현재)',
                             data: [3, 4, 5, 5, 5],
-                            color: '#EA580C',
+                            color: '#F86825',
                             borderWidth: 4,
                             pointRadius: 6
                         }

--- a/report/blog-2026-feb/en/index.html
+++ b/report/blog-2026-feb/en/index.html
@@ -757,7 +757,7 @@
                 datasets: [{
                     label: 'Additions (K lines)',
                     data: additions,
-                    backgroundColor: additions.map(function(v) { return v > 50 ? '#F86825' : '#14b8a6'; }),
+                    backgroundColor: additions.map(function(v) { return v > 50 ? '#F86825' : '#808080'; }),
                     borderRadius: 4
                 }]
             }, {

--- a/report/blog-2026-feb/ko/index.html
+++ b/report/blog-2026-feb/ko/index.html
@@ -757,7 +757,7 @@
                 datasets: [{
                     label: '추가 (K lines)',
                     data: additions,
-                    backgroundColor: additions.map(function(v) { return v > 50 ? '#F86825' : '#14b8a6'; }),
+                    backgroundColor: additions.map(function(v) { return v > 50 ? '#F86825' : '#808080'; }),
                     borderRadius: 4
                 }]
             }, {

--- a/report/blog-2026/en/index.html
+++ b/report/blog-2026/en/index.html
@@ -1204,7 +1204,7 @@
             PebblousChart.doughnut('categoryChart', {
                 labels: ['Tech', 'Data Art Lab', 'Business', 'Story'],
                 data: [35, 23, 14, 7],
-                colors: ['#14b8a6', '#a855f7', '#F86825', '#3b82f6']
+                colors: ['#F86825', '#171719', '#808080', '#BDBDBD']
             });
         }
 

--- a/report/blog-2026/ko/index.html
+++ b/report/blog-2026/ko/index.html
@@ -1203,7 +1203,7 @@
             PebblousChart.doughnut('categoryChart', {
                 labels: ['Tech', 'Data Art Lab', 'Business', 'Story'],
                 data: [35, 23, 14, 7],
-                colors: ['#14b8a6', '#a855f7', '#F86825', '#3b82f6']
+                colors: ['#F86825', '#171719', '#808080', '#BDBDBD']
             });
         }
 

--- a/report/mathematica-15-years/en/index.html
+++ b/report/mathematica-15-years/en/index.html
@@ -784,7 +784,7 @@
                         {
                             label: 'Research',
                             data: years.map(y => yearlyTopics[y].research),
-                            backgroundColor: '#3B82F6'
+                            backgroundColor: '#171719'
                         },
                         {
                             label: 'Art',
@@ -794,12 +794,12 @@
                         {
                             label: 'Pebblous',
                             data: years.map(y => yearlyTopics[y].pebblous),
-                            backgroundColor: '#14b8a6'
+                            backgroundColor: '#808080'
                         },
                         {
                             label: 'Lectures',
                             data: years.map(y => yearlyTopics[y].lecture),
-                            backgroundColor: '#8b5cf6'
+                            backgroundColor: '#585858'
                         },
                         {
                             label: 'Other',
@@ -838,7 +838,7 @@
 
             // ===== Chart 3: Project Timeline (Horizontal Bar) =====
             const projects = [
-                { name: 'CLC Research', start: 2013, end: 2019, count: 95, color: '#3B82F6' },
+                { name: 'CLC Research', start: 2013, end: 2019, count: 95, color: '#171719' },
                 { name: 'CLC Experiments', start: 2013, end: 2024, count: 167, color: '#60a5fa' },
                 { name: 'Camera/Geometric Algebra', start: 2013, end: 2018, count: 34, color: '#93c5fd' },
                 { name: 'RSAR/Tangram', start: 2015, end: 2017, count: 20, color: '#818cf8' },
@@ -846,9 +846,9 @@
                 { name: 'Code Painting', start: 2017, end: 2021, count: 140, color: '#F86825' },
                 { name: 'ML/DL', start: 2014, end: 2025, count: 187, color: '#fb923c' },
                 { name: 'Game Streaming', start: 2017, end: 2021, count: 30, color: '#94a3b8' },
-                { name: 'Lectures (WTC/SNU)', start: 2018, end: 2023, count: 48, color: '#8b5cf6' },
+                { name: 'Lectures (WTC/SNU)', start: 2018, end: 2023, count: 48, color: '#585858' },
                 { name: 'Art Camp', start: 2021, end: 2021, count: 31, color: '#f97316' },
-                { name: 'Pebblous [CLV]', start: 2022, end: 2026, count: 427, color: '#14b8a6' },
+                { name: 'Pebblous [CLV]', start: 2022, end: 2026, count: 427, color: '#808080' },
                 { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#2dd4bf' },
                 { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#5eead4' }
             ];

--- a/report/mathematica-15-years/ko/index.html
+++ b/report/mathematica-15-years/ko/index.html
@@ -784,7 +784,7 @@
                         {
                             label: '연구',
                             data: years.map(y => yearlyTopics[y].research),
-                            backgroundColor: '#3B82F6'
+                            backgroundColor: '#171719'
                         },
                         {
                             label: '아트',
@@ -794,12 +794,12 @@
                         {
                             label: '페블러스',
                             data: years.map(y => yearlyTopics[y].pebblous),
-                            backgroundColor: '#14b8a6'
+                            backgroundColor: '#808080'
                         },
                         {
                             label: '강의',
                             data: years.map(y => yearlyTopics[y].lecture),
-                            backgroundColor: '#8b5cf6'
+                            backgroundColor: '#585858'
                         },
                         {
                             label: '기타',
@@ -838,7 +838,7 @@
 
             // ===== Chart 3: Project Timeline (Horizontal Bar) =====
             const projects = [
-                { name: 'CLC 연구', start: 2013, end: 2019, count: 95, color: '#3B82F6' },
+                { name: 'CLC 연구', start: 2013, end: 2019, count: 95, color: '#171719' },
                 { name: 'CLC 실험', start: 2013, end: 2024, count: 167, color: '#60a5fa' },
                 { name: '카메라/기하대수', start: 2013, end: 2018, count: 34, color: '#93c5fd' },
                 { name: 'RSAR/Tangram', start: 2015, end: 2017, count: 20, color: '#818cf8' },
@@ -846,9 +846,9 @@
                 { name: 'Code Painting', start: 2017, end: 2021, count: 140, color: '#F86825' },
                 { name: 'ML/DL', start: 2014, end: 2025, count: 187, color: '#fb923c' },
                 { name: '게임 스트리밍', start: 2017, end: 2021, count: 30, color: '#94a3b8' },
-                { name: '강의 (WTC/서울대)', start: 2018, end: 2023, count: 48, color: '#8b5cf6' },
+                { name: '강의 (WTC/서울대)', start: 2018, end: 2023, count: 48, color: '#585858' },
                 { name: 'Art Camp', start: 2021, end: 2021, count: 31, color: '#f97316' },
-                { name: '페블러스 [CLV]', start: 2022, end: 2026, count: 427, color: '#14b8a6' },
+                { name: '페블러스 [CLV]', start: 2022, end: 2026, count: 427, color: '#808080' },
                 { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#2dd4bf' },
                 { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#5eead4' }
             ];

--- a/report/solar-vs-glm/solar-vs-glm-forensic/en/index.html
+++ b/report/solar-vs-glm/solar-vs-glm-forensic/en/index.html
@@ -1400,8 +1400,8 @@
             PebblousChart.line('highCorrelationChart', {
                 labels: subjects,
                 datasets: [
-                    { label: 'Alice', data: [70, 80, 90, 75, 85], color: '#14B8A6' },
-                    { label: 'Bob', data: [72, 82, 88, 77, 83], color: '#3B82F6' }
+                    { label: 'Alice', data: [70, 80, 90, 75, 85], color: '#F86825' },
+                    { label: 'Bob', data: [72, 82, 88, 77, 83], color: '#171719' }
                 ],
                 tension: 0.3,
                 showPoints: true,
@@ -1413,7 +1413,7 @@
                 labels: subjects,
                 datasets: [
                     { label: 'Charlie', data: [70, 80, 90, 75, 85], color: '#F86825' },
-                    { label: 'Diana', data: [85, 72, 78, 92, 70], color: '#A855F7' }
+                    { label: 'Diana', data: [85, 72, 78, 92, 70], color: '#171719' }
                 ],
                 tension: 0.3,
                 showPoints: true,

--- a/report/solar-vs-glm/solar-vs-glm-forensic/ko/index.html
+++ b/report/solar-vs-glm/solar-vs-glm-forensic/ko/index.html
@@ -940,8 +940,8 @@
             PebblousChart.line('highCorrelationChart', {
                 labels: subjects,
                 datasets: [
-                    { label: '철수', data: [70, 80, 90, 75, 85], color: '#14B8A6' },
-                    { label: '영희', data: [72, 82, 88, 77, 83], color: '#3B82F6' }
+                    { label: '철수', data: [70, 80, 90, 75, 85], color: '#F86825' },
+                    { label: '영희', data: [72, 82, 88, 77, 83], color: '#171719' }
                 ],
                 tension: 0.3,
                 showPoints: true,
@@ -953,7 +953,7 @@
                 labels: subjects,
                 datasets: [
                     { label: '민수', data: [70, 80, 90, 75, 85], color: '#F86825' },
-                    { label: '지영', data: [85, 72, 78, 92, 70], color: '#A855F7' }
+                    { label: '지영', data: [85, 72, 78, 92, 70], color: '#171719' }
                 ],
                 tension: 0.3,
                 showPoints: true,

--- a/story/blender-story-pb/en/index.html
+++ b/story/blender-story-pb/en/index.html
@@ -137,7 +137,7 @@
             height: 4px;
         }
         .engine-card.cycles::before {
-            background: linear-gradient(90deg, #265787, #3b82f6);
+            background: linear-gradient(90deg, #265787, #171719);
         }
         .engine-card.eevee::before {
             background: linear-gradient(90deg, #EA7600, #facc15);

--- a/story/blender-story-pb/ko/index.html
+++ b/story/blender-story-pb/ko/index.html
@@ -96,7 +96,7 @@
             top: 0;
             bottom: 0;
             width: 3px;
-            background: linear-gradient(180deg, var(--accent-color) 0%, var(--teal-color, #14b8a6) 50%, var(--accent-color) 100%);
+            background: linear-gradient(180deg, var(--accent-color) 0%, var(--teal-color, #F86825) 50%, var(--accent-color) 100%);
             border-radius: 2px;
         }
         .bl-timeline-item {
@@ -116,7 +116,7 @@
             z-index: 1;
         }
         .bl-timeline-dot.teal {
-            background-color: var(--teal-color, #14b8a6);
+            background-color: var(--teal-color, #F86825);
         }
         .bl-timeline-dot.danger {
             background-color: #ef4444;
@@ -169,14 +169,14 @@
         .warning-box {
             background-color: #fff7ed;
             border: 1px solid #fed7aa;
-            border-left: 4px solid #f97316;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
@@ -196,7 +196,7 @@
         .movie-year {
             font-size: 0.75rem;
             font-weight: 700;
-            color: var(--teal-color, #14b8a6);
+            color: var(--teal-color, #F86825);
             text-transform: uppercase;
             letter-spacing: 0.05em;
             margin-bottom: 0.25rem;
@@ -495,7 +495,7 @@
                         <!-- Text -->
                         <text x="110" y="95" text-anchor="middle" fill="var(--accent-color)" font-size="28" font-weight="800" transform="rotate(90 110 110)">€110K</text>
                         <text x="110" y="118" text-anchor="middle" fill="var(--text-muted)" font-size="11" font-weight="600" transform="rotate(90 110 110)">목표 €100K 달성</text>
-                        <text x="110" y="135" text-anchor="middle" fill="var(--teal-color, #14b8a6)" font-size="10" font-weight="700" transform="rotate(90 110 110)">110% &#183; 7주 완료</text>
+                        <text x="110" y="135" text-anchor="middle" fill="var(--teal-color, #F86825)" font-size="10" font-weight="700" transform="rotate(90 110 110)">110% &#183; 7주 완료</text>
                     </svg>
                 </div>
 
@@ -604,7 +604,7 @@
                         <text x="120" y="75" text-anchor="middle" fill="var(--text-secondary)" font-size="9">Elephants Dream</text>
 
                         <!-- 2008 -->
-                        <circle cx="270" cy="50" r="10" fill="var(--teal-color, #14b8a6)"/>
+                        <circle cx="270" cy="50" r="10" fill="var(--teal-color, #F86825)"/>
                         <text x="270" y="30" text-anchor="middle" fill="var(--text-primary)" font-size="11" font-weight="700">2008</text>
                         <text x="270" y="75" text-anchor="middle" fill="var(--text-secondary)" font-size="9">Big Buck Bunny</text>
 
@@ -614,13 +614,13 @@
                         <text x="420" y="75" text-anchor="middle" fill="var(--text-secondary)" font-size="9">Sintel</text>
 
                         <!-- 2015 -->
-                        <circle cx="570" cy="50" r="10" fill="var(--teal-color, #14b8a6)"/>
+                        <circle cx="570" cy="50" r="10" fill="var(--teal-color, #F86825)"/>
                         <text x="570" y="30" text-anchor="middle" fill="var(--text-primary)" font-size="11" font-weight="700">2015</text>
                         <text x="570" y="75" text-anchor="middle" fill="var(--text-secondary)" font-size="9">Cosmos Laundromat</text>
 
                         <!-- Connecting highlights -->
                         <line x1="130" y1="50" x2="260" y2="50" stroke="var(--accent-color)" stroke-width="3" opacity="0.4"/>
-                        <line x1="280" y1="50" x2="410" y2="50" stroke="var(--teal-color, #14b8a6)" stroke-width="3" opacity="0.4"/>
+                        <line x1="280" y1="50" x2="410" y2="50" stroke="var(--teal-color, #F86825)" stroke-width="3" opacity="0.4"/>
                         <line x1="430" y1="50" x2="560" y2="50" stroke="var(--accent-color)" stroke-width="3" opacity="0.4"/>
                     </svg>
                     <p class="text-xs themeable-muted mt-3 text-center">각 오픈 무비 프로젝트는 저의 기능을 한 단계씩 끌어올렸습니다.</p>
@@ -670,7 +670,7 @@
                                 <circle cx="42" cy="42" r="3" fill="var(--accent-color)"/>
                                 <line x1="14" y1="14" x2="42" y2="42" stroke="var(--accent-color)" stroke-width="1.5" stroke-dasharray="3 2"/>
                                 <line x1="42" y1="14" x2="14" y2="42" stroke="var(--accent-color)" stroke-width="1.5" stroke-dasharray="3 2"/>
-                                <polygon points="28,18 38,34 18,34" stroke="var(--teal-color, #14b8a6)" stroke-width="2" fill="none"/>
+                                <polygon points="28,18 38,34 18,34" stroke="var(--teal-color, #F86825)" stroke-width="2" fill="none"/>
                             </svg>
                         </div>
                         <div class="cap-title">모델링</div>
@@ -686,8 +686,8 @@
                                 <circle cx="16" cy="40" r="6" stroke="var(--accent-color)" stroke-width="2" fill="none"/>
                                 <circle cx="40" cy="16" r="6" stroke="var(--accent-color)" stroke-width="2" fill="none"/>
                                 <!-- Motion arcs -->
-                                <path d="M44 22 Q52 28 44 34" stroke="var(--teal-color, #14b8a6)" stroke-width="1.5" fill="none" stroke-dasharray="2 2"/>
-                                <path d="M48 20 Q58 28 48 36" stroke="var(--teal-color, #14b8a6)" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
+                                <path d="M44 22 Q52 28 44 34" stroke="var(--teal-color, #F86825)" stroke-width="1.5" fill="none" stroke-dasharray="2 2"/>
+                                <path d="M48 20 Q58 28 48 36" stroke="var(--teal-color, #F86825)" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
                             </svg>
                         </div>
                         <div class="cap-title">리깅 &amp; 애니메이션</div>
@@ -700,7 +700,7 @@
                             <svg viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <!-- Camera/render icon -->
                                 <rect x="10" y="18" width="36" height="24" rx="3" stroke="var(--accent-color)" stroke-width="2.5" fill="none"/>
-                                <circle cx="28" cy="30" r="8" stroke="var(--teal-color, #14b8a6)" stroke-width="2" fill="none"/>
+                                <circle cx="28" cy="30" r="8" stroke="var(--teal-color, #F86825)" stroke-width="2" fill="none"/>
                                 <circle cx="28" cy="30" r="3" fill="var(--accent-color)"/>
                                 <!-- Light rays -->
                                 <line x1="28" y1="8" x2="28" y2="14" stroke="var(--accent-color)" stroke-width="1.5"/>
@@ -742,11 +742,11 @@
                         <p class="text-sm font-bold themeable-heading mb-3">EEVEE (실시간 렌더러)</p>
                         <div class="compare-bar-wrap">
                             <div class="compare-bar-label"><span>현실감</span><span>75%</span></div>
-                            <div class="compare-bar-track"><div class="compare-bar-fill" style="width:75%; background: var(--teal-color, #14b8a6);"></div></div>
+                            <div class="compare-bar-track"><div class="compare-bar-fill" style="width:75%; background: var(--teal-color, #F86825);"></div></div>
                         </div>
                         <div class="compare-bar-wrap">
                             <div class="compare-bar-label"><span>속도</span><span>95%</span></div>
-                            <div class="compare-bar-track"><div class="compare-bar-fill" style="width:95%; background: var(--teal-color, #14b8a6);"></div></div>
+                            <div class="compare-bar-track"><div class="compare-bar-fill" style="width:95%; background: var(--teal-color, #F86825);"></div></div>
                         </div>
                         <p class="text-xs themeable-muted mt-1">비디오 게임과 같은 방식으로 빠르게 렌더링합니다. 완벽하진 않지만, 실시간으로 결과를 확인할 수 있습니다.</p>
                     </div>

--- a/story/ngogo-chimp-network-ai-pb/en/index.html
+++ b/story/ngogo-chimp-network-ai-pb/en/index.html
@@ -608,7 +608,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     new Chart(document.getElementById('chart-edges'), {
         type: 'bar',
-        data: { labels: years, datasets: [{ data: edges, backgroundColor: years.map(y => y >= 2018 ? 'rgba(248,104,37,0.4)' : 'rgba(20,184,166,0.5)'), borderColor: years.map(y => y >= 2018 ? '#F86825' : '#14b8a6'), borderWidth: 1 }] },
+        data: { labels: years, datasets: [{ data: edges, backgroundColor: years.map(y => y >= 2018 ? 'rgba(248,104,37,0.4)' : 'rgba(20,184,166,0.5)'), borderColor: years.map(y => y >= 2018 ? '#F86825' : '#808080'), borderWidth: 1 }] },
         options: chartOpts
     });
 });

--- a/story/ngogo-chimp-network-ai-pb/ko/index.html
+++ b/story/ngogo-chimp-network-ai-pb/ko/index.html
@@ -638,7 +638,7 @@ document.addEventListener('DOMContentLoaded', function() {
             datasets: [{
                 data: edges,
                 backgroundColor: years.map(y => y >= 2018 ? 'rgba(248,104,37,0.4)' : 'rgba(20,184,166,0.5)'),
-                borderColor: years.map(y => y >= 2018 ? '#F86825' : '#14b8a6'),
+                borderColor: years.map(y => y >= 2018 ? '#F86825' : '#808080'),
                 borderWidth: 1
             }]
         },

--- a/story/qr-story-pb/en/index.html
+++ b/story/qr-story-pb/en/index.html
@@ -60,7 +60,7 @@
         /* QR Code Anatomy SVG */
         .qr-anatomy-svg { max-width: 480px; margin: 0 auto; display: block; }
         .qr-anatomy-svg .finder { fill: #F86825; }
-        .qr-anatomy-svg .timing { fill: #14b8a6; }
+        .qr-anatomy-svg .timing { fill: #808080; }
         .qr-anatomy-svg .data-area { fill: #6366f1; }
         .qr-anatomy-svg .error-correction { fill: #ec4899; }
         .qr-anatomy-svg .quiet-zone { fill: none; stroke: #94a3b8; stroke-dasharray: 4; }
@@ -75,7 +75,7 @@
             top: 0;
             bottom: 0;
             width: 3px;
-            background: linear-gradient(to bottom, #22c55e, #3b82f6, #94a3b8, #94a3b8, #eab308, #ef4444, #8b5cf6);
+            background: linear-gradient(to bottom, #51C57A, #171719, #94a3b8, #94a3b8, #eab308, #ef4444, #585858);
             border-radius: 2px;
         }
         .emotion-node {
@@ -414,7 +414,7 @@
                         <line x1="100" y1="155" x2="100" y2="170" stroke="#F86825" stroke-width="1.5"/>
                         <text x="100" y="182" text-anchor="middle" fill="#F86825" font-weight="700" font-size="11">Finder Pattern</text>
 
-                        <text x="240" y="72" text-anchor="middle" fill="#14b8a6" font-weight="700" font-size="11">Timing Pattern</text>
+                        <text x="240" y="72" text-anchor="middle" fill="#808080" font-weight="700" font-size="11">Timing Pattern</text>
 
                         <text x="242" y="248" text-anchor="middle" fill="#6366f1" font-weight="700" font-size="12">DATA</text>
                         <text x="242" y="262" text-anchor="middle" fill="#6366f1" font-size="10">zigzag encoding</text>
@@ -456,16 +456,16 @@
                 <!-- Error Correction Visualization -->
                 <div class="ec-grid mb-8">
                     <div class="ec-card themeable-card">
-                        <div class="ec-level" style="color: #22c55e;">L</div>
+                        <div class="ec-level" style="color: #51C57A;">L</div>
                         <div class="ec-pct themeable-heading">7%</div>
                         <div class="ec-desc themeable-muted">Low recovery. Smallest size.</div>
-                        <div class="ec-bar"><div class="ec-bar-fill" style="width: 23%; background: #22c55e;"></div></div>
+                        <div class="ec-bar"><div class="ec-bar-fill" style="width: 23%; background: #51C57A;"></div></div>
                     </div>
                     <div class="ec-card themeable-card">
-                        <div class="ec-level" style="color: #3b82f6;">M</div>
+                        <div class="ec-level" style="color: #171719;">M</div>
                         <div class="ec-pct themeable-heading">15%</div>
                         <div class="ec-desc themeable-muted">Medium. Most common default.</div>
-                        <div class="ec-bar"><div class="ec-bar-fill" style="width: 50%; background: #3b82f6;"></div></div>
+                        <div class="ec-bar"><div class="ec-bar-fill" style="width: 50%; background: #171719;"></div></div>
                     </div>
                     <div class="ec-card themeable-card">
                         <div class="ec-level" style="color: #F86825;">Q</div>
@@ -507,12 +507,12 @@
                 <div class="themeable-card rounded-xl p-6 mb-8">
                     <h3 class="text-lg font-bold themeable-heading mb-6">My Emotional Journey</h3>
                     <div class="emotion-timeline">
-                        <div class="emotion-node" style="--node-color: #22c55e;">
-                            <span class="year" style="color: #22c55e;">1994</span>
+                        <div class="emotion-node" style="--node-color: #51C57A;">
+                            <span class="year" style="color: #51C57A;">1994</span>
                             <div class="label themeable-text"><span class="icon">&#127793;</span> <strong>Excitement.</strong> I am born. The factory floor is fast again.</div>
                         </div>
-                        <div class="emotion-node" style="--node-color: #3b82f6;">
-                            <span class="year" style="color: #3b82f6;">2000</span>
+                        <div class="emotion-node" style="--node-color: #171719;">
+                            <span class="year" style="color: #171719;">2000</span>
                             <div class="label themeable-text"><span class="icon">&#127775;</span> <strong>Hope.</strong> ISO standard. The world will know me now.</div>
                         </div>
                         <div class="emotion-node" style="--node-color: #94a3b8;">
@@ -527,8 +527,8 @@
                             <span class="year" style="color: #ef4444;">2020</span>
                             <div class="label themeable-text"><span class="icon">&#128293;</span> <strong>Explosion.</strong> COVID makes me essential. 750% app download surge.</div>
                         </div>
-                        <div class="emotion-node" style="--node-color: #8b5cf6;">
-                            <span class="year" style="color: #8b5cf6;">Now</span>
+                        <div class="emotion-node" style="--node-color: #585858;">
+                            <span class="year" style="color: #585858;">Now</span>
                             <div class="label themeable-text"><span class="icon">&#127754;</span> <strong>Complex feelings.</strong> Pride, gratitude, and the weight of responsibility.</div>
                         </div>
                     </div>

--- a/story/qr-story-pb/ko/index.html
+++ b/story/qr-story-pb/ko/index.html
@@ -96,7 +96,7 @@
             top: 0;
             bottom: 0;
             width: 3px;
-            background: linear-gradient(to bottom, #14b8a6, #F86825, #94a3b8, #F86825, #ef4444, #6366f1);
+            background: linear-gradient(to bottom, #808080, #F86825, #94a3b8, #F86825, #ef4444, #6366f1);
             border-radius: 2px;
         }
         .emotion-node {
@@ -118,8 +118,8 @@
             z-index: 1;
             border: 3px solid var(--bg-primary, #fff);
         }
-        .emotion-dot.birth { background: #14b8a6; }
-        .emotion-dot.hope { background: #3b82f6; }
+        .emotion-dot.birth { background: #808080; }
+        .emotion-dot.hope { background: #171719; }
         .emotion-dot.lonely { background: #94a3b8; }
         .emotion-dot.spark { background: #eab308; }
         .emotion-dot.explode { background: #ef4444; }
@@ -213,8 +213,8 @@
             font-weight: 800;
             line-height: 1;
         }
-        .ec-card[data-level="L"] .ec-level { color: #22c55e; }
-        .ec-card[data-level="M"] .ec-level { color: #3b82f6; }
+        .ec-card[data-level="L"] .ec-level { color: #51C57A; }
+        .ec-card[data-level="M"] .ec-level { color: #171719; }
         .ec-card[data-level="Q"] .ec-level { color: #f59e0b; }
         .ec-card[data-level="H"] .ec-level { color: #ef4444; }
         .ec-pct {
@@ -240,8 +240,8 @@
             border-radius: 3px;
             transition: width 0.6s ease;
         }
-        .ec-card[data-level="L"] .ec-bar-fill { width: 23%; background: #22c55e; }
-        .ec-card[data-level="M"] .ec-bar-fill { width: 50%; background: #3b82f6; }
+        .ec-card[data-level="L"] .ec-bar-fill { width: 23%; background: #51C57A; }
+        .ec-card[data-level="M"] .ec-bar-fill { width: 50%; background: #171719; }
         .ec-card[data-level="Q"] .ec-bar-fill { width: 83%; background: #f59e0b; }
         .ec-card[data-level="H"] .ec-bar-fill { width: 100%; background: #ef4444; }
 
@@ -308,14 +308,14 @@
         .warning-box {
             background-color: #fff7ed;
             border: 1px solid #fed7aa;
-            border-left: 4px solid #f97316;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #808080;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
@@ -486,13 +486,13 @@
                         <rect x="58" y="340" width="42" height="42" rx="2" fill="#F86825" opacity="0.85"/>
 
                         <!-- Timing Pattern - Horizontal -->
-                        <line x1="138" y1="79" x2="312" y2="79" stroke="#14b8a6" stroke-width="4" stroke-dasharray="10,10"/>
+                        <line x1="138" y1="79" x2="312" y2="79" stroke="#808080" stroke-width="4" stroke-dasharray="10,10"/>
 
                         <!-- Timing Pattern - Vertical -->
-                        <line x1="79" y1="138" x2="79" y2="312" stroke="#14b8a6" stroke-width="4" stroke-dasharray="10,10"/>
+                        <line x1="79" y1="138" x2="79" y2="312" stroke="#808080" stroke-width="4" stroke-dasharray="10,10"/>
 
                         <!-- Alignment Pattern (center area) -->
-                        <rect x="290" y="290" width="22" height="22" rx="2" fill="#3b82f6" opacity="0.7"/>
+                        <rect x="290" y="290" width="22" height="22" rx="2" fill="#171719" opacity="0.7"/>
                         <rect x="296" y="296" width="10" height="10" rx="1" fill="white"/>
 
                         <!-- Data modules (scattered dark squares) -->
@@ -514,13 +514,13 @@
 
                         <!-- Labels -->
                         <text x="79" y="18" text-anchor="middle" class="qr-anatomy-label" fill="#F86825">파인더 패턴</text>
-                        <text x="79" y="148" text-anchor="middle" class="qr-anatomy-label" fill="#14b8a6">타이밍 패턴</text>
+                        <text x="79" y="148" text-anchor="middle" class="qr-anatomy-label" fill="#808080">타이밍 패턴</text>
                         <text x="200" y="275" text-anchor="middle" class="qr-anatomy-label" fill="#475569">데이터 영역</text>
-                        <text x="301" y="285" text-anchor="middle" class="qr-anatomy-label" fill="#3b82f6">정렬 패턴</text>
+                        <text x="301" y="285" text-anchor="middle" class="qr-anatomy-label" fill="#171719">정렬 패턴</text>
 
                         <!-- Annotation lines -->
                         <line x1="79" y1="22" x2="79" y2="28" stroke="#F86825" stroke-width="1.5"/>
-                        <line x1="79" y1="132" x2="79" y2="138" stroke="#14b8a6" stroke-width="1.5"/>
+                        <line x1="79" y1="132" x2="79" y2="138" stroke="#808080" stroke-width="1.5"/>
                     </svg>
                     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4 text-center">
                         <div>
@@ -528,11 +528,11 @@
                             <span class="text-xs themeable-muted">파인더 패턴</span>
                         </div>
                         <div>
-                            <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:#14b8a6;vertical-align:middle;margin-right:4px;"></span>
+                            <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:#808080;vertical-align:middle;margin-right:4px;"></span>
                             <span class="text-xs themeable-muted">타이밍 패턴</span>
                         </div>
                         <div>
-                            <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:#3b82f6;vertical-align:middle;margin-right:4px;"></span>
+                            <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:#171719;vertical-align:middle;margin-right:4px;"></span>
                             <span class="text-xs themeable-muted">정렬 패턴</span>
                         </div>
                         <div>
@@ -551,7 +551,7 @@
                         </div>
                     </div>
                     <div class="flex gap-3 items-start p-4 themeable-card rounded-xl">
-                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: #14b8a6;">&#9313;</div>
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: #808080;">&#9313;</div>
                         <div>
                             <p class="text-sm font-semibold themeable-heading">타이밍 패턴 — 나의 뼈대</p>
                             <p class="text-sm themeable-text leading-relaxed mt-1">수평과 수직으로 교차하는 흑백 모듈 라인입니다. 격자 구조를 정의하고, 데이터가 어디에 위치하는지 알려줍니다. 제 뼈대가 없으면 스캐너는 길을 잃습니다.</p>
@@ -565,7 +565,7 @@
                         </div>
                     </div>
                     <div class="flex gap-3 items-start p-4 themeable-card rounded-xl">
-                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: #3b82f6;">&#9315;</div>
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: #171719;">&#9315;</div>
                         <div>
                             <p class="text-sm font-semibold themeable-heading">오류 정정 — 나의 면역 체계</p>
                             <p class="text-sm themeable-text leading-relaxed mt-1">1960년 MIT에서 개발된 리드-솔로몬(Reed-Solomon) 알고리즘을 적용했습니다. 제가 부분적으로 손상되어도 데이터를 복원할 수 있습니다. 이 덕분에 제 위에 로고를 올리거나, 일부가 더러워져도 정상적으로 읽힙니다.</p>


### PR DESCRIPTION
차트 5 + SVG도식 3의 장식 비브랜드색(틸·파랑·보라·오렌지변종) → 브랜드 토큰(오렌지+중립/공식초록). 오렌지 강조 유지. 빨강(의미색)은 별도 PR. 생성기(#503·#125) 후속 기존글 정리.