### PR TITLE
fix(brand): 틸 → 오렌지 site-wide 정규화 (~170글)

### DIFF
--- a/blog/pbls-test-2025-10-11-02.html
+++ b/blog/pbls-test-2025-10-11-02.html
@@ -182,7 +182,7 @@
                         const col = i % (numParticles / 10);
                         p.style.top = `${30 + row * 4}%`;
                         p.style.left = `${25 + col * 5}%`;
-                        p.style.backgroundColor = '#14B8A6'; // Teal
+                        p.style.backgroundColor = '#F86825'; // Teal
                     });
                 } else if (sceneIndex === 3) { // Scene 4: Outcomes (Artistic Form)
                     document.getElementById('outcome-magazine').classList.add('opacity-100', 'translate-y-0');

--- a/blog/yann-lecun-jepa-world-models/en/index.html
+++ b/blog/yann-lecun-jepa-world-models/en/index.html
@@ -454,7 +454,7 @@
                             </div>
                             <div>
                                 <p class="text-sm font-semibold themeable-heading mb-1">Planning Time</p>
-                                <p class="text-2xl font-bold" style="color: #14b8a6;">16 sec</p>
+                                <p class="text-2xl font-bold" style="color: #F86825;">16 sec</p>
                                 <p class="text-sm themeable-muted">Cosmos model: 4 min</p>
                             </div>
                             <div>

--- a/blog/yann-lecun-jepa-world-models/ko/index.html
+++ b/blog/yann-lecun-jepa-world-models/ko/index.html
@@ -454,7 +454,7 @@
                             </div>
                             <div>
                                 <p class="text-sm font-semibold themeable-heading mb-1">계획 수립 시간</p>
-                                <p class="text-2xl font-bold" style="color: #14b8a6;">16초</p>
+                                <p class="text-2xl font-bold" style="color: #F86825;">16초</p>
                                 <p class="text-sm themeable-muted">Cosmos 모델: 4분</p>
                             </div>
                             <div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -18,7 +18,7 @@
     --heading-color: #ffffff;
     --border-color: #374151;
     --accent-color: #F86825;
-    --teal-color: #14b8a6;
+    --teal-color: #F86825;
     --search-bg: rgba(30, 41, 59, 0.5);
     --search-border: #475569;
     --header-bg: #0f172a;
@@ -49,7 +49,7 @@
     --heading-color: #111827;
     --border-color: #E5E7EB;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --search-bg: rgba(255, 255, 255, 0.8);
     --search-border: #D1D5DB;
     --header-bg: #ffffff;
@@ -80,7 +80,7 @@
     --heading-color: #3A2E1C;
     --border-color: #E8D9B8;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --search-bg: rgba(255, 252, 245, 0.9);
     --search-border: #D4C5A0;
     --header-bg: #FFF8E1;

--- a/css/theme-variables.css
+++ b/css/theme-variables.css
@@ -28,7 +28,7 @@
     --heading-color: #ffffff;
     --border-color: #374151;
     --accent-color: #F86825;
-    --teal-color: #14b8a6;
+    --teal-color: #F86825;
     --tag-bg: rgba(248, 104, 37, 0.15);
     --logo-url: url('https://pebblous.github.io/image/Pebblous_BM_White_RGB.png');
     --hero-card-bg: rgba(30, 41, 59, 0.6);
@@ -59,7 +59,7 @@
     --heading-color: #111827;
     --border-color: #E5E7EB;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --tag-bg: rgba(248, 104, 37, 0.1);
     --logo-url: url('https://pebblous.github.io/image/Pebblous_BM_Black_RGB.png');
     --hero-card-bg: rgba(255, 255, 255, 0.8);
@@ -90,7 +90,7 @@
     --heading-color: #3A2E1C;
     --border-color: #E8D9B8;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --tag-bg: rgba(248, 104, 37, 0.12);
     --logo-url: url('https://pebblous.github.io/image/Pebblous_BM_Orange_RGB.png');
     --hero-card-bg: rgba(255, 248, 225, 0.8);

--- a/project/AADS/eu-ai-act-qa-dataset/en/index.html
+++ b/project/AADS/eu-ai-act-qa-dataset/en/index.html
@@ -59,7 +59,7 @@
         .interactive-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            border-left-color: #14b8a6;
+            border-left-color: #F86825;
         }
 
         .stat-card {
@@ -73,12 +73,12 @@
             top: 0;
             width: 4px;
             height: 100%;
-            background: linear-gradient(180deg, #14b8a6, #F86825);
+            background: linear-gradient(180deg, #F86825, #F86825);
             border-radius: 2px;
         }
 
         .teal-text {
-            color: #14b8a6;
+            color: #F86825;
         }
         .orange-text {
             color: #F86825;
@@ -111,7 +111,7 @@
             transition: all 0.2s ease;
         }
         .share-btn:hover {
-            color: #14b8a6;
+            color: #F86825;
             transform: translateY(-1px);
         }
         .share-btn svg {

--- a/project/AADS/eu-ai-act-qa-dataset/ko/index.html
+++ b/project/AADS/eu-ai-act-qa-dataset/ko/index.html
@@ -59,7 +59,7 @@
         .interactive-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            border-left-color: #14b8a6;
+            border-left-color: #F86825;
         }
 
         .stat-card {
@@ -73,12 +73,12 @@
             top: 0;
             width: 4px;
             height: 100%;
-            background: linear-gradient(180deg, #14b8a6, #F86825);
+            background: linear-gradient(180deg, #F86825, #F86825);
             border-radius: 2px;
         }
 
         .teal-text {
-            color: #14b8a6;
+            color: #F86825;
         }
         .orange-text {
             color: #F86825;
@@ -111,7 +111,7 @@
             transition: all 0.2s ease;
         }
         .share-btn:hover {
-            color: #14b8a6;
+            color: #F86825;
             transform: translateY(-1px);
         }
         .share-btn svg {

--- a/project/AADS/manufacturing-qa-dataset/en/index.html
+++ b/project/AADS/manufacturing-qa-dataset/en/index.html
@@ -146,7 +146,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -159,7 +159,7 @@
             --heading-color: #ffffff;
             --border-color: #374151;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         [data-theme="beige"] {
@@ -172,7 +172,7 @@
             --heading-color: #3A2E1C;
             --border-color: #E8D9B8;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         /* Interactive Card */

--- a/project/AADS/manufacturing-qa-dataset/ko/index.html
+++ b/project/AADS/manufacturing-qa-dataset/ko/index.html
@@ -146,7 +146,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -159,7 +159,7 @@
             --heading-color: #ffffff;
             --border-color: #374151;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         [data-theme="beige"] {
@@ -172,7 +172,7 @@
             --heading-color: #3A2E1C;
             --border-color: #E8D9B8;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         /* Interactive Card */

--- a/project/AADS/regulation-governance-qa-dataset/en/index.html
+++ b/project/AADS/regulation-governance-qa-dataset/en/index.html
@@ -81,7 +81,7 @@
         .interactive-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            border-left-color: #14b8a6;
+            border-left-color: #F86825;
         }
 
         .stat-card {
@@ -95,12 +95,12 @@
             top: 0;
             width: 4px;
             height: 100%;
-            background: linear-gradient(180deg, #14b8a6, #F86825);
+            background: linear-gradient(180deg, #F86825, #F86825);
             border-radius: 2px;
         }
 
         .teal-text {
-            color: #14b8a6;
+            color: #F86825;
         }
         .orange-text {
             color: #F86825;

--- a/project/AADS/regulation-governance-qa-dataset/ko/index.html
+++ b/project/AADS/regulation-governance-qa-dataset/ko/index.html
@@ -58,7 +58,7 @@
         .interactive-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            border-left-color: #14b8a6;
+            border-left-color: #F86825;
         }
 
         .stat-card {
@@ -72,12 +72,12 @@
             top: 0;
             width: 4px;
             height: 100%;
-            background: linear-gradient(180deg, #14b8a6, #F86825);
+            background: linear-gradient(180deg, #F86825, #F86825);
             border-radius: 2px;
         }
 
         .teal-text {
-            color: #14b8a6;
+            color: #F86825;
         }
         .orange-text {
             color: #F86825;

--- a/project/AADS/robot-qa-dataset-2/en/index.html
+++ b/project/AADS/robot-qa-dataset-2/en/index.html
@@ -146,7 +146,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -159,7 +159,7 @@
             --heading-color: #F1F5F9;
             --border-color: #334155;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         body {

--- a/project/AADS/robot-qa-dataset-2/ko/index.html
+++ b/project/AADS/robot-qa-dataset-2/ko/index.html
@@ -146,7 +146,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -159,7 +159,7 @@
             --heading-color: #F1F5F9;
             --border-color: #334155;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         body {

--- a/project/AADS/robot-qa-dataset/en/index.html
+++ b/project/AADS/robot-qa-dataset/en/index.html
@@ -146,7 +146,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -159,7 +159,7 @@
             --heading-color: #F1F5F9;
             --border-color: #334155;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         body {

--- a/project/AADS/robot-qa-dataset/ko/index.html
+++ b/project/AADS/robot-qa-dataset/ko/index.html
@@ -145,7 +145,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -158,7 +158,7 @@
             --heading-color: #F1F5F9;
             --border-color: #334155;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         body {

--- a/project/AADS/safety-qa-dataset/en/index.html
+++ b/project/AADS/safety-qa-dataset/en/index.html
@@ -139,7 +139,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -152,7 +152,7 @@
             --heading-color: #ffffff;
             --border-color: #374151;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         [data-theme="beige"] {
@@ -165,7 +165,7 @@
             --heading-color: #3A2E1C;
             --border-color: #E8D9B8;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         /* Interactive Card */

--- a/project/AADS/safety-qa-dataset/ko/index.html
+++ b/project/AADS/safety-qa-dataset/ko/index.html
@@ -138,7 +138,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -151,7 +151,7 @@
             --heading-color: #ffffff;
             --border-color: #374151;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         [data-theme="beige"] {
@@ -164,7 +164,7 @@
             --heading-color: #3A2E1C;
             --border-color: #E8D9B8;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         /* Interactive Card */

--- a/project/AgenticAI/deerflow-superagent/en/index.html
+++ b/project/AgenticAI/deerflow-superagent/en/index.html
@@ -199,7 +199,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }

--- a/project/AgenticAI/deerflow-superagent/ko/index.html
+++ b/project/AgenticAI/deerflow-superagent/ko/index.html
@@ -199,7 +199,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }

--- a/project/AgenticAI/hyperagents-self-improve/en/index.html
+++ b/project/AgenticAI/hyperagents-self-improve/en/index.html
@@ -204,7 +204,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }

--- a/project/AgenticAI/hyperagents-self-improve/ko/index.html
+++ b/project/AgenticAI/hyperagents-self-improve/ko/index.html
@@ -204,7 +204,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }

--- a/project/AgenticAI/moltbot-genie3-metaverse-for-agent/en/index.html
+++ b/project/AgenticAI/moltbot-genie3-metaverse-for-agent/en/index.html
@@ -135,7 +135,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -157,7 +157,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -275,7 +275,7 @@
         }
 
         .component-card.body::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.world::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.world::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.mind::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
 
         .component-card:hover {

--- a/project/AgenticAI/moltbot-genie3-metaverse-for-agent/ko/index.html
+++ b/project/AgenticAI/moltbot-genie3-metaverse-for-agent/ko/index.html
@@ -134,7 +134,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -156,7 +156,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -274,7 +274,7 @@
         }
 
         .component-card.body::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.world::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.world::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.mind::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
 
         .component-card:hover {

--- a/project/App/text-audit-01.html
+++ b/project/App/text-audit-01.html
@@ -91,8 +91,8 @@
             --border-color: rgba(71, 85, 105, 0.3);
             --accent-color: #F86825;
             --accent-hover: #e55a1a;
-            --teal-color: #14b8a6;
-            --teal-hover: #0d9488;
+            --teal-color: #F86825;
+            --teal-hover: #C64900;
         }
 
         [data-theme="light"] {

--- a/project/BizReport/anomalo-analysis-01/en/index.html
+++ b/project/BizReport/anomalo-analysis-01/en/index.html
@@ -187,7 +187,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$121M</p>
                     <p class="text-sm themeable-text-muted">Total funding raised (as of Mar 2025)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">~100</p>
                     <p class="text-sm themeable-text-muted">Employees (capital-efficient team)</p>
                 </div>
@@ -227,7 +227,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Instacart DNA: "Growth velocity" as product philosophy</h4>
                 <p class="themeable-text leading-relaxed">
                     Shmukler and Stanley managed hundreds of data pipelines at Instacart and experienced data quality failures firsthand. "You shouldn't need to write rules to know when your data is wrong" became Anomalo's founding insight. Connect in 5 minutes, learn for 2 weeks — <strong>radical minimization of Time-to-Value</strong> is pure Instacart growth culture.
@@ -323,7 +323,7 @@
                     <p class="font-bold accent-text mb-2">① Marketplace Deployment</p>
                     <p class="text-sm themeable-text">Auto-discovered via Snowflake/Databricks/GCP marketplaces. Capacity Drawdown allows purchase using existing cloud credits — no separate budget needed</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;">
                     <p class="font-bold teal-text mb-2">② Strategic Investor Referrals</p>
                     <p class="text-sm themeable-text">Databricks + Snowflake venture arms invest → platform sales teams internally recommend. Industry-unique: both platform investors simultaneously</p>
                 </div>
@@ -395,7 +395,7 @@
                 </div>
             </div>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">The Investor Counter-Argument: Look at Growth Rate and TAM Expansion</h4>
                 <p class="themeable-text leading-relaxed">
                     As AI/ML pipelines become universal, data quality shifts from "nice-to-have" to <strong>"must-have infrastructure."</strong> Annual enterprise data quality loss is estimated at $12.9M per company. Anomalo's ARR plateau reflects a GTM structure issue, not a market size ceiling — and this market keeps growing with AI adoption.

--- a/project/BizReport/anomalo-analysis-01/ko/index.html
+++ b/project/BizReport/anomalo-analysis-01/ko/index.html
@@ -189,7 +189,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$121M</p>
                     <p class="text-sm themeable-text-muted">총 투자 유치액 (2025.03 기준)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">~100명</p>
                     <p class="text-sm themeable-text-muted">임직원 수 (고자본효율 팀)</p>
                 </div>
@@ -229,7 +229,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Instacart DNA: "성장 속도"가 제품 철학이 되다</h4>
                 <p class="themeable-text leading-relaxed">
                     Shmukler와 Stanley는 Instacart에서 수백 개의 데이터 파이프라인을 운영하며 데이터 품질 문제를 직접 겪었습니다. "규칙을 일일이 설정하지 않아도 데이터가 이상해지면 즉시 알 수 있어야 한다"는 아이디어가 Anomalo의 출발점입니다. 연결 후 5분, 학습 2주 — <strong>Time-to-Value의 극소화</strong>는 Instacart 성장 문화의 산물입니다.
@@ -325,7 +325,7 @@
                     <p class="font-bold accent-text mb-2">① 마켓플레이스 배포</p>
                     <p class="text-sm themeable-text">Snowflake/Databricks/GCP 마켓플레이스에서 자동 발견. Capacity Drawdown으로 별도 예산 없이 기존 크레딧으로 결제 가능</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;">
                     <p class="font-bold teal-text mb-2">② 전략적 투자자 추천</p>
                     <p class="text-sm themeable-text">Databricks + Snowflake 양사 벤처 투자 → 플랫폼 세일즈팀이 내부 추천(referral). 업계에서 양사 동시 투자 유치는 유일</p>
                 </div>
@@ -397,7 +397,7 @@
                 </div>
             </div>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">투자자 반론: ARR이 아니라 성장률과 TAM 확장성을 보라</h4>
                 <p class="themeable-text leading-relaxed">
                     AI/ML 파이프라인이 보편화되면서 데이터 품질은 "nice-to-have"에서 <strong>"must-have 필수 인프라"</strong>로 전환 중입니다. 기업당 연간 데이터 품질 손실 추정액은 $12.9M에 달합니다. Anomalo의 ARR 정체는 시장 한계가 아닌 GTM 구조의 문제이며, 이 시장은 AI 확산과 함께 계속 커집니다.

--- a/project/BizReport/applied-intuition-analysis-01/en/index.html
+++ b/project/BizReport/applied-intuition-analysis-01/en/index.html
@@ -161,7 +161,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .timeline-item.timeline-danger::before { background: #ef4444; }
 
         .share-container { display: flex; gap: 1rem; align-items: center; justify-content: center; flex-wrap: wrap; margin-top: 1rem; }
@@ -270,7 +270,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$15B</p>
                     <p class="text-sm themeable-text-muted">Valuation (Series F, 2025)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$415M</p>
                     <p class="text-sm themeable-text-muted">2024 ARR (YoY +100%)</p>
                 </div>
@@ -321,7 +321,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Core Positioning: The "Android" Model</h4>
                 <p class="themeable-text leading-relaxed">
                     Applied Intuition defines itself as a "Vehicle Intelligence Company," pursuing a <strong>horizontal "Android" model</strong> in contrast to Tesla's vertical integration (Mac model). It provides vendor-neutral infrastructure that any OEM can license to build autonomous driving and vehicle software.
@@ -434,7 +434,7 @@
                 </div>
             </div>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <p class="font-bold teal-text mb-2">Technical Achievement Summary</p>
                 <p class="themeable-text leading-relaxed text-sm">Customers have run <strong>over 50 million simulations</strong>, validating billions of driving miles. Hundreds of PB of training data processed, improving perception, planning, and control performance across millions of frames.</p>
             </div>
@@ -566,7 +566,7 @@
             <p class="text-sm themeable-text-muted mb-6">Comparison benchmarks: Ansys $2.54B revenue (~14x, acquired by Synopsys for $35B), Anduril $1B revenue (~14x valuation), Tesla ~10x EV/Revenue.</p>
 
             <!-- Plain English Explanation -->
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-4">Plain English: Applied Intuition's Financial Story</h4>
                 <div class="themeable-text leading-relaxed space-y-3 text-sm">
                     <p><strong>ARR (Annual Recurring Revenue)</strong> — This is the steady subscription income that comes in year after year. Think of it like Netflix subscriptions, but for enterprise software licenses that customers renew annually. It grew from $207M in 2023 to $415M in 2024 (doubling in one year), and is projected to approach $1B by 2025.</p>
@@ -583,7 +583,7 @@
                     <p class="font-bold accent-text mb-2">Stage 1: Land</p>
                     <p class="themeable-text text-sm">Start with a single module (e.g., Simian basic simulation). A specific engineering team within the customer adopts after PoC</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #F86825;">
                     <p class="font-bold teal-text mb-2">Stage 2: Expand</p>
                     <p class="themeable-text text-sm">Add modules: Spectral (sensor) to Basis (data) to Safety Framework to Vehicle OS to SDS. Expand engineering seat count</p>
                 </div>
@@ -846,7 +846,7 @@
                     <p class="text-lg font-bold themeable-heading mb-2">"Embed in the Workflow"</p>
                     <p class="themeable-text text-sm">It was not technical excellence but depth of embedding in customer processes that created the $15B moat</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #F86825;">
                     <p class="font-bold teal-text mb-2">Key Message 2</p>
                     <p class="text-lg font-bold themeable-heading mb-2">"Move Fast"</p>
                     <p class="themeable-text text-sm">Before this giant expands into the manufacturing/process domain, Pebblous must be in market with a working product that delivers its unique integrated loop</p>

--- a/project/BizReport/applied-intuition-analysis-01/ko/index.html
+++ b/project/BizReport/applied-intuition-analysis-01/ko/index.html
@@ -160,7 +160,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .timeline-item.timeline-danger::before { background: #ef4444; }
 
         .share-container { display: flex; gap: 1rem; align-items: center; justify-content: center; flex-wrap: wrap; margin-top: 1rem; }
@@ -269,7 +269,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$150억</p>
                     <p class="text-sm themeable-text-muted">기업가치 (Series F, 2025)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$4.15억</p>
                     <p class="text-sm themeable-text-muted">2024년 ARR (YoY +100%)</p>
                 </div>
@@ -320,7 +320,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">핵심 포지셔닝: "안드로이드" 모델</h4>
                 <p class="themeable-text leading-relaxed">
                     Applied Intuition은 스스로를 "Vehicle Intelligence Company"로 정의하며, Tesla의 수직통합(Mac 모델)에 대비되는 <strong>수평적 "안드로이드" 모델</strong>을 지향합니다. 어떤 OEM이든 라이선스하여 자율주행·차량 소프트웨어를 구축할 수 있는 벤더-중립적 인프라를 제공합니다.
@@ -433,7 +433,7 @@
                 </div>
             </div>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <p class="font-bold teal-text mb-2">기술 성과 요약</p>
                 <p class="themeable-text leading-relaxed text-sm">고객이 <strong>5,000만 건 이상의 시뮬레이션</strong> 실행, 수십억 주행 마일 검증. 수백 PB의 학습 데이터 처리, 수백만 프레임의 인식·계획·제어 성능 개선.</p>
             </div>
@@ -565,7 +565,7 @@
             <p class="text-sm themeable-text-muted mb-6">비교 벤치마크: Ansys $25.4억 매출(~14x로 Synopsys에 $350억 인수), Anduril $10억 매출(~14x 밸류), Tesla ~10x EV/Revenue.</p>
 
             <!-- 쉬운 설명 블록쿼트 -->
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-4">쉬운 설명: Applied Intuition의 돈 이야기</h4>
                 <div class="themeable-text leading-relaxed space-y-3 text-sm">
                     <p><strong>ARR (연간반복매출)</strong> — 매년 꾸준히 들어오는 구독료 수입입니다. 넷플릭스 월정액처럼, 고객이 매년 갱신하는 소프트웨어 라이선스 매출이죠. 2023년 약 3천억 원에서 2024년 6천억 원으로 1년 만에 2배, 2025년에는 1.4조 원에 육박할 전망입니다.</p>
@@ -582,7 +582,7 @@
                     <p class="font-bold accent-text mb-2">1단계: 진입 (Land)</p>
                     <p class="themeable-text text-sm">하나의 모듈(예: Simian 기본 시뮬레이션)로 시작. 고객 내 특정 엔지니어링 팀이 PoC 후 채택</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #F86825;">
                     <p class="font-bold teal-text mb-2">2단계: 확장 (Expand)</p>
                     <p class="themeable-text text-sm">Spectral(센서) → Basis(데이터) → Safety Framework → Vehicle OS → SDS로 모듈 추가. 엔지니어링 시트 수 확대</p>
                 </div>
@@ -845,7 +845,7 @@
                     <p class="text-lg font-bold themeable-heading mb-2">"워크플로우에 박혀라"</p>
                     <p class="themeable-text text-sm">기술의 우수성이 아니라 고객 프로세스에의 임베딩 깊이가 $150억의 해자를 만들었다</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-left: 4px solid #F86825;">
                     <p class="font-bold teal-text mb-2">핵심 메시지 2</p>
                     <p class="text-lg font-bold themeable-heading mb-2">"빨리 움직여라"</p>
                     <p class="themeable-text text-sm">이 거인이 제조·공정 도메인까지 확장하기 전에, 페블러스만의 통합 루프가 작동하는 제품으로 시장에 있어야 한다</p>

--- a/project/BizReport/databricks-analysis-01/en/index.html
+++ b/project/BizReport/databricks-analysis-01/en/index.html
@@ -156,7 +156,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
     </style>
 </head>
 <body class="antialiased">
@@ -205,7 +205,7 @@
             <p class="themeable-text leading-relaxed mb-8">The three key metrics below capture Databricks' scale and growth velocity. Its open-source funnel strategy, consumption-based pricing, and multi-cloud neutrality offer an execution blueprint worth studying.</p>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
                 <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;"><p class="text-3xl font-bold accent-text mb-2">$134B</p><p class="text-sm themeable-text-muted">Valuation (Series L, Dec 2025)</p></div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;"><p class="text-3xl font-bold teal-text mb-2">$5.4B</p><p class="text-sm themeable-text-muted">Jan 2026 ARR (YoY +65%)</p></div>
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;"><p class="text-3xl font-bold teal-text mb-2">$5.4B</p><p class="text-sm themeable-text-muted">Jan 2026 ARR (YoY +65%)</p></div>
                 <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #475569;"><p class="text-3xl font-bold themeable-heading mb-2">10,000+</p><p class="text-sm themeable-text-muted">Global customers</p></div>
             </div>
         </section>
@@ -235,7 +235,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Core Positioning: "Open Core" Strategy</h4>
                 <p class="themeable-text leading-relaxed">Databricks is the textbook example of an <strong>"open core"</strong> strategy: open-sourcing key technologies (Apache Spark, Delta Lake, MLflow) to build community adoption, then monetizing through premium managed cloud services. With MLflow alone seeing 30M+ monthly downloads, the model proves that developer ecosystem dominance drives enterprise conversion.</p>
             </div>
@@ -282,7 +282,7 @@
             </div>
             <h3 class="text-xl font-semibold themeable-heading mb-4">2.4 AI/BI (Genie)</h3>
             <p class="themeable-text leading-relaxed mb-4">AI-powered BI tool enabling business users to analyze data via natural language without coding.</p>
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <p class="font-bold teal-text mb-2">Genie Key Features</p>
                 <p class="themeable-text leading-relaxed text-sm">Natural language query &rarr; auto SQL generation &rarr; visualization. Transparently displays thinking steps to build trust. Integrates with Unity Catalog Metric Views for consistent org-wide KPIs.</p>
             </div>

--- a/project/BizReport/databricks-analysis-01/ko/index.html
+++ b/project/BizReport/databricks-analysis-01/ko/index.html
@@ -156,7 +156,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
     </style>
 </head>
 <body class="antialiased">
@@ -228,7 +228,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$134B</p>
                     <p class="text-sm themeable-text-muted">기업가치 (Series L, 2025.12)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$5.4B</p>
                     <p class="text-sm themeable-text-muted">2026.01 ARR (YoY +65%)</p>
                 </div>
@@ -278,7 +278,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">핵심 포지셔닝: "오픈 코어" 전략</h4>
                 <p class="themeable-text leading-relaxed">
                     Databricks는 Apache Spark, Delta Lake, MLflow 등 핵심 기술을 오픈소스로 공개하여 커뮤니티를 확산시킨 뒤, 프리미엄 매니지드 클라우드 서비스로 수익화하는 <strong>"오픈 코어"</strong> 전략의 교과서적 사례입니다. 월 3,000만+ 다운로드의 MLflow가 증명하듯, 개발자 생태계를 장악한 뒤 엔터프라이즈 전환율을 높이는 모델입니다.
@@ -364,7 +364,7 @@
             <!-- 2.4 AI/BI -->
             <h3 class="text-xl font-semibold themeable-heading mb-4">2.4 AI/BI (Genie)</h3>
             <p class="themeable-text leading-relaxed mb-4">비즈니스 사용자가 코딩 없이 자연어로 데이터를 분석할 수 있는 AI 기반 BI 도구입니다. 2025년 중반 출시 이후 빠르게 확산되고 있습니다.</p>
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <p class="font-bold teal-text mb-2">Genie 핵심 기능</p>
                 <p class="themeable-text leading-relaxed text-sm">자연어 질의 → SQL 자동 생성 → 시각화. 사고 과정(thinking steps)을 투명하게 표시하여 비즈니스 사용자의 신뢰를 확보합니다. Unity Catalog Metric Views와 연동하여 조직 전체에서 일관된 지표를 사용할 수 있습니다.</p>
             </div>

--- a/project/BizReport/palantir-analysis-2026/en/index.html
+++ b/project/BizReport/palantir-analysis-2026/en/index.html
@@ -125,7 +125,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .timeline-item.timeline-danger::before { background: #ef4444; }
 
         .strategy-matrix { display: grid; grid-template-columns: 1fr 1fr; gap: 2px; border-radius: 12px; overflow: hidden; margin: 2rem 0; }
@@ -226,7 +226,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$4.46B</p>
                     <p class="text-sm themeable-text-muted">FY2025 Annual Revenue</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">+137%</p>
                     <p class="text-sm themeable-text-muted">U.S. Commercial FY2025 YoY Growth</p>
                 </div>
@@ -367,7 +367,7 @@
                 AIP Bootcamp is the direct cause of Palantir's commercial explosion. In 2–5 day intensive on-site workshops, the team uses the customer's actual data and business problems to generate a working AI prototype on the same day. Not a demo — an actual deliverable running in the customer's environment. This model completely inverts the traditional enterprise software approach of "6–12 month pilots."
             </p>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">AIP Bootcamp Performance Metrics (Q4 2025)</h4>
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
                     <div>
@@ -680,7 +680,7 @@
                 The GTM lessons AIP Bootcamp's success offers DataClinic are clear: "show value first, contract later." Instead of the traditional long POC (Proof of Concept) cycle, Pebblous can design a "DataClinic Sprint" model that diagnoses a customer's actual data in 2–3 days and delivers immediate insights.
             </p>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-4">DataClinic Sprint (Benchmarked from Palantir Bootcamp)</h4>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="text-center">

--- a/project/BizReport/palantir-analysis-2026/ko/index.html
+++ b/project/BizReport/palantir-analysis-2026/ko/index.html
@@ -125,7 +125,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .timeline-item.timeline-danger::before { background: #ef4444; }
 
         .strategy-matrix { display: grid; grid-template-columns: 1fr 1fr; gap: 2px; border-radius: 12px; overflow: hidden; margin: 2rem 0; }
@@ -226,7 +226,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$44.6억</p>
                     <p class="text-sm themeable-text-muted">FY2025 연간 매출</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">+137%</p>
                     <p class="text-sm themeable-text-muted">미국 상업 FY2025 YoY 성장</p>
                 </div>
@@ -367,7 +367,7 @@
                 AIP Bootcamp는 팔란티어 상업 성장 폭발의 직접적인 원인입니다. 2~5일간의 현장 집중 워크숍에서 고객의 실제 데이터와 비즈니스 문제를 이용해 작동하는 AI 프로토타입을 당일 생성합니다. 단순한 데모가 아니라 고객의 환경에서 실제로 실행되는 결과물을 만들어 보여줍니다. 이는 기존 엔터프라이즈 소프트웨어의 "6~12개월 파일럿" 관행을 완전히 뒤집는 모델입니다.
             </p>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">AIP Bootcamp 성과 지표 (Q4 2025)</h4>
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
                     <div>
@@ -680,7 +680,7 @@
                 AIP Bootcamp의 성공이 DataClinic에게 주는 GTM 교훈은 명확합니다. "먼저 가치를 보여라, 그 다음 계약하라"는 원칙입니다. 전통적인 엔터프라이즈 세일즈의 긴 POC(Proof of Concept) 사이클 대신, 고객의 실제 데이터를 2~3일 안에 진단해 즉각적인 인사이트를 제공하는 "DataClinic Sprint" 모델을 설계할 수 있습니다.
             </p>
 
-            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-6 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-4">DataClinic Sprint (팔란티어 Bootcamp 벤치마킹)</h4>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="text-center">

--- a/project/BizReport/shelf-io-analysis-01/en/index.html
+++ b/project/BizReport/shelf-io-analysis-01/en/index.html
@@ -184,7 +184,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$60.7M</p>
                     <p class="text-sm themeable-text-muted">Total raised (as of Series B, Aug 2021)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$32.5M</p>
                     <p class="text-sm themeable-text-muted">2024 ARR (8,000 customers, ARPA ~$4K)</p>
                 </div>
@@ -256,7 +256,7 @@
                     <p class="font-bold accent-text mb-2">MerlinAI (Core AI Engine)</p>
                     <p class="text-sm themeable-text">NLP intent detection, content quality scoring, 100+ language auto-translation, proactive identification of duplicate/outdated docs, GenAI-based answer generation</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;">
                     <p class="font-bold teal-text mb-2">Agent Assist</p>
                     <p class="text-sm themeable-text">Real-time intent detection during live calls/chats → answer popup suggestions to agents. IVR integration support</p>
                 </div>

--- a/project/BizReport/shelf-io-analysis-01/ko/index.html
+++ b/project/BizReport/shelf-io-analysis-01/ko/index.html
@@ -185,7 +185,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$60.7M</p>
                     <p class="text-sm themeable-text-muted">총 투자 유치액 (2021.08 Series B 기준)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$32.5M</p>
                     <p class="text-sm themeable-text-muted">2024 ARR (8,000 고객, ARPA ~$4K)</p>
                 </div>
@@ -257,7 +257,7 @@
                     <p class="font-bold accent-text mb-2">MerlinAI (핵심 AI 엔진)</p>
                     <p class="text-sm themeable-text">NLP 의도 감지, 콘텐츠 품질 스코어링, 100+ 언어 자동 번역, 중복·오래된 문서 프로액티브 식별, GenAI 기반 자동 응답 생성</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;">
                     <p class="font-bold teal-text mb-2">Agent Assist</p>
                     <p class="text-sm themeable-text">실시간 통화·채팅 중 고객 의도 감지 → 에이전트에게 답변 팝업 제안. IVR 통합 지원</p>
                 </div>

--- a/project/BizReport/snowflake-analysis-01/en/index.html
+++ b/project/BizReport/snowflake-analysis-01/en/index.html
@@ -101,7 +101,7 @@
         @media (max-width: 768px) { .comparison-table { font-size: 0.875rem; } .comparison-table th, .comparison-table td { padding: 0.75rem 0.5rem; } }
         .timeline-item { position: relative; padding-left: 1.5rem; border-left: 2px solid var(--border-color); }
         .timeline-item::before { content: ''; position: absolute; left: -6px; top: 0.5rem; width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825); }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .strategy-matrix { display: grid; grid-template-columns: 1fr 1fr; gap: 2px; border-radius: 12px; overflow: hidden; margin: 2rem 0; }
         .matrix-cell { padding: 1.5rem; }
         .matrix-cell .axis-label { font-size: 0.75rem; letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 0.75rem; font-weight: 700; }
@@ -165,7 +165,7 @@
             <p class="themeable-text leading-relaxed mb-8">The three key metrics below illustrate Snowflake's scale and data ecosystem dominance. Its consumption-based pricing, NRR of 125% Land &amp; Expand model, and $400M+ AI partnership investments are a playbook Pebblous should study.</p>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
                 <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;"><p class="text-3xl font-bold accent-text mb-2">$53B</p><p class="text-sm themeable-text-muted">Market Cap (Mar 2026)</p></div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;"><p class="text-3xl font-bold teal-text mb-2">$4.47B</p><p class="text-sm themeable-text-muted">FY2026 Product Revenue (YoY +29%)</p></div>
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;"><p class="text-3xl font-bold teal-text mb-2">$4.47B</p><p class="text-sm themeable-text-muted">FY2026 Product Revenue (YoY +29%)</p></div>
                 <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #475569;"><p class="text-3xl font-bold themeable-heading mb-2">125%</p><p class="text-sm themeable-text-muted">Net Revenue Retention (NRR)</p></div>
             </div>
 
@@ -228,7 +228,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Core Positioning: "AI Data Cloud"</h4>
                 <p class="themeable-text leading-relaxed">Snowflake defines itself as the "AI Data Cloud." Going beyond a simple data warehouse, it provides <strong>data storage, sharing, and AI/ML</strong> on a single platform, aiming to become the foundational infrastructure for enterprise AI through Cortex AI. Its consumption-based pricing lowers the entry barrier, while NRR of 125% drives natural expansion.</p>
             </div>
@@ -315,7 +315,7 @@
 
             <h3 class="text-2xl font-semibold themeable-heading mb-4">Plain Language: Snowflake's Money Story</h3>
             <p class="themeable-text leading-relaxed mb-4">Think of Snowflake's business like a cloud storage landlord. Just as a building owner rents out floors, Snowflake rents "cloud space" for storing and processing enterprise data. The twist: <strong>you pay only for what you use</strong>, not a flat monthly fee.</p>
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Snowflake Business Model at a Glance</h4>
                 <ul class="themeable-text leading-relaxed space-y-2" style="list-style:none;margin-left:0;line-height:2.0;">
                     <li>• <strong>Revenue source</strong>: Usage-based billing for data storage, processing, and AI services (credit-based)</li>
@@ -346,7 +346,7 @@
             <p class="themeable-text leading-relaxed mb-4">Snowflake chose to integrate best-in-class AI models rather than building its own. This creates a powerful positioning: "Your data is already here, so run AI here too."</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
                 <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;"><p class="font-bold accent-text mb-2">Anthropic — $200M</p><p class="text-sm themeable-text-muted">Claude models natively in Cortex, 12,600+ customer access (Dec 2025)</p></div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;"><p class="font-bold teal-text mb-2">OpenAI — $200M</p><p class="text-sm themeable-text-muted">GPT model integration, joint GTM (Feb 2026)</p></div>
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;"><p class="font-bold teal-text mb-2">OpenAI — $200M</p><p class="text-sm themeable-text-muted">GPT model integration, joint GTM (Feb 2026)</p></div>
                 <div class="themeable-card rounded-xl p-6 interactive-card"><p class="font-bold themeable-heading mb-2">Google Cloud — Gemini 3</p><p class="text-sm themeable-text-muted">Native Cortex AI integration (Jan 2025)</p></div>
                 <div class="themeable-card rounded-xl p-6 interactive-card"><p class="font-bold themeable-heading mb-2">Palantir</p><p class="text-sm themeable-text-muted">Foundry + AIP ↔ AI Data Cloud integration (Oct 2025)</p></div>
             </div>

--- a/project/BizReport/snowflake-analysis-01/ko/index.html
+++ b/project/BizReport/snowflake-analysis-01/ko/index.html
@@ -125,7 +125,7 @@
             content: ''; position: absolute; left: -6px; top: 0.5rem;
             width: 10px; height: 10px; border-radius: 50%; background: var(--accent-color, #F86825);
         }
-        .timeline-item.timeline-success::before { background: var(--teal-color, #14b8a6); }
+        .timeline-item.timeline-success::before { background: var(--teal-color, #F86825); }
         .timeline-item.timeline-danger::before { background: #ef4444; }
 
         /* Strategy Matrix */
@@ -222,7 +222,7 @@
                     <p class="text-3xl font-bold accent-text mb-2">$530억</p>
                     <p class="text-sm themeable-text-muted">시가총액 (2026.03)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <p class="text-3xl font-bold teal-text mb-2">$44.7억</p>
                     <p class="text-sm themeable-text-muted">FY2026 제품 매출 (YoY +29%)</p>
                 </div>
@@ -305,7 +305,7 @@
                 </table>
             </div>
 
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">핵심 포지셔닝: "AI Data Cloud"</h4>
                 <p class="themeable-text leading-relaxed">
                     Snowflake는 스스로를 "AI Data Cloud"로 정의합니다. 단순 데이터 웨어하우스를 넘어 <strong>데이터 저장 → 공유 → AI/ML 활용</strong>을 하나의 플랫폼에서 제공하며, Cortex AI를 통해 엔터프라이즈 AI의 기본 인프라로 자리잡겠다는 전략입니다. 소비 기반 과금 모델로 초기 진입 장벽을 낮추고, NRR 125%로 자연스럽게 확장하는 구조입니다.
@@ -445,7 +445,7 @@
             <p class="themeable-text leading-relaxed mb-4">
                 Snowflake의 사업 모델을 클라우드 저장소 임대업에 비유할 수 있습니다. 건물주가 층별로 공간을 임대하듯, Snowflake는 기업의 데이터를 저장하고 처리하는 "클라우드 공간"을 임대합니다. 특이한 점은 <strong>월세가 아니라 사용한 만큼만 과금</strong>한다는 것입니다.
             </p>
-            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #14b8a6;">
+            <div class="themeable-card rounded-xl p-8 mb-8" style="border-left: 4px solid #F86825;">
                 <h4 class="font-bold teal-text mb-3">Snowflake 비즈니스 모델 한눈에</h4>
                 <ul class="themeable-text leading-relaxed space-y-2" style="list-style:none;margin-left:0;line-height:2.0;">
                     <li>• <strong>수익원</strong>: 데이터 저장·처리·AI 서비스 사용량에 따른 과금 (크레딧 기반)</li>
@@ -481,7 +481,7 @@
                     <p class="font-bold accent-text mb-2">Anthropic — $200M</p>
                     <p class="text-sm themeable-text-muted">Claude 모델 Cortex 내장, 12,600+ 고객 접근 (2025.12)</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 3px solid #F86825;">
                     <p class="font-bold teal-text mb-2">OpenAI — $200M</p>
                     <p class="text-sm themeable-text-muted">GPT 모델 통합, 공동 GTM (2026.02)</p>
                 </div>

--- a/project/CURK/Mini-Project/CURK-2025-09-29/index.html
+++ b/project/CURK/Mini-Project/CURK-2025-09-29/index.html
@@ -140,12 +140,12 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
             --diagram-bg: rgba(30, 41, 59, 0.8);
             --diagram-border: #475569;
             --diagram-accent-bg: rgba(20, 184, 166, 0.2);
-            --diagram-accent-text: #5eead4;
+            --diagram-accent-text: #FFC6B1;
             --chart-text: #e2e8f0;
             --chart-grid: #334155;
         }
@@ -158,7 +158,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
             --diagram-bg: #f1f5f9;
             --diagram-border: #cbd5e1;
@@ -176,7 +176,7 @@
             --text-secondary: #574523;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #E8D9B8;
             --diagram-bg: rgba(255, 252, 245, 0.6);
             --diagram-border: #E8D9B8;
@@ -637,7 +637,7 @@
 
                                 <!-- Example 2 -->
                                 <div class="flex items-center space-x-3">
-                                    <div class="flex-shrink-0 w-2 h-2 rounded-full" style="background-color: #14b8a6;"></div>
+                                    <div class="flex-shrink-0 w-2 h-2 rounded-full" style="background-color: #F86825;"></div>
                                     <p class="text-sm font-mono themeable-subtitle flex-1">
                                         <span style="color: #3b82f6; font-weight: 600;">"파리"</span>
                                         <span style="color: #ef4444;"> - </span>
@@ -700,7 +700,7 @@
                                         <path d="M0,0 L0,6 L9,3 z" fill="#3b82f6" />
                                     </marker>
                                     <marker id="arrowteal" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-                                        <path d="M0,0 L0,6 L9,3 z" fill="#14b8a6" />
+                                        <path d="M0,0 L0,6 L9,3 z" fill="#F86825" />
                                     </marker>
                                     <marker id="arroworange" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
                                         <path d="M0,0 L0,6 L9,3 z" fill="#F86825" />
@@ -711,14 +711,14 @@
                                 <text x="100" y="115" fill="currentColor" font-size="12" font-weight="bold">A</text>
 
                                 <!-- Vector B (teal) -->
-                                <line x1="50" y1="150" x2="100" y2="80" stroke="#14b8a6" stroke-width="2.5" marker-end="url(#arrowteal)"/>
+                                <line x1="50" y1="150" x2="100" y2="80" stroke="#F86825" stroke-width="2.5" marker-end="url(#arrowteal)"/>
                                 <text x="60" y="110" fill="currentColor" font-size="12" font-weight="bold">B</text>
 
                                 <!-- Plus sign -->
                                 <text x="175" y="105" fill="currentColor" font-size="20" font-weight="bold">+</text>
 
                                 <!-- Vector B shifted (teal dashed) -->
-                                <line x1="150" y1="100" x2="200" y2="30" stroke="#14b8a6" stroke-width="2" stroke-dasharray="4,4" marker-end="url(#arrowteal)"/>
+                                <line x1="150" y1="100" x2="200" y2="30" stroke="#F86825" stroke-width="2" stroke-dasharray="4,4" marker-end="url(#arrowteal)"/>
 
                                 <!-- Result Vector A+B (orange) -->
                                 <line x1="50" y1="150" x2="200" y2="30" stroke="#F86825" stroke-width="3" marker-end="url(#arroworange)"/>
@@ -1233,7 +1233,7 @@
                         {
                             selector: 'node',
                             style: {
-                                'background-color': '#14b8a6',
+                                'background-color': '#F86825',
                                 'label': 'data(label)',
                                 'color': '#ffffff',
                                 'text-valign': 'center',
@@ -1245,15 +1245,15 @@
                                 'padding': '30px',
                                 'shape': 'roundrectangle',
                                 'border-width': '3px',
-                                'border-color': '#0d9488'
+                                'border-color': '#C64900'
                             }
                         },
                         {
                             selector: 'edge',
                             style: {
                                 'width': 4,
-                                'line-color': '#14b8a6',
-                                'target-arrow-color': '#14b8a6',
+                                'line-color': '#F86825',
+                                'target-arrow-color': '#F86825',
                                 'target-arrow-shape': 'triangle',
                                 'curve-style': 'bezier',
                                 'arrow-scale': 2,
@@ -1261,7 +1261,7 @@
                                 'font-size': '18px',
                                 'font-weight': '700',
                                 'color': '#ffffff',
-                                'text-background-color': '#14b8a6',
+                                'text-background-color': '#F86825',
                                 'text-background-opacity': 1,
                                 'text-background-padding': '8px',
                                 'text-background-shape': 'roundrectangle'
@@ -1324,7 +1324,7 @@
                                     const type = ele.data('type');
                                     if (type === 'input') return '#475569';
                                     if (type === 'output') return '#F86825';
-                                    return '#14b8a6';
+                                    return '#F86825';
                                 },
                                 'label': 'data(label)',
                                 'color': '#ffffff',
@@ -1342,7 +1342,7 @@
                                     const type = ele.data('type');
                                     if (type === 'input') return '#334155';
                                     if (type === 'output') return '#ea580c';
-                                    return '#0d9488';
+                                    return '#C64900';
                                 }
                             }
                         },
@@ -1354,7 +1354,7 @@
                                 'background-color': function(ele) {
                                     const type = ele.data('type');
                                     if (type === 'output') return '#ea580c';
-                                    return '#0d9488';
+                                    return '#C64900';
                                 }
                             }
                         },
@@ -1443,7 +1443,7 @@
                         {
                             selector: 'node',
                             style: {
-                                'background-color': '#14b8a6',
+                                'background-color': '#F86825',
                                 'label': 'data(label)',
                                 'color': '#ffffff',
                                 'text-valign': 'center',
@@ -1461,7 +1461,7 @@
                         {
                             selector: 'node[type="central"]',
                             style: {
-                                'background-color': '#14b8a6',
+                                'background-color': '#F86825',
                                 'shape': 'ellipse',
                                 'padding': '28px',
                                 'font-size': '16px',
@@ -1471,7 +1471,7 @@
                         {
                             selector: 'node[type="company"]',
                             style: {
-                                'background-color': '#0d9488'
+                                'background-color': '#C64900'
                             }
                         },
                         {
@@ -1483,7 +1483,7 @@
                         {
                             selector: 'node[type="category"]',
                             style: {
-                                'background-color': '#0d9488'
+                                'background-color': '#C64900'
                             }
                         },
                         {
@@ -1496,8 +1496,8 @@
                             selector: 'edge',
                             style: {
                                 'width': 3,
-                                'line-color': '#14b8a6',
-                                'target-arrow-color': '#14b8a6',
+                                'line-color': '#F86825',
+                                'target-arrow-color': '#F86825',
                                 'target-arrow-shape': 'triangle',
                                 'curve-style': 'bezier',
                                 'arrow-scale': 1.5,
@@ -1505,7 +1505,7 @@
                                 'font-size': '13px',
                                 'font-weight': '600',
                                 'color': '#ffffff',
-                                'text-background-color': '#14b8a6',
+                                'text-background-color': '#F86825',
                                 'text-background-opacity': 1,
                                 'text-background-padding': '6px',
                                 'text-background-shape': 'roundrectangle'

--- a/project/CURK/Mini-Project/CURK-2025-09-29/index_new.html
+++ b/project/CURK/Mini-Project/CURK-2025-09-29/index_new.html
@@ -52,7 +52,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -64,7 +64,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -76,7 +76,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -121,8 +121,8 @@
 
         .tab-btn { transition: all 0.3s ease; }
         .tab-btn.active {
-            border-color: #14b8a6;
-            background-color: #14b8a6;
+            border-color: #F86825;
+            background-color: #F86825;
             color: #ffffff;
             font-weight: 700;
         }

--- a/project/CURK/intelligent-parrot/en/index.html
+++ b/project/CURK/intelligent-parrot/en/index.html
@@ -92,7 +92,7 @@
             --heading-color: #111827;
             --border-color: #E5E7EB;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         [data-theme="dark"] {
@@ -105,7 +105,7 @@
             --heading-color: #ffffff;
             --border-color: #334155;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
         }
 
         [data-theme="beige"] {
@@ -118,7 +118,7 @@
             --heading-color: #2d2a26;
             --border-color: #d6cec0;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
         }
 
         body {

--- a/project/CURK/ontology/enterprise-ontology-paradigm/en/index.html
+++ b/project/CURK/ontology/enterprise-ontology-paradigm/en/index.html
@@ -108,7 +108,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -120,7 +120,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -132,7 +132,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -986,7 +986,7 @@
                                 </svg>
                                 View PDF
                             </a>
-                            <a href="source/엔터프라이즈 인텔리전스를 위한 온톨로지 패러다임의 전환.pdf" download class="download-btn" style="background: linear-gradient(135deg, #0d9488, #0f766e);">
+                            <a href="source/엔터프라이즈 인텔리전스를 위한 온톨로지 패러다임의 전환.pdf" download class="download-btn" style="background: linear-gradient(135deg, #C64900, #0f766e);">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
                                 </svg>

--- a/project/CURK/ontology/enterprise-ontology-paradigm/ko/index.html
+++ b/project/CURK/ontology/enterprise-ontology-paradigm/ko/index.html
@@ -108,7 +108,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -120,7 +120,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -132,7 +132,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -986,7 +986,7 @@
                                 </svg>
                                 PDF 보기
                             </a>
-                            <a href="source/엔터프라이즈 인텔리전스를 위한 온톨로지 패러다임의 전환.pdf" download class="download-btn" style="background: linear-gradient(135deg, #0d9488, #0f766e);">
+                            <a href="source/엔터프라이즈 인텔리전스를 위한 온톨로지 패러다임의 전환.pdf" download class="download-btn" style="background: linear-gradient(135deg, #C64900, #0f766e);">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
                                 </svg>

--- a/project/CURK/ontology/iso5259-ontology-extraction.html
+++ b/project/CURK/ontology/iso5259-ontology-extraction.html
@@ -328,8 +328,8 @@
             background: rgba(51, 65, 85, 0.3);
         }
         .example-tab-btn.active {
-            color: #14b8a6;
-            border-bottom-color: #14b8a6;
+            color: #F86825;
+            border-bottom-color: #F86825;
             background: rgba(20, 184, 166, 0.1);
         }
         .example-content {
@@ -567,7 +567,7 @@
             left: 0;
             width: 0%;
             height: 3px;
-            background: linear-gradient(90deg, #F86825, #14b8a6);
+            background: linear-gradient(90deg, #F86825, #F86825);
             z-index: 60;
             transition: width 0.1s ease;
         }
@@ -579,7 +579,7 @@
             bottom: 2rem;
             width: 48px;
             height: 48px;
-            background: #14b8a6;
+            background: #F86825;
             border: none;
             border-radius: 50%;
             cursor: pointer;
@@ -597,7 +597,7 @@
             visibility: visible;
         }
         #back-to-top:hover {
-            background: #0d9488;
+            background: #C64900;
             transform: translateY(-4px);
             box-shadow: 0 8px 20px rgba(20, 184, 166, 0.4);
         }
@@ -803,7 +803,7 @@
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-size: 0.875rem;
-            color: #14b8a6;
+            color: #F86825;
             font-family: 'Roboto Mono', monospace;
         }
         #md-viewer-content pre {
@@ -826,7 +826,7 @@
             color: #e05a1a;
         }
         #md-viewer-content blockquote {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             padding-left: 1rem;
             color: #94a3b8;
             margin-bottom: 1rem;
@@ -1113,9 +1113,9 @@
                                             <text x="140" y="46" text-anchor="middle" fill="#94a3b8" font-size="10">Characteristic</text>
 
                                             <!-- InherentCharacteristic (중간) -->
-                                            <ellipse cx="140" cy="110" rx="88" ry="26" fill="#14b8a6" opacity="0.2" stroke="#14b8a6" stroke-width="2"/>
-                                            <text x="140" y="109" text-anchor="middle" fill="#14b8a6" font-size="12" font-weight="bold">Inherent</text>
-                                            <text x="140" y="121" text-anchor="middle" fill="#14b8a6" font-size="10">Characteristic</text>
+                                            <ellipse cx="140" cy="110" rx="88" ry="26" fill="#F86825" opacity="0.2" stroke="#F86825" stroke-width="2"/>
+                                            <text x="140" y="109" text-anchor="middle" fill="#F86825" font-size="12" font-weight="bold">Inherent</text>
+                                            <text x="140" y="121" text-anchor="middle" fill="#F86825" font-size="10">Characteristic</text>
 
                                             <!-- Accuracy (하위) -->
                                             <ellipse cx="140" cy="195" rx="70" ry="24" fill="#F86825" opacity="0.3" stroke="#F86825" stroke-width="2"/>
@@ -1180,9 +1180,9 @@
                                             <text x="140" y="46" text-anchor="middle" fill="#94a3b8" font-size="10">Characteristic</text>
 
                                             <!-- InherentCharacteristic (중간) -->
-                                            <ellipse cx="140" cy="110" rx="88" ry="26" fill="#14b8a6" opacity="0.2" stroke="#14b8a6" stroke-width="2"/>
-                                            <text x="140" y="109" text-anchor="middle" fill="#14b8a6" font-size="12" font-weight="bold">Inherent</text>
-                                            <text x="140" y="121" text-anchor="middle" fill="#14b8a6" font-size="10">Characteristic</text>
+                                            <ellipse cx="140" cy="110" rx="88" ry="26" fill="#F86825" opacity="0.2" stroke="#F86825" stroke-width="2"/>
+                                            <text x="140" y="109" text-anchor="middle" fill="#F86825" font-size="12" font-weight="bold">Inherent</text>
+                                            <text x="140" y="121" text-anchor="middle" fill="#F86825" font-size="10">Characteristic</text>
 
                                             <!-- Completeness (하위) -->
                                             <ellipse cx="140" cy="195" rx="75" ry="24" fill="#F86825" opacity="0.3" stroke="#F86825" stroke-width="2"/>
@@ -2205,22 +2205,22 @@ ORDER BY ?labelKo</textarea>
 
         // Minimal color palette - Pebblous Brand Colors
         // Philosophy: 최소한의 색상으로 최대 효과
-        // Only 3 colors: Orange (#F86825) + Teal (#14b8a6) + Slate (#475569)
+        // Only 3 colors: Orange (#F86825) + Teal (#F86825) + Slate (#475569)
         const colors = {
             primary: '#F86825',    // Orange - 브랜드 메인
-            secondary: '#14b8a6',  // Teal - 보색 대비
+            secondary: '#F86825',  // Teal - 보색 대비
             neutral: '#475569',    // Slate - 중립
             accent: '#06b6d4',     // Cyan - 특수 강조 (최소 사용)
 
             // Mapping to node types (3-4 colors only)
-            model: '#14b8a6',      // Teal - 모델
-            root: '#14b8a6',       // Teal - 루트
-            category: '#14b8a6',   // Teal - 카테고리 (통일)
+            model: '#F86825',      // Teal - 모델
+            root: '#F86825',       // Teal - 루트
+            category: '#F86825',   // Teal - 카테고리 (통일)
             inherent: '#F86825',   // Orange - 고유 특성 (브랜드)
             system: '#06b6d4',     // Cyan - 시스템 의존 (accent)
             measure: '#F86825',    // Orange - 측정 (브랜드 통일)
             dataset: '#06b6d4',    // Cyan - 데이터셋
-            requirement: '#14b8a6', // Teal - 요구사항
+            requirement: '#F86825', // Teal - 요구사항
             edge: '#475569',       // Slate - 엣지 (중립)
             edgeArrow: '#F86825'   // Orange - 화살표 (브랜드)
         };
@@ -3182,7 +3182,7 @@ ORDER BY ?date`
                 const btn = this;
                 const originalText = btn.querySelector('span').textContent;
                 btn.querySelector('span').textContent = '복사됨!';
-                btn.style.color = '#14b8a6';
+                btn.style.color = '#F86825';
 
                 setTimeout(() => {
                     btn.querySelector('span').textContent = originalText;

--- a/project/CURK/ontology/pdf-navigator.html
+++ b/project/CURK/ontology/pdf-navigator.html
@@ -156,7 +156,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -304,7 +304,7 @@
         /* Hover effect */
         .resizer:hover::before,
         .resizer:hover::after {
-            background: #14b8a6;
+            background: #F86825;
             height: 60px;
             box-shadow: 0 0 8px rgba(20, 184, 166, 0.4);
         }
@@ -528,7 +528,7 @@
             display: inline-block;
             padding: 0.25rem 0.5rem;
             background: rgba(20, 184, 166, 0.2);
-            color: #14b8a6;
+            color: #F86825;
             border-radius: 0.25rem;
             font-size: 0.75rem;
             margin-left: 0.5rem;
@@ -566,7 +566,7 @@
         }
 
         .tab-btn-top:hover {
-            color: #14b8a6;
+            color: #F86825;
             background: rgba(20, 184, 166, 0.05);
         }
 
@@ -589,8 +589,8 @@
         }
 
         .source-tab-btn.active {
-            color: #14b8a6;
-            border-bottom-color: #14b8a6;
+            color: #F86825;
+            border-bottom-color: #F86825;
             background: rgba(20, 184, 166, 0.05);
         }
 
@@ -620,9 +620,9 @@
         }
 
         .source-modal-tab-btn.active {
-            color: #14b8a6;
+            color: #F86825;
             background: rgba(20, 184, 166, 0.1);
-            border-color: #14b8a6;
+            border-color: #F86825;
         }
 
         /* Guide Tabs */
@@ -632,7 +632,7 @@
         }
 
         .guide-tab:hover {
-            color: #14b8a6;
+            color: #F86825;
         }
 
         .guide-tab.active {
@@ -680,7 +680,7 @@
 
         .tree-item:hover {
             background: rgba(20, 184, 166, 0.1);
-            color: #14b8a6;
+            color: #F86825;
         }
 
         .tree-item.selected {
@@ -718,7 +718,7 @@
             font-size: 0.75rem;
             padding: 0.125rem 0.375rem;
             background: rgba(20, 184, 166, 0.2);
-            color: #14b8a6;
+            color: #F86825;
             border-radius: 0.25rem;
             margin-left: auto;
         }
@@ -743,7 +743,7 @@
 
         .tree-control-btn:hover {
             background: #475569;
-            color: #14b8a6;
+            color: #F86825;
         }
 
         /* Graph Layout Buttons */
@@ -766,8 +766,8 @@
         }
 
         .graph-layout-btn.active {
-            background: #14b8a6;
-            border-color: #14b8a6;
+            background: #F86825;
+            border-color: #F86825;
             color: white;
             font-weight: 600;
         }
@@ -839,8 +839,8 @@
 
         .location-nav-btn:hover {
             background: #475569;
-            border-color: #14b8a6;
-            color: #14b8a6;
+            border-color: #F86825;
+            color: #F86825;
         }
 
         .location-nav-btn.active {
@@ -870,7 +870,7 @@
         }
 
         .location-nav-arrow:hover:not(:disabled) {
-            background: #14b8a6;
+            background: #F86825;
             color: white;
         }
 
@@ -1249,13 +1249,13 @@
         }
 
         .disclaimer-link {
-            color: #14b8a6;
+            color: #F86825;
             text-decoration: underline;
             transition: color 0.2s;
         }
 
         .disclaimer-link:hover {
-            color: #5eead4;
+            color: #FFC6B1;
         }
 
         /* Custom Tooltip */
@@ -2587,7 +2587,7 @@ Part 2: Data quality measures
             // Minimal color palette
             const colors = {
                 primary: '#F86825',    // Orange
-                secondary: '#14b8a6',  // Teal
+                secondary: '#F86825',  // Teal
                 neutral: '#475569',    // Slate
                 accent: '#06b6d4'      // Cyan
             };

--- a/project/ChaosTheory/butterfly-effect-data/ko/index.html
+++ b/project/ChaosTheory/butterfly-effect-data/ko/index.html
@@ -121,7 +121,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -143,7 +143,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/DAL/blog-future-vision/en/index.html
+++ b/project/DAL/blog-future-vision/en/index.html
@@ -986,7 +986,7 @@
         }
 
         function randomColor() {
-            const colors = ['#F86825', '#14B8A6', '#8B5CF6', '#EC4899', '#F59E0B', '#10B981'];
+            const colors = ['#F86825', '#F86825', '#8B5CF6', '#EC4899', '#F59E0B', '#10B981'];
             currentColor = colors[Math.floor(Math.random() * colors.length)];
         }
     </script>

--- a/project/DAL/blog-future-vision/ko/index.html
+++ b/project/DAL/blog-future-vision/ko/index.html
@@ -984,7 +984,7 @@
         }
 
         function randomColor() {
-            const colors = ['#F86825', '#14B8A6', '#8B5CF6', '#EC4899', '#F59E0B', '#10B981'];
+            const colors = ['#F86825', '#F86825', '#8B5CF6', '#EC4899', '#F59E0B', '#10B981'];
             currentColor = colors[Math.floor(Math.random() * colors.length)];
         }
     </script>

--- a/project/DAL/code-painting/en/index.html
+++ b/project/DAL/code-painting/en/index.html
@@ -133,7 +133,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -146,7 +146,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -159,7 +159,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/DAL/code-painting/ko/index.html
+++ b/project/DAL/code-painting/ko/index.html
@@ -133,7 +133,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -146,7 +146,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -159,7 +159,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/DAL/robotic-painting/en/index.html
+++ b/project/DAL/robotic-painting/en/index.html
@@ -121,7 +121,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -132,7 +132,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -143,7 +143,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/DAL/robotic-painting/ko/index.html
+++ b/project/DAL/robotic-painting/ko/index.html
@@ -121,7 +121,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -132,7 +132,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -143,7 +143,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/DataClinic/data-greenhouse-investment.html
+++ b/project/DataClinic/data-greenhouse-investment.html
@@ -106,7 +106,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -118,7 +118,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -130,7 +130,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -314,7 +314,7 @@
         }
 
         .wedge-card.wedge-1::before { background: #F86825; }
-        .wedge-card.wedge-2::before { background: #14b8a6; }
+        .wedge-card.wedge-2::before { background: #F86825; }
         .wedge-card.wedge-3::before { background: #8b5cf6; }
         .wedge-card.wedge-4::before { background: #06b6d4; }
 

--- a/project/DataClinic/data-greenhouse/en/index.html
+++ b/project/DataClinic/data-greenhouse/en/index.html
@@ -72,7 +72,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -84,7 +84,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -96,7 +96,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -177,7 +177,7 @@
             border-radius: 2px 0 0 2px;
         }
 
-        .layer-card.observation::before { background: #14b8a6; }
+        .layer-card.observation::before { background: #F86825; }
         .layer-card.orchestration::before { background: #F86825; }
         .layer-card.action::before { background: #8b5cf6; }
         .layer-card.governance::before { background: #06b6d4; }
@@ -510,7 +510,7 @@
                         </div>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             🎯 <strong>Solution Definition:</strong> Data Greenhouse does <strong>not replace</strong> existing data platforms.
                             Instead, it places Snowflake, Databricks, and Data Lake as the "platform layer" underneath,
@@ -589,7 +589,7 @@
 
                     <div class="grid gap-4 mb-6">
                         <div class="themeable-card rounded-xl p-5 flex items-start gap-4">
-                            <div class="w-10 h-10 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0" style="background: #14b8a6;">1</div>
+                            <div class="w-10 h-10 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0" style="background: #F86825;">1</div>
                             <div>
                                 <h4 class="font-bold themeable-heading mb-1">Observation Layer</h4>
                                 <p class="themeable-text text-sm">Combines embedding-based distribution analysis with ontology-based contextual interpretation to diagnose data quality.</p>
@@ -834,7 +834,7 @@
                             </p>
                         </div>
 
-                        <div class="themeable-card rounded-xl p-5" style="border: 2px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-5" style="border: 2px solid #F86825;">
                             <h4 class="font-semibold themeable-heading mb-2 flex items-center gap-2">
                                 <span class="text-xl">🏛️</span> Sovereign AI
                             </h4>
@@ -947,7 +947,7 @@
                         <h2>Conclusion: Greenhouse Produces Trust</h2>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             The core of Data Greenhouse is not "more data" but <strong class="accent-text">"better data"</strong> —
                             more precisely, <strong>"an operations framework that continuously produces AI-Ready Data immediately usable for AI."</strong>

--- a/project/DataClinic/data-greenhouse/ko/index.html
+++ b/project/DataClinic/data-greenhouse/ko/index.html
@@ -71,7 +71,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -83,7 +83,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -95,7 +95,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -176,7 +176,7 @@
             border-radius: 2px 0 0 2px;
         }
 
-        .layer-card.observation::before { background: #14b8a6; }
+        .layer-card.observation::before { background: #F86825; }
         .layer-card.orchestration::before { background: #F86825; }
         .layer-card.action::before { background: #8b5cf6; }
         .layer-card.governance::before { background: #06b6d4; }
@@ -509,7 +509,7 @@
                         </div>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             🎯 <strong>해결 정의:</strong> Data Greenhouse는 기존 데이터 플랫폼을 <strong>대체하지 않습니다</strong>.
                             오히려 Snowflake, Databricks, Data Lake를 "플랫폼 계층"으로 하부에 두고,
@@ -588,7 +588,7 @@
 
                     <div class="grid gap-4 mb-6">
                         <div class="themeable-card rounded-xl p-5 flex items-start gap-4">
-                            <div class="w-10 h-10 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0" style="background: #14b8a6;">1</div>
+                            <div class="w-10 h-10 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0" style="background: #F86825;">1</div>
                             <div>
                                 <h4 class="font-bold themeable-heading mb-1">Observation Layer</h4>
                                 <p class="themeable-text text-sm">임베딩 기반의 분포 분석과 온톨로지 기반의 맥락 해석을 결합하여 데이터 품질을 진단합니다.</p>
@@ -833,7 +833,7 @@
                             </p>
                         </div>
 
-                        <div class="themeable-card rounded-xl p-5" style="border: 2px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-5" style="border: 2px solid #F86825;">
                             <h4 class="font-semibold themeable-heading mb-2 flex items-center gap-2">
                                 <span class="text-xl">🏛️</span> 소버린 AI (Sovereign AI)
                             </h4>
@@ -946,7 +946,7 @@
                         <h2>맺음말: Greenhouse는 신뢰를 생산한다</h2>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             Data Greenhouse의 핵심은 "더 많은 데이터"가 아니라 <strong class="accent-text">"더 좋은 데이터"</strong>이며,
                             더 정확히는 <strong>"AI에 즉시 사용 가능한 AI-Ready Data를 지속적으로 생산하는 운영 체계"</strong>입니다.

--- a/project/DataClinic/data-quality-guide-book-01/en/index.html
+++ b/project/DataClinic/data-quality-guide-book-01/en/index.html
@@ -191,7 +191,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -202,7 +202,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -213,7 +213,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/DataClinic/data-quality-guide-book-01/ko/index.html
+++ b/project/DataClinic/data-quality-guide-book-01/ko/index.html
@@ -191,7 +191,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -202,7 +202,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -213,7 +213,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/DataClinic/data-quality/en/index.html
+++ b/project/DataClinic/data-quality/en/index.html
@@ -130,7 +130,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -142,7 +142,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -154,7 +154,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -1163,7 +1163,7 @@
                 <!-- DataClinic Blog Section -->
                 <section id="dataclinic-blog" class="mb-12">
                     <div class="section-header">
-                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #0d9488, #0f766e);">
+                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #C64900, #0f766e);">
                             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path>
                             </svg>

--- a/project/DataClinic/pbls-patent-portfolio-2025/en/index.html
+++ b/project/DataClinic/pbls-patent-portfolio-2025/en/index.html
@@ -259,7 +259,7 @@
         .stat-number {
             font-size: 2.5rem;
             font-weight: 800;
-            background: linear-gradient(135deg, #F86825, #14b8a6);
+            background: linear-gradient(135deg, #F86825, #F86825);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/project/DataClinic/pbls-patent-portfolio-2025/ko/index.html
+++ b/project/DataClinic/pbls-patent-portfolio-2025/ko/index.html
@@ -257,7 +257,7 @@
         .stat-number {
             font-size: 2.5rem;
             font-weight: 800;
-            background: linear-gradient(135deg, #F86825, #14b8a6);
+            background: linear-gradient(135deg, #F86825, #F86825);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/project/DataGreenhouse/data-greenhouse-strategy/en/index.html
+++ b/project/DataGreenhouse/data-greenhouse-strategy/en/index.html
@@ -1522,7 +1522,7 @@
             PebblousChart.bar('marketTrendChart', {
                 labels: ['Physical AI', 'Sovereign AI', 'Data Mgmt SW', 'AI Model Competition'],
                 data: [85, 75, 92, 60],
-                colors: ['#0d9488', '#0d9488', '#F86825', '#94a3b8'],  // teal: target market, orange: core area, gray: competition
+                colors: ['#C64900', '#C64900', '#F86825', '#94a3b8'],  // teal: target market, orange: core area, gray: competition
                 horizontal: true
             });
         }

--- a/project/DataGreenhouse/data-greenhouse-strategy/ko/index.html
+++ b/project/DataGreenhouse/data-greenhouse-strategy/ko/index.html
@@ -1522,7 +1522,7 @@
             PebblousChart.bar('marketTrendChart', {
                 labels: ['피지컬 AI', '소버린 AI', '데이터 관리 SW', 'AI 모델 경쟁'],
                 data: [85, 75, 92, 60],
-                colors: ['#0d9488', '#0d9488', '#F86825', '#94a3b8'],  // teal: 타겟시장, orange: 핵심영역, gray: 경쟁
+                colors: ['#C64900', '#C64900', '#F86825', '#94a3b8'],  // teal: 타겟시장, orange: 핵심영역, gray: 경쟁
                 horizontal: true
             });
         }

--- a/project/IR/investment-review-2026/ko/index.html
+++ b/project/IR/investment-review-2026/ko/index.html
@@ -105,7 +105,7 @@
             background: #F86825;
         }
         .timeline-item.active::before {
-            background: #14B8A6;
+            background: #F86825;
             box-shadow: 0 0 0 4px rgba(20,184,166,0.2);
         }
         .product-card {
@@ -1128,7 +1128,7 @@
                     labels: ['2024A', '2025A', '2026E', '2027E', '2028E', '2029E', '2030E'],
                     datasets: [
                         { label: 'Base', data: [292, 630, 1100, 2400, 4500, 7000, 10800], color: '#64748B' },
-                        { label: 'Accelerated', data: [292, 630, 1650, 4910, 9500, 16000, 23700], color: '#14B8A6' },
+                        { label: 'Accelerated', data: [292, 630, 1650, 4910, 9500, 16000, 23700], color: '#F86825' },
                         { label: 'Max C-1 (글로벌)', data: [292, 630, 1650, 4910, 20200, 44800, 100000], color: '#F86825' },
                         { label: 'Max C-2 (보수적)', data: [292, 630, 1650, 4910, 14200, 25800, 43000], color: '#3B82F6' }
                     ],

--- a/project/IR/pbls-ir-2026-03/en/index.html
+++ b/project/IR/pbls-ir-2026-03/en/index.html
@@ -82,7 +82,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -94,7 +94,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -106,7 +106,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/IR/pbls-ir-2026-03/ko/index.html
+++ b/project/IR/pbls-ir-2026-03/ko/index.html
@@ -81,7 +81,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -93,7 +93,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -105,7 +105,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/IR/pbls-ir-physical-ai/en/index.html
+++ b/project/IR/pbls-ir-physical-ai/en/index.html
@@ -90,7 +90,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -102,7 +102,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -114,7 +114,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -713,7 +713,7 @@
                                 </div>
                             </div>
                             <div class="flex items-center gap-4 p-4 rounded-lg border themeable-border">
-                                <div class="w-2 h-12 rounded" style="background-color: #14B8A6;"></div>
+                                <div class="w-2 h-12 rounded" style="background-color: #F86825;"></div>
                                 <div class="flex-1">
                                     <div class="flex justify-between items-center mb-1">
                                         <strong class="themeable-heading">GTM Execution</strong>
@@ -846,7 +846,7 @@
                         labels: ['On-Prem Product', 'GTM Execution', 'Operations'],
                         datasets: [{
                             data: [40, 40, 20],
-                            backgroundColor: ['#F86825', '#14B8A6', '#A855F7'],
+                            backgroundColor: ['#F86825', '#F86825', '#A855F7'],
                             borderWidth: 3,
                             borderColor: '#ffffff',
                             hoverOffset: 15

--- a/project/IR/pbls-ir-physical-ai/ko/index.html
+++ b/project/IR/pbls-ir-physical-ai/ko/index.html
@@ -88,7 +88,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -100,7 +100,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -112,7 +112,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -1165,7 +1165,7 @@
                                 </div>
                             </div>
                             <div class="flex items-center gap-4 p-4 rounded-lg border themeable-border">
-                                <div class="w-2 h-12 rounded" style="background-color: #14B8A6;"></div>
+                                <div class="w-2 h-12 rounded" style="background-color: #F86825;"></div>
                                 <div class="flex-1">
                                     <div class="flex justify-between items-center mb-1">
                                         <strong class="themeable-heading">GTM 실행</strong>
@@ -1306,7 +1306,7 @@
                         labels: ['On-Prem 제품화', 'GTM 실행', '운영 안정화'],
                         datasets: [{
                             data: [40, 40, 20],
-                            backgroundColor: ['#F86825', '#14B8A6', '#A855F7'],
+                            backgroundColor: ['#F86825', '#F86825', '#A855F7'],
                             borderWidth: 3,
                             borderColor: '#ffffff',
                             hoverOffset: 15

--- a/project/IR/pitchbook-ai-outlook-analysis/en/index.html
+++ b/project/IR/pitchbook-ai-outlook-analysis/en/index.html
@@ -69,7 +69,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -81,7 +81,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -93,7 +93,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/IR/pitchbook-ai-outlook-analysis/ko/index.html
+++ b/project/IR/pitchbook-ai-outlook-analysis/ko/index.html
@@ -67,7 +67,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -79,7 +79,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -91,7 +91,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/IR/press-room/en/index.html
+++ b/project/IR/press-room/en/index.html
@@ -61,7 +61,7 @@
         .unlocked-icon {
             width: 20px;
             height: 20px;
-            color: #14b8a6;
+            color: #F86825;
             flex-shrink: 0;
         }
     </style>

--- a/project/IR/press-room/ko/index.html
+++ b/project/IR/press-room/ko/index.html
@@ -61,7 +61,7 @@
         .unlocked-icon {
             width: 20px;
             height: 20px;
-            color: #14b8a6;
+            color: #F86825;
             flex-shrink: 0;
         }
     </style>

--- a/project/IR/shareholder-letter-2026-03/en/index.html
+++ b/project/IR/shareholder-letter-2026-03/en/index.html
@@ -181,7 +181,7 @@
         }
 
         .strategy-card.teal {
-            border-left-color: var(--teal-color, #14b8a6);
+            border-left-color: var(--teal-color, #F86825);
         }
 
         .strategy-card.slate {
@@ -358,7 +358,7 @@
                             <div class="metric-sub">$435K (KRW 630M) achieved</div>
                         </div>
                         <div class="metric-card">
-                            <div class="metric-value" style="color: #14b8a6;">-81.5%</div>
+                            <div class="metric-value" style="color: #F86825;">-81.5%</div>
                             <div class="metric-label">Net Loss Reduction</div>
                             <div class="metric-sub">BEP milestone reached</div>
                         </div>
@@ -371,7 +371,7 @@
 
                     <p><strong style="color: #F86825;">Revenue Growth</strong> — Achieved $435K (KRW 630M) in revenue, a 115.7% increase year-over-year.</p>
 
-                    <p><strong style="color: #14b8a6;">Profitability</strong> — Reduced net losses by 81.5%, establishing a bridgehead toward break-even point (BEP).</p>
+                    <p><strong style="color: #F86825;">Profitability</strong> — Reduced net losses by 81.5%, establishing a bridgehead toward break-even point (BEP).</p>
 
                     <p><strong>Financial Health</strong> — Streamlined SG&A expenses by 52.2% while securing $372K (KRW 539M) in cash at year-end.</p>
 
@@ -402,7 +402,7 @@
                     </div>
 
                     <div class="strategy-card teal">
-                        <p><span class="strategy-number" style="background: #14b8a6;">2</span><strong>Penetrating industrial markets.</strong> We will accelerate collaboration with Hyundai Motor's ZER01NE (SI) to solidify our position in the mobility AI market. Moving beyond simple processing, we will commercialize data quality management automation solutions to transition to a high-value revenue structure.</p>
+                        <p><span class="strategy-number" style="background: #F86825;">2</span><strong>Penetrating industrial markets.</strong> We will accelerate collaboration with Hyundai Motor's ZER01NE (SI) to solidify our position in the mobility AI market. Moving beyond simple processing, we will commercialize data quality management automation solutions to transition to a high-value revenue structure.</p>
                     </div>
 
                     <div class="strategy-card slate">

--- a/project/IR/shareholder-letter-2026-03/ko/index.html
+++ b/project/IR/shareholder-letter-2026-03/ko/index.html
@@ -181,7 +181,7 @@
         }
 
         .strategy-card.teal {
-            border-left-color: var(--teal-color, #14b8a6);
+            border-left-color: var(--teal-color, #F86825);
         }
 
         .strategy-card.slate {
@@ -358,7 +358,7 @@
                             <div class="metric-sub">6.3억 원 달성</div>
                         </div>
                         <div class="metric-card">
-                            <div class="metric-value" style="color: #14b8a6;">-81.5%</div>
+                            <div class="metric-value" style="color: #F86825;">-81.5%</div>
                             <div class="metric-label">당기순손실 감소</div>
                             <div class="metric-sub">BEP 교두보 마련</div>
                         </div>
@@ -371,7 +371,7 @@
 
                     <p><strong style="color: #F86825;">매출 성장</strong> — 전년 대비 115.7% 성장한 6.3억 원의 매출을 달성하였습니다.</p>
 
-                    <p><strong style="color: #14b8a6;">수익성 개선</strong> — 당기순손실을 81.5% 급감시키며 손익분기점(BEP)을 향한 교두보를 마련했습니다.</p>
+                    <p><strong style="color: #F86825;">수익성 개선</strong> — 당기순손실을 81.5% 급감시키며 손익분기점(BEP)을 향한 교두보를 마련했습니다.</p>
 
                     <p><strong>재무 건전성</strong> — 판관비를 52.2% 효율화함과 동시에 기말 기준 5.39억 원의 현금을 확보했습니다.</p>
 
@@ -402,7 +402,7 @@
                     </div>
 
                     <div class="strategy-card teal">
-                        <p><span class="strategy-number" style="background: #14b8a6;">2</span><strong>산업 현장으로의 침투.</strong> 현대차 제로원(SI)과의 협업을 본격화하여 모빌리티 AI 시장 내 입지를 굳히겠습니다. 단순 가공을 넘어 데이터 품질 관리 자동화 솔루션을 상용화하여 고부가가치 수익 구조로 전환하겠습니다.</p>
+                        <p><span class="strategy-number" style="background: #F86825;">2</span><strong>산업 현장으로의 침투.</strong> 현대차 제로원(SI)과의 협업을 본격화하여 모빌리티 AI 시장 내 입지를 굳히겠습니다. 단순 가공을 넘어 데이터 품질 관리 자동화 솔루션을 상용화하여 고부가가치 수익 구조로 전환하겠습니다.</p>
                     </div>
 
                     <div class="strategy-card slate">

--- a/project/ISO25024/iso-25024-test-01.html
+++ b/project/ISO25024/iso-25024-test-01.html
@@ -105,7 +105,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 

--- a/project/ISO5259/5259-image-guide-01/en/index.html
+++ b/project/ISO5259/5259-image-guide-01/en/index.html
@@ -857,7 +857,7 @@
                     </table>
                 </div>
 
-                <div class="themeable-card p-6 rounded-xl border-l-4 shadow-lg mb-8" style="border-left-color: #14b8a6;">
+                <div class="themeable-card p-6 rounded-xl border-l-4 shadow-lg mb-8" style="border-left-color: #F86825;">
                     <p class="themeable-text leading-relaxed" style="line-height: 2.1;">
                         Items not yet supported by DataClinic do not represent gaps in data quality — they simply fall outside the current scope of automation. These items can be addressed through specialized tools (BRISQUE, IoU validators, C2PA toolkit, etc.) or through structured manual review processes.
                     </p>

--- a/project/ISO5259/5259-image-guide-01/ko/index.html
+++ b/project/ISO5259/5259-image-guide-01/ko/index.html
@@ -857,7 +857,7 @@
                     </table>
                 </div>
 
-                <div class="themeable-card p-6 rounded-xl border-l-4 shadow-lg mb-8" style="border-left-color: #14b8a6;">
+                <div class="themeable-card p-6 rounded-xl border-l-4 shadow-lg mb-8" style="border-left-color: #F86825;">
                     <p class="themeable-text leading-relaxed" style="line-height: 2.1;">
                         DataClinic이 지원하지 않는 항목은 데이터 품질의 영역이 없는 게 아니라, 아직 자동화 범위 밖이라는 의미다. 이런 항목들은 전문 도구(BRISQUE, IoU 검증기, C2PA 툴킷 등)나 수동 검토 프로세스로 보완할 수 있다.
                     </p>

--- a/project/ISO5259/5259-image-guide-02/en/index.html
+++ b/project/ISO5259/5259-image-guide-02/en/index.html
@@ -146,7 +146,7 @@
 
         /* Insight box */
         .insight-box {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             background: linear-gradient(135deg, #f0fdfa 0%, #ecfdf5 100%);
             padding: 1.25rem 1.5rem;
             border-radius: 0 0.75rem 0.75rem 0;

--- a/project/ISO5259/5259-image-guide-02/ko/index.html
+++ b/project/ISO5259/5259-image-guide-02/ko/index.html
@@ -146,7 +146,7 @@
 
         /* Insight box */
         .insight-box {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             background: linear-gradient(135deg, #f0fdfa 0%, #ecfdf5 100%);
             padding: 1.25rem 1.5rem;
             border-radius: 0 0.75rem 0.75rem 0;

--- a/project/ISO5259/5259-pbls-dataclinic-01/en/index.html
+++ b/project/ISO5259/5259-pbls-dataclinic-01/en/index.html
@@ -107,7 +107,7 @@
 
         .mapping-table td:first-child {
             font-weight: 600;
-            color: #14b8a6;
+            color: #F86825;
         }
 
         .sticky-toc {

--- a/project/ISO5259/5259-pbls-dataclinic-01/ko/index.html
+++ b/project/ISO5259/5259-pbls-dataclinic-01/ko/index.html
@@ -106,7 +106,7 @@
 
         .mapping-table td:first-child {
             font-weight: 600;
-            color: #14b8a6;
+            color: #F86825;
         }
 
         .sticky-toc {

--- a/project/ISO5259/imagenet-iso5259-eval/en/index.html
+++ b/project/ISO5259/imagenet-iso5259-eval/en/index.html
@@ -146,7 +146,7 @@
             background: linear-gradient(135deg, rgba(249,115,22,0.12) 0%, rgba(234,179,8,0.08) 100%);
         }
         .highlight-box {
-            border: 2px solid #14b8a6;
+            border: 2px solid #F86825;
             background: linear-gradient(135deg, #f0fdfa 0%, #ecfdf5 100%);
             padding: 1.5rem;
             border-radius: 0.75rem;

--- a/project/ISO5259/imagenet-iso5259-eval/ko/index.html
+++ b/project/ISO5259/imagenet-iso5259-eval/ko/index.html
@@ -146,7 +146,7 @@
             background: linear-gradient(135deg, rgba(249,115,22,0.12) 0%, rgba(234,179,8,0.08) 100%);
         }
         .highlight-box {
-            border: 2px solid #14b8a6;
+            border: 2px solid #F86825;
             background: linear-gradient(135deg, #f0fdfa 0%, #ecfdf5 100%);
             padding: 1.5rem;
             border-radius: 0.75rem;

--- a/project/ISO5259/iso5259-standardization-roadmap/en/index.html
+++ b/project/ISO5259/iso5259-standardization-roadmap/en/index.html
@@ -153,7 +153,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -165,7 +165,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -177,7 +177,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/NeuroSymbolicAI/henry-kautz-ai-history/en/index.html
+++ b/project/NeuroSymbolicAI/henry-kautz-ai-history/en/index.html
@@ -135,7 +135,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -157,7 +157,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/en/index.html
+++ b/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/en/index.html
@@ -133,7 +133,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -145,7 +145,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -157,7 +157,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -320,7 +320,7 @@
         }
 
         .dialectic-card.thesis { border-top: 4px solid #F86825; }
-        .dialectic-card.antithesis { border-top: 4px solid #0d9488; }
+        .dialectic-card.antithesis { border-top: 4px solid #C64900; }
         .dialectic-card.synthesis { border-top: 4px solid #8b5cf6; }
 
         .dialectic-card .card-icon {

--- a/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/ko/index.html
+++ b/project/NeuroSymbolicAI/neuro-symbolic-ai-architecture/ko/index.html
@@ -132,7 +132,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -144,7 +144,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -156,7 +156,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -319,7 +319,7 @@
         }
 
         .dialectic-card.thesis { border-top: 4px solid #F86825; }
-        .dialectic-card.antithesis { border-top: 4px solid #0d9488; }
+        .dialectic-card.antithesis { border-top: 4px solid #C64900; }
         .dialectic-card.synthesis { border-top: 4px solid #8b5cf6; }
 
         .dialectic-card .card-icon {

--- a/project/PhysicalAI/data-greenhouse-vision/en/index.html
+++ b/project/PhysicalAI/data-greenhouse-vision/en/index.html
@@ -132,7 +132,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -144,7 +144,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -156,7 +156,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/data-greenhouse-vision/ko/index.html
+++ b/project/PhysicalAI/data-greenhouse-vision/ko/index.html
@@ -132,7 +132,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -144,7 +144,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -156,7 +156,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/data-pipeline-for-physical-ai-01/en/index.html
+++ b/project/PhysicalAI/data-pipeline-for-physical-ai-01/en/index.html
@@ -164,7 +164,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -176,7 +176,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -188,7 +188,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/data-pipeline-for-physical-ai-01/ko/index.html
+++ b/project/PhysicalAI/data-pipeline-for-physical-ai-01/ko/index.html
@@ -164,7 +164,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -176,7 +176,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -188,7 +188,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/digital-twin-physical-ai-market/en/index.html
+++ b/project/PhysicalAI/digital-twin-physical-ai-market/en/index.html
@@ -128,7 +128,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -139,7 +139,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -150,7 +150,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/PhysicalAI/digital-twin-physical-ai-market/ko/index.html
+++ b/project/PhysicalAI/digital-twin-physical-ai-market/ko/index.html
@@ -128,7 +128,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -139,7 +139,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -150,7 +150,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/PhysicalAI/physical-ai-competition-strategy/en/index.html
+++ b/project/PhysicalAI/physical-ai-competition-strategy/en/index.html
@@ -108,7 +108,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -120,7 +120,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -132,7 +132,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/physical-ai-competition-strategy/ko/index.html
+++ b/project/PhysicalAI/physical-ai-competition-strategy/ko/index.html
@@ -108,7 +108,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -120,7 +120,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -132,7 +132,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 

--- a/project/PhysicalAI/physical-ai-data-infra-strategy/en/index.html
+++ b/project/PhysicalAI/physical-ai-data-infra-strategy/en/index.html
@@ -148,7 +148,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -159,7 +159,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -170,7 +170,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/PhysicalAI/physical-ai-data-infra-strategy/ko/index.html
+++ b/project/PhysicalAI/physical-ai-data-infra-strategy/ko/index.html
@@ -148,7 +148,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="light"] {
@@ -159,7 +159,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="beige"] {
@@ -170,7 +170,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body {

--- a/project/PhysicalAI/physical-ai/en/index.html
+++ b/project/PhysicalAI/physical-ai/en/index.html
@@ -125,7 +125,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -137,7 +137,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -149,7 +149,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -894,7 +894,7 @@
                         </div>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             🛡️ <strong>The Role of Pebblous DataClinic:</strong> We systematically generate and validate rare <strong class="accent-text">Edge Case</strong> data
                             to ensure our clients' AI models <strong class="teal-text">operate safely</strong> in the field.

--- a/project/PhysicalAI/physical-ai/ko/index.html
+++ b/project/PhysicalAI/physical-ai/ko/index.html
@@ -125,7 +125,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -137,7 +137,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -149,7 +149,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -893,7 +893,7 @@
                         </div>
                     </div>
 
-                    <div class="highlight-box" style="border-left-color: #14b8a6;">
+                    <div class="highlight-box" style="border-left-color: #F86825;">
                         <p>
                             🛡️ <strong>페블러스 DataClinic의 역할:</strong> 희소한 <strong class="accent-text">에지 케이스(Edge Case)</strong> 데이터를
                             체계적으로 생성하고 검증하여, 고객사의 AI 모델이 현장에서 <strong class="teal-text">안전하게 작동</strong>하도록 보장합니다.

--- a/project/SyntheticData/synthetic-data-companies-rise-fall/en/index.html
+++ b/project/SyntheticData/synthetic-data-companies-rise-fall/en/index.html
@@ -121,8 +121,8 @@
                     <h3 class="text-lg font-bold themeable-heading mt-2">2030 Market Forecast</h3>
                     <p class="text-sm themeable-muted leading-relaxed mt-2">CAGR 31-46% growth from $500M-$900M in 2025</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 text-center" style="border-top: 4px solid #14b8a6;">
-                    <p class="text-2xl font-bold" style="color: #14b8a6;">$3.2B+</p>
+                <div class="themeable-card rounded-xl p-6 text-center" style="border-top: 4px solid #F86825;">
+                    <p class="text-2xl font-bold" style="color: #F86825;">$3.2B+</p>
                     <h3 class="text-lg font-bold themeable-heading mt-2">Largest M&A Deal</h3>
                     <p class="text-sm themeable-muted leading-relaxed mt-2">NVIDIA's Gretel acquisition (2025.03)</p>
                 </div>
@@ -193,7 +193,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">Lesson for Pebblous</p>
+                    <p class="font-bold" style="color: #F86825;">Lesson for Pebblous</p>
                     <p class="themeable-text leading-relaxed mt-2">Even with money in the bank, survival is impossible without a "platform foundation" to pivot on. Pebblous's Data Greenhouse (data OS) goes beyond synthetic data generation, aiming for an operational framework of "diagnose-judge-act-prove" — a structural defense line that Datagen lacked.</p>
                 </div>
             </div>
@@ -221,7 +221,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">Lesson for Pebblous</p>
+                    <p class="font-bold" style="color: #F86825;">Lesson for Pebblous</p>
                     <p class="themeable-text leading-relaxed mt-2">While the technology was excellent, it was absorbed as a "component" of a larger SI/IT services company. Pebblous's multi-domain strategy (automotive, defense, shipbuilding) and "diagnosis-to-generation auto-linking" structurally avoids this "componentization" risk.</p>
                 </div>
             </div>
@@ -250,7 +250,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">Lesson for Pebblous</p>
+                    <p class="font-bold" style="color: #F86825;">Lesson for Pebblous</p>
                     <p class="themeable-text leading-relaxed mt-2">Defense contracts are a powerful starting point, but without balancing commercial revenue, you risk becoming a talent acquisition target. Pebblous's strategy of securing multiple enterprise customers (Hyundai, Hanwha, Samsung, LG) and maintaining government project share below 50% reflects this lesson.</p>
                 </div>
             </div>
@@ -282,7 +282,7 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Founded</td><td class="p-3">2019, San Diego (USA)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Total Funding</td><td class="p-3">$67M+</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Business Area</td><td class="p-3">Privacy-preserving synthetic data (tabular, time series, text)</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Final Status</td><td class="p-3"><strong style="color: #14b8a6;">Acquired by NVIDIA in March 2025 (&gt;$320M)</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Final Status</td><td class="p-3"><strong style="color: #F86825;">Acquired by NVIDIA in March 2025 (&gt;$320M)</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -310,7 +310,7 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Founded</td><td class="p-3">2017, London (UK)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Total Funding</td><td class="p-3">$11.3M</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Business Area</td><td class="p-3">Tabular synthetic data for regulated industries (finance, healthcare)</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Final Status</td><td class="p-3"><strong style="color: #14b8a6;">IP acquired by SAS in November 2024</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Final Status</td><td class="p-3"><strong style="color: #F86825;">IP acquired by SAS in November 2024</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -370,14 +370,14 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Founded</td><td class="p-3">2017, Vienna (Austria)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Total Funding</td><td class="p-3">$31M (including $25M Series B)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Key Customers</td><td class="p-3">Citi Bank, US DHS, Erste Group, Telefonica</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Current Status</td><td class="p-3"><strong style="color: #14b8a6;">Operating independently, open-source pivot</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Current Status</td><td class="p-3"><strong style="color: #F86825;">Operating independently, open-source pivot</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
 
                 <h4 class="text-lg font-bold themeable-heading mb-4">Three-Tier Revenue Model</h4>
                 <div class="grid md:grid-cols-3 gap-4 mb-6">
-                    <div class="themeable-card rounded-lg p-4" style="border-top: 3px solid #14b8a6;">
+                    <div class="themeable-card rounded-lg p-4" style="border-top: 3px solid #F86825;">
                         <p class="font-bold themeable-heading text-sm mb-2">Open Source SDK (Free)</p>
                         <p class="text-sm themeable-muted leading-relaxed">Apache v2, fully local execution</p>
                     </div>
@@ -392,7 +392,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">Implication for Pebblous</p>
+                    <p class="font-bold" style="color: #F86825;">Implication for Pebblous</p>
                     <p class="themeable-text leading-relaxed mt-2">MOSTLY AI's open-source pivot signals that "tabular data synthesis" is being commoditized. Pebblous's differentiator — "physics simulation-based unstructured synthetic data + neuro-symbolic quality evaluation" — operates in a high-value domain free from such commoditization.</p>
                 </div>
             </div>
@@ -406,7 +406,7 @@
                 </p>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">Implication for Pebblous</p>
+                    <p class="font-bold" style="color: #F86825;">Implication for Pebblous</p>
                     <p class="themeable-text leading-relaxed mt-2">The "NVIDIA ecosystem partner" position mirrors PebbloSim's architecture of running on Omniverse. Pebblous should consider mid-term positioning within the NVIDIA Omniverse/Cosmos ecosystem.</p>
                 </div>
             </div>
@@ -460,10 +460,10 @@
                         <th class="text-left p-3 themeable-heading">Tonic.ai</th>
                     </tr></thead>
                     <tbody class="themeable-muted">
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Platformization (multi-module)</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3">Partial</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Deep workflow embedding</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Ecosystem partnerships</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3">AWS Marketplace</td><td class="p-3" style="color: #14b8a6;">&#10003; NVIDIA</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">High switching cost creation</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Platformization (multi-module)</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3">Partial</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Deep workflow embedding</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Ecosystem partnerships</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3">AWS Marketplace</td><td class="p-3" style="color: #F86825;">&#10003; NVIDIA</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">High switching cost creation</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -483,7 +483,7 @@
                     <h4 class="text-lg font-bold themeable-heading mb-3">Workflow Embedding</h4>
                     <p class="themeable-muted text-sm leading-relaxed">Data Greenhouse integrates at the OS level into customer data operations — not one-time data delivery.</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                     <h4 class="text-lg font-bold themeable-heading mb-3">Diagnosis-to-Generation Auto-Linking</h4>
                     <p class="themeable-muted text-sm leading-relaxed">Data Clinic's diagnosis results automatically convert to PebbloSim's generation parameters (Vector-to-Param) — the only such integration globally.</p>
                 </div>
@@ -566,21 +566,21 @@
         <section id="references" class="mb-16 fade-in-card">
             <h2 class="text-3xl font-bold themeable-heading mb-8">References</h2>
             <ol class="space-y-3 text-sm themeable-muted">
-                <li><span class="font-semibold" style="color: #14b8a6;">[1]</span> Datagen Shutdown Analysis — TechCrunch, CTech (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[2]</span> Synthesis AI — Globant Acquisition Announcement (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[3]</span> AI.Reverie — Meta Acquisition Analysis, The Information (2021)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[4]</span> Gretel — NVIDIA Acquisition, GTC 2025 Announcement (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[5]</span> Hazy — SAS IP Acquisition, IDC Analysis (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[6]</span> MOSTLY AI — Open Source Pivot, Apache v2 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[7]</span> Parallel Domain — NVIDIA Cosmos Partnership (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[8]</span> Tonic.ai — Enterprise Synthetic Data Market Analysis (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[9]</span> Applied Intuition — $15B Valuation, Forbes (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[10]</span> Grand View Research, "Synthetic Data Market Size Report" (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[11]</span> MarketsandMarkets, "Synthetic Data Generation Market" (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[12]</span> CB Insights, "Top 100 AI Startups" (2019, 2021)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[13]</span> IDC, "GenAI in Enterprise Data Generation" (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[14]</span> Scale AI — $29B Valuation, Accel Partners (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[15]</span> Palantir Technologies — 2025 Annual Report (NYSE: PLTR)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[1]</span> Datagen Shutdown Analysis — TechCrunch, CTech (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[2]</span> Synthesis AI — Globant Acquisition Announcement (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[3]</span> AI.Reverie — Meta Acquisition Analysis, The Information (2021)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[4]</span> Gretel — NVIDIA Acquisition, GTC 2025 Announcement (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[5]</span> Hazy — SAS IP Acquisition, IDC Analysis (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[6]</span> MOSTLY AI — Open Source Pivot, Apache v2 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[7]</span> Parallel Domain — NVIDIA Cosmos Partnership (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[8]</span> Tonic.ai — Enterprise Synthetic Data Market Analysis (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[9]</span> Applied Intuition — $15B Valuation, Forbes (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[10]</span> Grand View Research, "Synthetic Data Market Size Report" (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[11]</span> MarketsandMarkets, "Synthetic Data Generation Market" (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[12]</span> CB Insights, "Top 100 AI Startups" (2019, 2021)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[13]</span> IDC, "GenAI in Enterprise Data Generation" (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[14]</span> Scale AI — $29B Valuation, Accel Partners (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[15]</span> Palantir Technologies — 2025 Annual Report (NYSE: PLTR)</li>
             </ol>
         </section>
 

--- a/project/SyntheticData/synthetic-data-companies-rise-fall/ko/index.html
+++ b/project/SyntheticData/synthetic-data-companies-rise-fall/ko/index.html
@@ -120,8 +120,8 @@
                     <h3 class="text-lg font-bold themeable-heading mt-2">2030년 시장 전망</h3>
                     <p class="text-sm themeable-muted leading-relaxed mt-2">2025년 $5~9억에서 CAGR 31~46% 급성장</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6 text-center" style="border-top: 4px solid #14b8a6;">
-                    <p class="text-2xl font-bold" style="color: #14b8a6;">$3.2B+</p>
+                <div class="themeable-card rounded-xl p-6 text-center" style="border-top: 4px solid #F86825;">
+                    <p class="text-2xl font-bold" style="color: #F86825;">$3.2B+</p>
                     <h3 class="text-lg font-bold themeable-heading mt-2">최대 M&A 규모</h3>
                     <p class="text-sm themeable-muted leading-relaxed mt-2">NVIDIA의 Gretel 인수 (2025.03)</p>
                 </div>
@@ -198,7 +198,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">페블러스 교훈</p>
+                    <p class="font-bold" style="color: #F86825;">페블러스 교훈</p>
                     <p class="themeable-text leading-relaxed mt-2">돈이 있어도 피봇할 "플랫폼적 기반"이 없으면 생존이 불가능합니다. 페블러스의 Data Greenhouse(데이터 OS)는 합성데이터 생성이라는 단일 기능을 넘어 "진단-판단-행동-증명"의 운영 체계를 지향하며, 이는 Datagen이 갖추지 못한 구조적 방어선입니다.</p>
                 </div>
             </div>
@@ -226,7 +226,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">페블러스 교훈</p>
+                    <p class="font-bold" style="color: #F86825;">페블러스 교훈</p>
                     <p class="themeable-text leading-relaxed mt-2">기술 자체는 우수했지만 더 큰 SI/IT 서비스 기업의 "부품"으로 흡수되었습니다. 페블러스의 멀티도메인(자동차·국방·조선) 전략과 "진단→생성 자동 연동"이라는 통합 가치는 이런 "부품화" 위험을 구조적으로 회피하는 설계입니다.</p>
                 </div>
             </div>
@@ -255,7 +255,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">페블러스 교훈</p>
+                    <p class="font-bold" style="color: #F86825;">페블러스 교훈</p>
                     <p class="themeable-text leading-relaxed mt-2">국방 계약은 시작점으로 강력하지만, 상용 매출과 균형을 맞추지 않으면 대기업의 인재 흡수 대상이 될 수 있습니다. 페블러스의 복수 대기업 고객(현대·한화·삼성·LG) 확보와 정부과제 비중 50% 이하 관리 전략은 이 교훈을 반영한 것입니다.</p>
                 </div>
             </div>
@@ -290,7 +290,7 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">설립</td><td class="p-3">2019년, 샌디에이고 (미국)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">총 유치액</td><td class="p-3">$6,700만+</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">사업 영역</td><td class="p-3">프라이버시 보존 합성데이터 (정형·시계열·텍스트)</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">최종 상태</td><td class="p-3"><strong style="color: #14b8a6;">2025년 3월 NVIDIA에 인수 (&gt;$3.2억)</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">최종 상태</td><td class="p-3"><strong style="color: #F86825;">2025년 3월 NVIDIA에 인수 (&gt;$3.2억)</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -318,7 +318,7 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">설립</td><td class="p-3">2017년, 런던 (영국)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">총 유치액</td><td class="p-3">$1,130만</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">사업 영역</td><td class="p-3">금융·헬스케어 규제 산업용 정형 합성데이터</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">최종 상태</td><td class="p-3"><strong style="color: #14b8a6;">2024년 11월 SAS에 IP 인수</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">최종 상태</td><td class="p-3"><strong style="color: #F86825;">2024년 11월 SAS에 IP 인수</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -381,14 +381,14 @@
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">설립</td><td class="p-3">2017년, 빈 (오스트리아)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">총 유치액</td><td class="p-3">$3,100만 (시리즈 B $2,500만 포함)</td></tr>
                             <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">주요 고객</td><td class="p-3">Citi Bank, 미 국토안보부, Erste Group, Telefonica</td></tr>
-                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">현재 상태</td><td class="p-3"><strong style="color: #14b8a6;">독립 운영 중, 오픈소스 전환</strong></td></tr>
+                            <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">현재 상태</td><td class="p-3"><strong style="color: #F86825;">독립 운영 중, 오픈소스 전환</strong></td></tr>
                         </tbody>
                     </table>
                 </div>
 
                 <h4 class="text-lg font-bold themeable-heading mb-4">3단계 수익 모델</h4>
                 <div class="grid md:grid-cols-3 gap-4 mb-6">
-                    <div class="themeable-card rounded-lg p-4" style="border-top: 3px solid #14b8a6;">
+                    <div class="themeable-card rounded-lg p-4" style="border-top: 3px solid #F86825;">
                         <p class="font-bold themeable-heading text-sm mb-2">오픈소스 SDK (무료)</p>
                         <p class="text-sm themeable-muted leading-relaxed">Apache v2, 완전한 로컬 실행</p>
                     </div>
@@ -403,7 +403,7 @@
                 </div>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">페블러스 시사점</p>
+                    <p class="font-bold" style="color: #F86825;">페블러스 시사점</p>
                     <p class="themeable-text leading-relaxed mt-2">MOSTLY AI의 오픈소스 전환은 "정형 데이터 합성"이 범용화(commoditization)되고 있다는 강력한 신호입니다. 페블러스의 차별화 포인트인 "물리 시뮬레이션 기반 비정형 합성데이터 + 뉴로-심볼릭 품질 평가"는 이런 범용화에서 자유로운 고부가가치 영역입니다.</p>
                 </div>
             </div>
@@ -417,7 +417,7 @@
                 </p>
 
                 <div class="key-insight">
-                    <p class="font-bold" style="color: #14b8a6;">페블러스 시사점</p>
+                    <p class="font-bold" style="color: #F86825;">페블러스 시사점</p>
                     <p class="themeable-text leading-relaxed mt-2">"NVIDIA 생태계 파트너"라는 포지션은 PebbloSim이 Omniverse 위에서 구동되는 구조와 유사한 접근입니다. 페블러스도 중기적으로 NVIDIA Omniverse/Cosmos 생태계 내 파트너 포지셔닝을 고려할 필요가 있습니다.</p>
                 </div>
             </div>
@@ -474,10 +474,10 @@
                         <th class="text-left p-3 themeable-heading">Tonic.ai</th>
                     </tr></thead>
                     <tbody class="themeable-muted">
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">플랫폼화 (멀티모듈)</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3">부분적</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">워크플로우 깊이 임베딩</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">생태계 파트너십</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3">AWS Marketplace</td><td class="p-3" style="color: #14b8a6;">&#10003; NVIDIA</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
-                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">높은 전환비용 창출</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td><td class="p-3" style="color: #14b8a6;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">플랫폼화 (멀티모듈)</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3">부분적</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">워크플로우 깊이 임베딩</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">생태계 파트너십</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3">AWS Marketplace</td><td class="p-3" style="color: #F86825;">&#10003; NVIDIA</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
+                        <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">높은 전환비용 창출</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td><td class="p-3" style="color: #F86825;">&#10003;</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -500,7 +500,7 @@
                     <h4 class="text-lg font-bold themeable-heading mb-3">워크플로우 임베딩</h4>
                     <p class="themeable-muted text-sm leading-relaxed">Data Greenhouse는 일회성 데이터 납품이 아니라, 고객의 데이터 운영 체계에 OS 레벨로 통합됩니다.</p>
                 </div>
-                <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                     <h4 class="text-lg font-bold themeable-heading mb-3">진단→생성 자동 연동</h4>
                     <p class="themeable-muted text-sm leading-relaxed">Data Clinic의 진단 결과가 PebbloSim의 생성 파라미터로 자동 변환(Vector-to-Param)되는 구조는 글로벌 시장에서 유일한 통합입니다.</p>
                 </div>
@@ -589,21 +589,21 @@
         <section id="references" class="mb-16 fade-in-card">
             <h2 class="text-3xl font-bold themeable-heading mb-8">참고문헌</h2>
             <ol class="space-y-3 text-sm themeable-muted">
-                <li><span class="font-semibold" style="color: #14b8a6;">[1]</span> Datagen 폐업 분석 -- TechCrunch, CTech (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[2]</span> Synthesis AI -- Globant 인수 발표 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[3]</span> AI.Reverie -- Meta 인수 분석, The Information (2021)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[4]</span> Gretel -- NVIDIA 인수, GTC 2025 발표 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[5]</span> Hazy -- SAS IP 인수, IDC 분석 (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[6]</span> MOSTLY AI -- 오픈소스 전환, Apache v2 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[7]</span> Parallel Domain -- NVIDIA Cosmos 파트너십 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[8]</span> Tonic.ai -- 엔터프라이즈 합성데이터 시장 분석 (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[9]</span> Applied Intuition -- $150억 기업가치 평가, Forbes (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[10]</span> Grand View Research, "Synthetic Data Market Size Report" (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[11]</span> MarketsandMarkets, "Synthetic Data Generation Market" (2025)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[12]</span> CB Insights, "Top 100 AI Startups" (2019, 2021)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[13]</span> IDC, "GenAI in Enterprise Data Generation" (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[14]</span> Scale AI -- $290억 기업가치, Accel Partners (2024)</li>
-                <li><span class="font-semibold" style="color: #14b8a6;">[15]</span> Palantir Technologies -- 2025년 연간 보고서 (NYSE: PLTR)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[1]</span> Datagen 폐업 분석 -- TechCrunch, CTech (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[2]</span> Synthesis AI -- Globant 인수 발표 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[3]</span> AI.Reverie -- Meta 인수 분석, The Information (2021)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[4]</span> Gretel -- NVIDIA 인수, GTC 2025 발표 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[5]</span> Hazy -- SAS IP 인수, IDC 분석 (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[6]</span> MOSTLY AI -- 오픈소스 전환, Apache v2 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[7]</span> Parallel Domain -- NVIDIA Cosmos 파트너십 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[8]</span> Tonic.ai -- 엔터프라이즈 합성데이터 시장 분석 (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[9]</span> Applied Intuition -- $150억 기업가치 평가, Forbes (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[10]</span> Grand View Research, "Synthetic Data Market Size Report" (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[11]</span> MarketsandMarkets, "Synthetic Data Generation Market" (2025)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[12]</span> CB Insights, "Top 100 AI Startups" (2019, 2021)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[13]</span> IDC, "GenAI in Enterprise Data Generation" (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[14]</span> Scale AI -- $290억 기업가치, Accel Partners (2024)</li>
+                <li><span class="font-semibold" style="color: #F86825;">[15]</span> Palantir Technologies -- 2025년 연간 보고서 (NYSE: PLTR)</li>
             </ol>
         </section>
 

--- a/project/SyntheticData/synthetic-data-pricing/en/index.html
+++ b/project/SyntheticData/synthetic-data-pricing/en/index.html
@@ -78,7 +78,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -90,7 +90,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -102,7 +102,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -425,7 +425,7 @@
                     </p>
                 </div>
 
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <div class="text-center mb-4">
                         <div class="inline-flex items-center justify-center w-12 h-12 rounded-full mb-3" style="background-color: rgba(20, 184, 166, 0.1);">
                             <span class="text-2xl font-bold teal-text">2</span>
@@ -929,7 +929,7 @@
             <div class="themeable-card rounded-xl p-8 mb-8">
                 <h3 class="text-2xl font-bold themeable-heading mb-6">B. Core Conclusion: Modality Determines Price Structure</h3>
 
-                <div class="p-6 rounded-lg mb-6" style="background-color: rgba(20, 184, 166, 0.1); border-left: 4px solid #14b8a6;">
+                <div class="p-6 rounded-lg mb-6" style="background-color: rgba(20, 184, 166, 0.1); border-left: 4px solid #F86825;">
                     <p class="text-lg font-semibold themeable-heading mb-2">
                         Customers buy 'solutions,' not 'data'
                     </p>
@@ -975,7 +975,7 @@
                         <span class="themeable-text-muted"><strong>Platform Floor:</strong> Minimum commitment</span>
                     </div>
                     <div class="flex items-center gap-2">
-                        <div class="w-4 h-4 rounded" style="background-color: #14B8A6;"></div>
+                        <div class="w-4 h-4 rounded" style="background-color: #F86825;"></div>
                         <span class="themeable-text-muted"><strong>Variable Meter:</strong> Usage-based</span>
                     </div>
                     <div class="flex items-center gap-2">
@@ -1070,7 +1070,7 @@
                         <div class="flex items-start justify-between mb-4">
                             <h4 class="text-xl font-bold themeable-heading">Pro</h4>
                             <div class="text-right">
-                                <p class="text-2xl font-bold" style="color: #14B8A6;">~$400</p>
+                                <p class="text-2xl font-bold" style="color: #F86825;">~$400</p>
                                 <p class="text-sm themeable-text-muted">/mo</p>
                             </div>
                         </div>
@@ -1254,7 +1254,7 @@
                 labels: ['Tabular/Time-Series', 'Text/LLM', 'Image/CV'],
                 datasets: [
                     { label: 'Platform Floor', data: [1, 10, 70], color: '#F86825' },
-                    { label: 'Variable Meter', data: [1, 60, 10], color: '#14B8A6' },
+                    { label: 'Variable Meter', data: [1, 60, 10], color: '#F86825' },
                     { label: 'Value-Add', data: [98, 30, 20], color: '#A855F7' }
                 ],
                 yMax: 100,

--- a/project/SyntheticData/synthetic-data-pricing/ko/index.html
+++ b/project/SyntheticData/synthetic-data-pricing/ko/index.html
@@ -76,7 +76,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -88,7 +88,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -100,7 +100,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -432,7 +432,7 @@
                     </p>
                 </div>
 
-                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #14b8a6;">
+                <div class="themeable-card rounded-xl p-6 interactive-card" style="border-top: 4px solid #F86825;">
                     <div class="text-center mb-4">
                         <div class="inline-flex items-center justify-center w-12 h-12 rounded-full mb-3" style="background-color: rgba(20, 184, 166, 0.1);">
                             <span class="text-2xl font-bold teal-text">2</span>
@@ -936,7 +936,7 @@
             <div class="themeable-card rounded-xl p-8 mb-8">
                 <h3 class="text-2xl font-bold themeable-heading mb-6">B. 핵심 결론: 모달리티가 가격 구조를 결정한다</h3>
 
-                <div class="p-6 rounded-lg mb-6" style="background-color: rgba(20, 184, 166, 0.1); border-left: 4px solid #14b8a6;">
+                <div class="p-6 rounded-lg mb-6" style="background-color: rgba(20, 184, 166, 0.1); border-left: 4px solid #F86825;">
                     <p class="text-lg font-semibold themeable-heading mb-2">
                         고객은 '데이터'가 아닌 '솔루션'을 구매합니다
                     </p>
@@ -982,7 +982,7 @@
                         <span class="themeable-text-muted"><strong>Platform Floor:</strong> 플랫폼 최소 약정</span>
                     </div>
                     <div class="flex items-center gap-2">
-                        <div class="w-4 h-4 rounded" style="background-color: #14B8A6;"></div>
+                        <div class="w-4 h-4 rounded" style="background-color: #F86825;"></div>
                         <span class="themeable-text-muted"><strong>Variable Meter:</strong> 가변 미터 (사용량)</span>
                     </div>
                     <div class="flex items-center gap-2">
@@ -1077,7 +1077,7 @@
                         <div class="flex items-start justify-between mb-4">
                             <h4 class="text-xl font-bold themeable-heading">Pro</h4>
                             <div class="text-right">
-                                <p class="text-2xl font-bold" style="color: #14B8A6;">&#8361;500,000</p>
+                                <p class="text-2xl font-bold" style="color: #F86825;">&#8361;500,000</p>
                                 <p class="text-sm themeable-text-muted">/월</p>
                             </div>
                         </div>
@@ -1261,7 +1261,7 @@
                 labels: ['정형/시계열', '텍스트/LLM', '이미지/CV'],
                 datasets: [
                     { label: 'Platform Floor', data: [1, 10, 70], color: '#F86825' },
-                    { label: 'Variable Meter', data: [1, 60, 10], color: '#14B8A6' },
+                    { label: 'Variable Meter', data: [1, 60, 10], color: '#F86825' },
                     { label: 'Value-Add', data: [98, 30, 20], color: '#A855F7' }
                 ],
                 yMax: 100,

--- a/project/TeslaFSD/tesla-fsd-desk/en/index.html
+++ b/project/TeslaFSD/tesla-fsd-desk/en/index.html
@@ -208,7 +208,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.red::before { background: linear-gradient(180deg, #ef4444, #dc2626); }

--- a/project/TeslaFSD/tesla-fsd-desk/ko/index.html
+++ b/project/TeslaFSD/tesla-fsd-desk/ko/index.html
@@ -208,7 +208,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.red::before { background: linear-gradient(180deg, #ef4444, #dc2626); }

--- a/project/UrbanGPT/urbangpt2-pebblous/en/index.html
+++ b/project/UrbanGPT/urbangpt2-pebblous/en/index.html
@@ -115,7 +115,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -137,7 +137,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -259,7 +259,7 @@
         }
 
         .component-card.data::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.scope::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.scope::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.sim::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.greenhouse::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
 

--- a/project/UrbanGPT/urbangpt2-pebblous/ko/index.html
+++ b/project/UrbanGPT/urbangpt2-pebblous/ko/index.html
@@ -115,7 +115,7 @@
             --text-secondary: #475569;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #e2e8f0;
         }
 
@@ -137,7 +137,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -259,7 +259,7 @@
         }
 
         .component-card.data::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.scope::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.scope::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.sim::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.greenhouse::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
 

--- a/project/WiFiDensePose/wifi-densepose-ruview/en/index.html
+++ b/project/WiFiDensePose/wifi-densepose-ruview/en/index.html
@@ -208,7 +208,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }
@@ -654,7 +654,7 @@
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                             <div class="component-card teal">
                                 <div class="flex items-center gap-3 mb-3">
-                                    <div class="component-badge" style="background:#14b8a6;">📶</div>
+                                    <div class="component-badge" style="background:#F86825;">📶</div>
                                     <p class="font-bold themeable-heading">Existing WiFi (RSSI Only)</p>
                                 </div>
                                 <p class="text-sm themeable-text">Laptop or existing router. $0 per zone. No precise CSI — only presence detection and coarse movement sensing.</p>
@@ -687,7 +687,7 @@
                         <div class="grid grid-cols-1 gap-4 mb-6">
                             <div class="component-card teal">
                                 <div class="flex items-start gap-4">
-                                    <div class="component-badge flex-shrink-0" style="background:#14b8a6; margin-top:2px;">🏥</div>
+                                    <div class="component-badge flex-shrink-0" style="background:#F86825; margin-top:2px;">🏥</div>
                                     <div>
                                         <p class="font-bold themeable-heading mb-1">Hospital Patient Monitoring</p>
                                         <p class="text-sm themeable-text leading-relaxed">24/7 continuous respiration and heart rate monitoring in non-critical wards without cameras. Nurse alerts on anomaly detection. Patient fall detection with no privacy invasion. 1~2 APs per ward cover all beds.</p>
@@ -859,7 +859,7 @@
                             </div>
                             <div class="component-card teal">
                                 <div class="flex items-start gap-4">
-                                    <div class="component-badge flex-shrink-0" style="background:#14b8a6; margin-top:2px; font-size:0.9rem;">🌿</div>
+                                    <div class="component-badge flex-shrink-0" style="background:#F86825; margin-top:2px; font-size:0.9rem;">🌿</div>
                                     <div>
                                         <p class="font-bold themeable-heading mb-1">Data Greenhouse — Automated Continuous CSI Data Pipeline</p>
                                         <p class="text-sm themeable-text leading-relaxed">Even after WiFi DensePose is deployed on-site, the environment changes. New furniture, renovations, seasonal staffing fluctuations. Data Greenhouse is an autonomous pipeline that continuously collects, refines, and labels on-site CSI streams, automatically detects model performance degradation, and triggers retraining.</p>

--- a/project/WiFiDensePose/wifi-densepose-ruview/ko/index.html
+++ b/project/WiFiDensePose/wifi-densepose-ruview/ko/index.html
@@ -208,7 +208,7 @@
         }
 
         .component-card.orange::before { background: linear-gradient(180deg, #F86825, #ea580c); }
-        .component-card.teal::before { background: linear-gradient(180deg, #14b8a6, #0d9488); }
+        .component-card.teal::before { background: linear-gradient(180deg, #F86825, #C64900); }
         .component-card.purple::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
         .component-card.green::before { background: linear-gradient(180deg, #22c55e, #16a34a); }
         .component-card.blue::before { background: linear-gradient(180deg, #3b82f6, #1d4ed8); }
@@ -654,7 +654,7 @@
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                             <div class="component-card teal">
                                 <div class="flex items-center gap-3 mb-3">
-                                    <div class="component-badge" style="background:#14b8a6;">📶</div>
+                                    <div class="component-badge" style="background:#F86825;">📶</div>
                                     <p class="font-bold themeable-heading">기존 WiFi (RSSI 전용)</p>
                                 </div>
                                 <p class="text-sm themeable-text">노트북 또는 기존 공유기. 구역당 비용 $0. 정밀 CSI 없음 — 존재 유무와 거친 움직임 감지만 가능.</p>
@@ -687,7 +687,7 @@
                         <div class="grid grid-cols-1 gap-4 mb-6">
                             <div class="component-card teal">
                                 <div class="flex items-start gap-4">
-                                    <div class="component-badge flex-shrink-0" style="background:#14b8a6; margin-top:2px;">🏥</div>
+                                    <div class="component-badge flex-shrink-0" style="background:#F86825; margin-top:2px;">🏥</div>
                                     <div>
                                         <p class="font-bold themeable-heading mb-1">병원 환자 모니터링</p>
                                         <p class="text-sm themeable-text leading-relaxed">비중증 병상에서 카메라 없이 호흡·심박 24시간 연속 감시. 이상 감지 시 간호사 알림. 프라이버시 침해 없이 환자 낙상 감지. 병동당 1~2개 AP로 전 병상 커버.</p>
@@ -859,7 +859,7 @@
                             </div>
                             <div class="component-card teal">
                                 <div class="flex items-start gap-4">
-                                    <div class="component-badge flex-shrink-0" style="background:#14b8a6; margin-top:2px; font-size:0.9rem;">🌿</div>
+                                    <div class="component-badge flex-shrink-0" style="background:#F86825; margin-top:2px; font-size:0.9rem;">🌿</div>
                                     <div>
                                         <p class="font-bold themeable-heading mb-1">데이터 그린하우스 — 지속적인 CSI 데이터 파이프라인 자동화</p>
                                         <p class="text-sm themeable-text leading-relaxed">WiFi DensePose가 현장에 배포된 이후에도 환경은 바뀝니다. 새 가구, 리모델링, 계절별 인원 변화. 데이터 그린하우스는 현장 CSI 스트림을 지속적으로 수집·정제·레이블링하고, 모델 성능 저하를 자동으로 감지해 재학습을 트리거하는 자율형 파이프라인입니다.</p>

--- a/project/World Model/world-model-comparison/en/index.html
+++ b/project/World Model/world-model-comparison/en/index.html
@@ -96,7 +96,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -108,7 +108,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -120,7 +120,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -263,7 +263,7 @@
         }
 
         .scholar-card.hawkins::before { background: linear-gradient(180deg, #f97316, #ea580c); }
-        .scholar-card.lecun::before { background: linear-gradient(180deg, #0d9488, #0f766e); }
+        .scholar-card.lecun::before { background: linear-gradient(180deg, #C64900, #0f766e); }
         .scholar-card.feifei::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
 
         .scholar-card:hover {
@@ -921,7 +921,7 @@
                             <p class="fusion-author">Jeff Hawkins</p>
                             <p class="text-xs themeable-text-secondary mt-2">Mapping information via reference frames</p>
                         </div>
-                        <div class="fusion-item" style="border-color: #0d9488;">
+                        <div class="fusion-item" style="border-color: #C64900;">
                             <div class="fusion-icon">⚡</div>
                             <p class="fusion-label">Layer 2</p>
                             <p class="fusion-title">Reasoning</p>

--- a/project/World Model/world-model-comparison/ko/index.html
+++ b/project/World Model/world-model-comparison/ko/index.html
@@ -94,7 +94,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -106,7 +106,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -118,7 +118,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -261,7 +261,7 @@
         }
 
         .scholar-card.hawkins::before { background: linear-gradient(180deg, #f97316, #ea580c); }
-        .scholar-card.lecun::before { background: linear-gradient(180deg, #0d9488, #0f766e); }
+        .scholar-card.lecun::before { background: linear-gradient(180deg, #C64900, #0f766e); }
         .scholar-card.feifei::before { background: linear-gradient(180deg, #8b5cf6, #7c3aed); }
 
         .scholar-card:hover {
@@ -919,7 +919,7 @@
                             <p class="fusion-author">Jeff Hawkins</p>
                             <p class="text-xs themeable-text-secondary mt-2">참조 프레임으로 정보를 '좌표화'</p>
                         </div>
-                        <div class="fusion-item" style="border-color: #0d9488;">
+                        <div class="fusion-item" style="border-color: #C64900;">
                             <div class="fusion-icon">⚡</div>
                             <p class="fusion-label">Layer 2</p>
                             <p class="fusion-title">추론 (Reasoning)</p>

--- a/report/ai-science-new-era/en/index.html
+++ b/report/ai-science-new-era/en/index.html
@@ -57,11 +57,11 @@
 
     <style>
         .fact-card { border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 1.5rem; }
-        .fact-true { border-left: 4px solid #14b8a6; }
+        .fact-true { border-left: 4px solid #F86825; }
         .fact-false { border-left: 4px solid #ef4444; }
         .fact-nuance { border-left: 4px solid #f59e0b; }
         .fact-badge { display: inline-block; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
-        .badge-true { background: #14b8a620; color: #14b8a6; }
+        .badge-true { background: #F8682520; color: #F86825; }
         .badge-false { background: #ef444420; color: #ef4444; }
         .badge-nuance { background: #f59e0b20; color: #f59e0b; }
         .stat-card { border-radius: 0.75rem; padding: 1.25rem; text-align: center; }

--- a/report/ai-science-new-era/ko/index.html
+++ b/report/ai-science-new-era/ko/index.html
@@ -57,11 +57,11 @@
 
     <style>
         .fact-card { border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 1.5rem; }
-        .fact-true { border-left: 4px solid #14b8a6; }
+        .fact-true { border-left: 4px solid #F86825; }
         .fact-false { border-left: 4px solid #ef4444; }
         .fact-nuance { border-left: 4px solid #f59e0b; }
         .fact-badge { display: inline-block; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
-        .badge-true { background: #14b8a620; color: #14b8a6; }
+        .badge-true { background: #F8682520; color: #F86825; }
         .badge-false { background: #ef444420; color: #ef4444; }
         .badge-nuance { background: #f59e0b20; color: #f59e0b; }
         .stat-card { border-radius: 0.75rem; padding: 1.25rem; text-align: center; }

--- a/report/anthropic-emotions-report/en/index.html
+++ b/report/anthropic-emotions-report/en/index.html
@@ -247,8 +247,8 @@
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors" style="background: rgba(20,184,166,0.08);">
                                     <td class="border themeable-border px-4 py-3 font-semibold">calm +0.05</td>
-                                    <td class="border themeable-border px-4 py-3 text-right font-semibold" style="color: #14b8a6;">0%</td>
-                                    <td class="border themeable-border px-4 py-3 text-right" style="color: #14b8a6;">-22%p</td>
+                                    <td class="border themeable-border px-4 py-3 text-right font-semibold" style="color: #F86825;">0%</td>
+                                    <td class="border themeable-border px-4 py-3 text-right" style="color: #F86825;">-22%p</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3">calm -0.05</td>
@@ -486,7 +486,7 @@
                                 <tr class="hover:bg-orange-500/5 transition-colors" style="background: rgba(248,104,37,0.08);">
                                     <td class="border themeable-border px-4 py-3 font-semibold">Anthropic</td>
                                     <td class="border themeable-border px-4 py-3">SAE + Attribution Graphs + Circuit Tracing</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #14b8a6;">171 emotion vectors</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #F86825;">171 emotion vectors</td>
                                     <td class="border themeable-border px-4 py-3 text-center">Ambitious reverse-engineering</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
@@ -516,7 +516,7 @@
                             <p class="themeable-text text-sm leading-relaxed mb-3">In March 2025, DeepMind <a href="https://www.alignmentforum.org/posts/QoR8noAB3Mp2KBA4B/decomposing-the-dark-matter-of-interpretability-investigating" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">publicly reported negative SAE results</a> and pivoted strategy. SAEs underperformed simple linear probes on downstream tasks like harmful intent detection, and <a href="https://github.com/google-deepmind/gemma_scope" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">Gemma 2 SAEs</a> required 20PB of storage and GPT-3-scale compute.</p>
                             <p class="themeable-text text-sm leading-relaxed"><strong>Why they avoid emotion framing:</strong> An honest admission of "no ground truth for true features." Anthropic's emotion vector findings can be read as experimental counterevidence to this critique.</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-5" style="border-top: 3px solid #14b8a6;">
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-5" style="border-top: 3px solid #F86825;">
                             <h4 class="font-bold themeable-heading mb-3 text-base">🧬 Anthropic</h4>
                             <p class="themeable-text text-sm leading-relaxed mb-3">The <a href="https://transformer-circuits.pub/2026/emotions/index.html" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">emotion vectors paper</a> marks a milestone in a three-stage progression: Scaling Monosemanticity (2024) → Circuit Tracing (2025) → Emotion Vectors (2026). It advances most rapidly toward the 2027 goal set by Dario Amodei's <a href="https://www.darioamodei.com/post/the-urgency-of-interpretability" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">"The Urgency of Interpretability."</a></p>
                             <p class="themeable-text text-sm leading-relaxed"><strong>Key differentiator:</strong> Anthropic maintains the "ambitious reverse-engineering" approach DeepMind abandoned, experimentally sidestepping the ground truth problem via valence·arousal correlation validation (r=0.81, r=0.66).</p>
@@ -547,7 +547,7 @@
                             <p class="font-semibold themeable-heading mb-2">Emotional Bias Diagnosis</p>
                             <p class="text-sm themeable-text-secondary">Analyze the emotional distribution of text training data &mdash; detect overrepresentation of desperation/fear</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #14b8a6;">
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #F86825;">
                             <p class="font-semibold themeable-heading mb-2">Synthetic Data Emotion Design</p>
                             <p class="text-sm themeable-text-secondary">Generate synthetic data with intentionally designed emotional diversity</p>
                         </div>

--- a/report/anthropic-emotions-report/ko/index.html
+++ b/report/anthropic-emotions-report/ko/index.html
@@ -247,8 +247,8 @@
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors" style="background: rgba(20,184,166,0.08);">
                                     <td class="border themeable-border px-4 py-3 font-semibold">calm +0.05</td>
-                                    <td class="border themeable-border px-4 py-3 text-right font-semibold" style="color: #14b8a6;">0%</td>
-                                    <td class="border themeable-border px-4 py-3 text-right" style="color: #14b8a6;">-22%p</td>
+                                    <td class="border themeable-border px-4 py-3 text-right font-semibold" style="color: #F86825;">0%</td>
+                                    <td class="border themeable-border px-4 py-3 text-right" style="color: #F86825;">-22%p</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3">calm -0.05</td>
@@ -486,7 +486,7 @@
                                 <tr class="hover:bg-orange-500/5 transition-colors" style="background: rgba(248,104,37,0.08);">
                                     <td class="border themeable-border px-4 py-3 font-semibold">Anthropic</td>
                                     <td class="border themeable-border px-4 py-3">SAE + Attribution Graphs + Circuit Tracing</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #14b8a6;">171개 감정 벡터</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #F86825;">171개 감정 벡터</td>
                                     <td class="border themeable-border px-4 py-3 text-center">야심적 역공학</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
@@ -516,7 +516,7 @@
                             <p class="themeable-text text-sm leading-relaxed mb-3">2025년 3월 <a href="https://www.alignmentforum.org/posts/QoR8noAB3Mp2KBA4B/decomposing-the-dark-matter-of-interpretability-investigating" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">SAE 연구의 부정적 결과</a>를 공개하며 전략을 전환했다. SAE가 유해 의도 탐지에서 단순 선형 프로브보다 성능이 낮았고, <a href="https://github.com/google-deepmind/gemma_scope" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">Gemma 2 SAE</a>는 20PB 스토리지와 GPT-3급 연산이 필요했다.</p>
                             <p class="themeable-text text-sm leading-relaxed"><strong>감정 프레임 회피 이유:</strong> "참 특징의 ground truth 부재"를 솔직히 인정했기 때문이다. Anthropic의 감정 벡터 연구는 바로 이 비판에 대한 실험적 반증 사례로 읽힐 수 있다.</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-5" style="border-top: 3px solid #14b8a6;">
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-5" style="border-top: 3px solid #F86825;">
                             <h4 class="font-bold themeable-heading mb-3 text-base">🧬 Anthropic</h4>
                             <p class="themeable-text text-sm leading-relaxed mb-3"><a href="https://transformer-circuits.pub/2026/emotions/index.html" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">감정 벡터 논문</a>은 Scaling Monosemanticity(2024) → Circuit Tracing(2025) → Emotion Vectors(2026)로 이어지는 3단계 진화의 이정표다. Dario Amodei의 <a href="https://www.darioamodei.com/post/the-urgency-of-interpretability" target="_blank" rel="noopener noreferrer" class="text-orange-400 hover:text-orange-300 transition-colors">"The Urgency of Interpretability"</a>가 제시한 2027년 목표를 향해 가장 빠르게 나아가고 있다.</p>
                             <p class="themeable-text text-sm leading-relaxed"><strong>차별점:</strong> DeepMind가 포기한 "야심적 역공학" 노선을 유지하면서, ground truth 문제를 valence·arousal 상관 검증(r=0.81, r=0.66)으로 실험적으로 우회했다.</p>
@@ -547,7 +547,7 @@
                             <p class="font-semibold themeable-heading mb-2">감정적 편향 진단</p>
                             <p class="text-sm themeable-text-secondary">텍스트 학습 데이터의 감정 분포 분석 &mdash; 절망/공포 과다 여부 판별</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #14b8a6;">
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #F86825;">
                             <p class="font-semibold themeable-heading mb-2">합성 데이터 감정 설계</p>
                             <p class="text-sm themeable-text-secondary">감정적 다양성을 의도적으로 설계한 합성 데이터 생성</p>
                         </div>

--- a/report/blog-2025-review/index.html
+++ b/report/blog-2025-review/index.html
@@ -88,7 +88,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -100,7 +100,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -112,7 +112,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -284,7 +284,7 @@
         }
 
         .category-card.purple::before { background: #a855f7; }
-        .category-card.teal::before { background: #14b8a6; }
+        .category-card.teal::before { background: #F86825; }
         .category-card.orange::before { background: #F86825; }
         .category-card.blue::before { background: #3b82f6; }
 

--- a/report/blog-2026-feb/en/index.html
+++ b/report/blog-2026-feb/en/index.html
@@ -68,7 +68,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="dark"] {
@@ -79,7 +79,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="beige"] {
@@ -90,7 +90,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body { background-color: var(--bg-primary); color: var(--text-primary); font-family: var(--font-sans, 'Pretendard', sans-serif); line-height: 2.0; }
@@ -100,12 +100,12 @@
         .section-header h2 { font-size: 1.875rem; font-weight: 700; color: var(--text-primary); margin: 0; }
         .icon-wrapper { width: 2.5rem; height: 2.5rem; border-radius: 0.5rem; background: linear-gradient(135deg, var(--accent-color), #fb923c); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
         .icon-wrapper svg { width: 1.25rem; height: 1.25rem; color: white; }
-        .icon-wrapper.teal { background: linear-gradient(135deg, var(--teal-color), #2dd4bf); }
+        .icon-wrapper.teal { background: linear-gradient(135deg, var(--teal-color), #FFB092); }
 
         /* Stat cards */
         .stat-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; text-align: center; position: relative; overflow: hidden; }
         .stat-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: linear-gradient(90deg, var(--accent-color), var(--teal-color)); }
-        .stat-card.teal::before { background: linear-gradient(90deg, var(--teal-color), #2dd4bf); }
+        .stat-card.teal::before { background: linear-gradient(90deg, var(--teal-color), #FFB092); }
         .stat-value { font-size: 2.25rem; font-weight: 800; color: var(--accent-color); line-height: 1.2; }
         .stat-value.teal { color: var(--teal-color); }
         .stat-label { font-size: 0.875rem; font-weight: 600; color: var(--text-secondary); margin-top: 0.25rem; }

--- a/report/blog-2026-feb/ko/index.html
+++ b/report/blog-2026-feb/ko/index.html
@@ -68,7 +68,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
         [data-theme="dark"] {
@@ -79,7 +79,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
         [data-theme="beige"] {
@@ -90,7 +90,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
         body { background-color: var(--bg-primary); color: var(--text-primary); font-family: var(--font-sans, 'Pretendard', sans-serif); line-height: 2.0; }
@@ -100,12 +100,12 @@
         .section-header h2 { font-size: 1.875rem; font-weight: 700; color: var(--text-primary); margin: 0; }
         .icon-wrapper { width: 2.5rem; height: 2.5rem; border-radius: 0.5rem; background: linear-gradient(135deg, var(--accent-color), #fb923c); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
         .icon-wrapper svg { width: 1.25rem; height: 1.25rem; color: white; }
-        .icon-wrapper.teal { background: linear-gradient(135deg, var(--teal-color), #2dd4bf); }
+        .icon-wrapper.teal { background: linear-gradient(135deg, var(--teal-color), #FFB092); }
 
         /* Stat cards */
         .stat-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; text-align: center; position: relative; overflow: hidden; }
         .stat-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: linear-gradient(90deg, var(--accent-color), var(--teal-color)); }
-        .stat-card.teal::before { background: linear-gradient(90deg, var(--teal-color), #2dd4bf); }
+        .stat-card.teal::before { background: linear-gradient(90deg, var(--teal-color), #FFB092); }
         .stat-value { font-size: 2.25rem; font-weight: 800; color: var(--accent-color); line-height: 1.2; }
         .stat-value.teal { color: var(--teal-color); }
         .stat-label { font-size: 0.875rem; font-weight: 600; color: var(--text-secondary); margin-top: 0.25rem; }

--- a/report/blog-2026-mar-lighthouse/en/index.html
+++ b/report/blog-2026-mar-lighthouse/en/index.html
@@ -193,28 +193,28 @@
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">39</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">87</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">92</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+53</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+53</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Accessibility</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #f59e0b; font-weight: 700;">83</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">95</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">95</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+12</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+12</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Best Practices</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">92</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">96</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">100</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+8</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+8</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">SEO</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">N/A</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">100</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">100</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">N/A → 100</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">N/A → 100</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -259,35 +259,35 @@
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">0.661</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0.19</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0.021</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">97% reduction</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">97% reduction</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>LCP</strong><br><span class="text-xs themeable-muted">Largest Contentful Paint</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">4.7s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">1.3s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">1.8s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">62% reduction</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">62% reduction</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>Speed Index</strong></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">11.5s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0.9s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0.9s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">92% reduction</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">92% reduction</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>TBT</strong><br><span class="text-xs themeable-muted">Total Blocking Time</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #f59e0b; font-weight: 700;">200ms</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0ms</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0ms</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">100% eliminated</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">100% eliminated</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>TTI</strong><br><span class="text-xs themeable-muted">Time to Interactive</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">4.8s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">1.3s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">1.8s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">63% reduction</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">63% reduction</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>FCP</strong><br><span class="text-xs themeable-muted">First Contentful Paint</span></td>
@@ -326,13 +326,13 @@
 
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
                         <div class="key-insight text-center p-4">
-                            <p class="text-2xl font-bold" style="color: #14b8a6;">62%</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">62%</p>
                         </div>
                         <div class="key-insight text-center p-4">
                             <p class="text-2xl font-bold" style="color: #F86825;">92%</p>
                         </div>
                         <div class="key-insight text-center p-4">
-                            <p class="text-2xl font-bold" style="color: #14b8a6;">100%</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">100%</p>
                         </div>
                     </div>
 
@@ -580,29 +580,29 @@
                             <thead>
                                 <tr class="themeable-bg-secondary">
                                     <th class="border themeable-border px-4 py-3 text-left themeable-text font-semibold"></th>
-                                    <th class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #14b8a6;">AI Agent (Claude Code)</th>
+                                    <th class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #F86825;">AI Agent (Claude Code)</th>
                                     <th class="border themeable-border px-4 py-3 text-center themeable-text font-semibold">Human Team</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Cost</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">~$391</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">~$391</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">~$14,000</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Duration</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">~2 days</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">~2 days</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">3-4 weeks</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Team Size</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">1 person (+ AI)</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">1 person (+ AI)</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">2-3 people</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Lighthouse Runs</td>
-                                    <td class="border themeable-border px-4 py-3 text-center" style="color: #14b8a6;">25+ (instant analysis)</td>
+                                    <td class="border themeable-border px-4 py-3 text-center" style="color: #F86825;">25+ (instant analysis)</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">5-10 (manual analysis)</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
@@ -622,11 +622,11 @@
                     </p>
 
                     <ul class="space-y-3 mb-6 themeable-text" style="line-height: 2.0;">
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>Rapid feedback loops</strong> — Code change → build → Lighthouse → analysis in minutes, not the 30-60 minutes per cycle it would take solo</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>Cross-domain integration</strong> — SEO, Performance, Accessibility, and Architecture handled in a single session without separate specialists</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>Instant codebase comprehension</strong> — 139 files and tens of thousands of lines explored and analyzed instantly</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>Automated documentation</strong> — Measurement reports, comparative analyses, and commit histories generated automatically</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>Consistency</strong> — Coding conventions and commit message styles maintained across all 36 commits</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>Rapid feedback loops</strong> — Code change → build → Lighthouse → analysis in minutes, not the 30-60 minutes per cycle it would take solo</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>Cross-domain integration</strong> — SEO, Performance, Accessibility, and Architecture handled in a single session without separate specialists</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>Instant codebase comprehension</strong> — 139 files and tens of thousands of lines explored and analyzed instantly</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>Automated documentation</strong> — Measurement reports, comparative analyses, and commit histories generated automatically</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>Consistency</strong> — Coding conventions and commit message styles maintained across all 36 commits</li>
                     </ul>
                 </section>
 

--- a/report/blog-2026-mar-lighthouse/ko/index.html
+++ b/report/blog-2026-mar-lighthouse/ko/index.html
@@ -193,28 +193,28 @@
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">39</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">87</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">92</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+53</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+53</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Accessibility</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #f59e0b; font-weight: 700;">83</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">95</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">95</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+12</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+12</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Best Practices</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">92</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">96</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">100</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">+8</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">+8</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">SEO</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">N/A</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">100</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">100</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">N/A → 만점</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">N/A → 만점</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -259,35 +259,35 @@
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">0.661</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0.19</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0.021</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">97% 감소</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">97% 감소</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>LCP</strong><br><span class="text-xs themeable-muted">Largest Contentful Paint</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">4.7s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">1.3s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">1.8s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">62% 감소</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">62% 감소</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>Speed Index</strong></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">11.5s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0.9s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0.9s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">92% 감소</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">92% 감소</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>TBT</strong><br><span class="text-xs themeable-muted">Total Blocking Time</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #f59e0b; font-weight: 700;">200ms</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">0ms</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">0ms</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">100% 제거</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">100% 제거</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>TTI</strong><br><span class="text-xs themeable-muted">Time to Interactive</span></td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #ef4444; font-weight: 700;">4.8s</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">1.3s</td>
                                     <td class="border themeable-border px-4 py-3 text-center" style="color: #22c55e; font-weight: 700;">1.8s</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">63% 감소</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">63% 감소</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 themeable-text"><strong>FCP</strong><br><span class="text-xs themeable-muted">First Contentful Paint</span></td>
@@ -326,13 +326,13 @@
 
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
                         <div class="key-insight text-center p-4">
-                            <p class="text-2xl font-bold" style="color: #14b8a6;">62%</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">62%</p>
                         </div>
                         <div class="key-insight text-center p-4">
                             <p class="text-2xl font-bold" style="color: #F86825;">92%</p>
                         </div>
                         <div class="key-insight text-center p-4">
-                            <p class="text-2xl font-bold" style="color: #14b8a6;">100%</p>
+                            <p class="text-2xl font-bold" style="color: #F86825;">100%</p>
                         </div>
                     </div>
 
@@ -590,29 +590,29 @@
                             <thead>
                                 <tr class="themeable-bg-secondary">
                                     <th class="border themeable-border px-4 py-3 text-left themeable-text font-semibold"></th>
-                                    <th class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #14b8a6;">AI Agent (Claude Code)</th>
+                                    <th class="border themeable-border px-4 py-3 text-center font-semibold" style="color: #F86825;">AI Agent (Claude Code)</th>
                                     <th class="border themeable-border px-4 py-3 text-center themeable-text font-semibold">Human Team</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">비용</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">~56만 원</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">~56만 원</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">~1,980만 원</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">소요 시간</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">~2일</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">~2일</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">3~4주</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">인력</td>
-                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #14b8a6;">1명 (+ AI)</td>
+                                    <td class="border themeable-border px-4 py-3 text-center font-bold" style="color: #F86825;">1명 (+ AI)</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">2~3명</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
                                     <td class="border themeable-border px-4 py-3 font-semibold themeable-text">Lighthouse 측정</td>
-                                    <td class="border themeable-border px-4 py-3 text-center" style="color: #14b8a6;">25회+ (즉시 분석)</td>
+                                    <td class="border themeable-border px-4 py-3 text-center" style="color: #F86825;">25회+ (즉시 분석)</td>
                                     <td class="border themeable-border px-4 py-3 text-center themeable-text">5~10회 (수동 분석)</td>
                                 </tr>
                                 <tr class="hover:bg-orange-500/5 transition-colors">
@@ -632,11 +632,11 @@
                     </p>
 
                     <ul class="space-y-3 mb-6 themeable-text" style="line-height: 2.0;">
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>빠른 피드백 루프</strong> — 코드 수정 → 빌드 검증 → Lighthouse 측정 → 분석을 분 단위로 반복. 사람 혼자라면 한 사이클에 30분~1시간 걸릴 것을 5~10분으로 단축</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>전문 영역 통합</strong> — SEO, Performance, Accessibility, Architecture를 별도 전문가 없이 한 세션에서 처리</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>코드베이스 즉시 이해</strong> — 139개 파일, 수만 줄의 코드를 즉시 탐색·분석</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>문서 자동화</strong> — 측정 보고서, 비교 분석, 커밋 히스토리를 자동 생성</li>
-                        <li class="pl-4 border-l-2" style="border-color: #14b8a6;"><strong>일관성 유지</strong> — 36개 커밋 전체에서 코딩 컨벤션, 커밋 메시지 스타일 일관 유지</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>빠른 피드백 루프</strong> — 코드 수정 → 빌드 검증 → Lighthouse 측정 → 분석을 분 단위로 반복. 사람 혼자라면 한 사이클에 30분~1시간 걸릴 것을 5~10분으로 단축</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>전문 영역 통합</strong> — SEO, Performance, Accessibility, Architecture를 별도 전문가 없이 한 세션에서 처리</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>코드베이스 즉시 이해</strong> — 139개 파일, 수만 줄의 코드를 즉시 탐색·분석</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>문서 자동화</strong> — 측정 보고서, 비교 분석, 커밋 히스토리를 자동 생성</li>
+                        <li class="pl-4 border-l-2" style="border-color: #F86825;"><strong>일관성 유지</strong> — 36개 커밋 전체에서 코딩 컨벤션, 커밋 메시지 스타일 일관 유지</li>
                     </ul>
                 </section>
 

--- a/report/blog-2026/en/index.html
+++ b/report/blog-2026/en/index.html
@@ -89,7 +89,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -101,7 +101,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -113,7 +113,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -201,7 +201,7 @@
             box-shadow: 2px 0 8px rgba(100, 116, 139, 0.3);
         }
         .category-card.purple::before { background: #a855f7; }
-        .category-card.teal::before { background: #14b8a6; }
+        .category-card.teal::before { background: #F86825; }
         .category-card.orange::before { background: #F86825; }
         .category-card.blue::before { background: #3b82f6; }
         .category-desc { font-size: 0.7rem; color: var(--text-muted); margin-top: 0.5rem; line-height: 1.4; }

--- a/report/blog-2026/ko/index.html
+++ b/report/blog-2026/ko/index.html
@@ -88,7 +88,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -100,7 +100,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -112,7 +112,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -200,7 +200,7 @@
             box-shadow: 2px 0 8px rgba(100, 116, 139, 0.3);
         }
         .category-card.purple::before { background: #a855f7; }
-        .category-card.teal::before { background: #14b8a6; }
+        .category-card.teal::before { background: #F86825; }
         .category-card.orange::before { background: #F86825; }
         .category-card.blue::before { background: #3b82f6; }
         .category-desc { font-size: 0.7rem; color: var(--text-muted); margin-top: 0.5rem; line-height: 1.4; }

--- a/report/data-quality-mathematics/en/index.html
+++ b/report/data-quality-mathematics/en/index.html
@@ -63,7 +63,7 @@
             font-family: inherit;
         }
         .concept-card {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             padding: 1rem 1.25rem;
             margin: 1rem 0;
             border-radius: 0 8px 8px 0;
@@ -71,7 +71,7 @@
         .concept-title {
             font-weight: 700;
             font-size: 0.95rem;
-            color: #14b8a6;
+            color: #F86825;
             margin-bottom: 0.4rem;
         }
         .dimension-grid {
@@ -308,7 +308,7 @@
                         </p>
                         <p class="themeable-text text-sm leading-relaxed mt-2">
                             Topological sort result: raw_customers, raw_orders → cleaned_customers, cleaned_orders → customer_segments, order_summary → revenue_report<br>
-                            <span style="color: #14b8a6; font-weight: 600;">No matter which valid order is chosen, all dependencies are guaranteed to be satisfied.</span>
+                            <span style="color: #F86825; font-weight: 600;">No matter which valid order is chosen, all dependencies are guaranteed to be satisfied.</span>
                         </p>
                     </div>
 

--- a/report/data-quality-mathematics/ko/index.html
+++ b/report/data-quality-mathematics/ko/index.html
@@ -63,7 +63,7 @@
             font-family: inherit;
         }
         .concept-card {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             padding: 1rem 1.25rem;
             margin: 1rem 0;
             border-radius: 0 8px 8px 0;
@@ -71,7 +71,7 @@
         .concept-title {
             font-weight: 700;
             font-size: 0.95rem;
-            color: #14b8a6;
+            color: #F86825;
             margin-bottom: 0.4rem;
         }
         .dimension-grid {
@@ -308,7 +308,7 @@
                         </p>
                         <p class="themeable-text text-sm leading-relaxed mt-2">
                             위상 정렬 결과: raw_customers, raw_orders → cleaned_customers, cleaned_orders → customer_segments, order_summary → revenue_report<br>
-                            <span style="color: #14b8a6; font-weight: 600;">어떤 순서로 실행해도 의존성은 반드시 지켜진다.</span>
+                            <span style="color: #F86825; font-weight: 600;">어떤 순서로 실행해도 의존성은 반드시 지켜진다.</span>
                         </p>
                     </div>
 

--- a/report/data-value-proof/en/index.html
+++ b/report/data-value-proof/en/index.html
@@ -60,14 +60,14 @@
 
     <style>
         .stat-card {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             padding: 1rem 1.25rem;
             margin-bottom: 0.75rem;
         }
         .stat-number {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #14b8a6;
+            color: #F86825;
         }
         .pipeline-step {
             display: flex;
@@ -347,7 +347,7 @@
                                     <td class="border themeable-border px-4 py-3 font-semibold">Value Proof Infra</td>
                                     <td class="border themeable-border px-4 py-3 font-semibold">Pebblous</td>
                                     <td class="border themeable-border px-4 py-3">Diagnose-Supplement-Prove</td>
-                                    <td class="border themeable-border px-4 py-3 font-semibold" style="color: #14b8a6;">End-to-end</td>
+                                    <td class="border themeable-border px-4 py-3 font-semibold" style="color: #F86825;">End-to-end</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/report/data-value-proof/ko/index.html
+++ b/report/data-value-proof/ko/index.html
@@ -60,14 +60,14 @@
 
     <style>
         .stat-card {
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             padding: 1rem 1.25rem;
             margin-bottom: 0.75rem;
         }
         .stat-number {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #14b8a6;
+            color: #F86825;
         }
         .pipeline-step {
             display: flex;
@@ -347,7 +347,7 @@
                                     <td class="border themeable-border px-4 py-3 font-semibold">가치 증명 인프라</td>
                                     <td class="border themeable-border px-4 py-3 font-semibold">페블러스</td>
                                     <td class="border themeable-border px-4 py-3">진단-보완-증명</td>
-                                    <td class="border themeable-border px-4 py-3 font-semibold" style="color: #14b8a6;">엔드투엔드</td>
+                                    <td class="border themeable-border px-4 py-3 font-semibold" style="color: #F86825;">엔드투엔드</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/report/eupe-universal-encoder/en/index.html
+++ b/report/eupe-universal-encoder/en/index.html
@@ -70,7 +70,7 @@
         }
         .pipeline-stage .stage-label {
             display: inline-block;
-            background: #14b8a6;
+            background: #F86825;
             color: #fff;
             font-size: 0.72rem;
             font-weight: 700;
@@ -126,7 +126,7 @@
         }
         .encoder-card .encoder-strength {
             font-size: 0.8rem;
-            color: #14b8a6;
+            color: #F86825;
             font-weight: 600;
         }
         .encoder-card .encoder-weak {

--- a/report/eupe-universal-encoder/ko/index.html
+++ b/report/eupe-universal-encoder/ko/index.html
@@ -70,7 +70,7 @@
         }
         .pipeline-stage .stage-label {
             display: inline-block;
-            background: #14b8a6;
+            background: #F86825;
             color: #fff;
             font-size: 0.72rem;
             font-weight: 700;
@@ -126,7 +126,7 @@
         }
         .encoder-card .encoder-strength {
             font-size: 0.8rem;
-            color: #14b8a6;
+            color: #F86825;
             font-weight: 600;
         }
         .encoder-card .encoder-weak {

--- a/report/hermes-agent-growth-with-user/en/index.html
+++ b/report/hermes-agent-growth-with-user/en/index.html
@@ -137,7 +137,7 @@
                             <p class="font-bold themeable-heading mb-2">① Task Execution</p>
                             <p class="themeable-muted text-sm leading-relaxed">Parses user intent, calls appropriate skills, or synthesizes new ones. Execution context is preserved in memory.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">② Outcome Evaluation</p>
                             <p class="themeable-muted text-sm leading-relaxed">Self-evaluates success or failure. User feedback, error logs, and tool call patterns become inputs.</p>
                         </div>
@@ -145,7 +145,7 @@
                             <p class="font-bold themeable-heading mb-2">③ Skill Abstraction</p>
                             <p class="themeable-muted text-sm leading-relaxed">Generalizes recurring patterns into reusable skills. One-off code becomes reusable methods.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">④ Skill Refinement</p>
                             <p class="themeable-muted text-sm leading-relaxed">Updates existing skills with new experience. The evolution mechanism that handles the same job faster and more accurately.</p>
                         </div>
@@ -222,7 +222,7 @@
                             <p class="font-bold themeable-heading mb-2">Hermes Agent's Self-Evolution</p>
                             <p class="themeable-muted text-sm leading-relaxed">User intent → skill synthesis → evaluation → skill library update. Over time, more refined tool invocation.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">Data Greenhouse's Autonomous Operation</p>
                             <p class="themeable-muted text-sm leading-relaxed">Data diagnosis → quality enhancement → learning → pipeline update. Over time, more refined data operations.</p>
                         </div>
@@ -280,11 +280,11 @@
                                 <th class="text-left p-3 themeable-heading">Assessment</th>
                             </tr></thead>
                             <tbody class="themeable-muted">
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Error Fossilization</td><td class="p-3">v0.12.0 Autonomous Curator — auto prune/consolidate on 7-day cycle</td><td class="p-3" style="color: #14b8a6;">Partially addressed (internal automation)</td></tr>
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Feedback Loop Contamination</td><td class="p-3">v0.12.0 self-improvement review fork "substantially upgraded", v0.13.0 hallucination gate</td><td class="p-3" style="color: #14b8a6;">Partially mitigated (internal gates)</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Error Fossilization</td><td class="p-3">v0.12.0 Autonomous Curator — auto prune/consolidate on 7-day cycle</td><td class="p-3" style="color: #F86825;">Partially addressed (internal automation)</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Feedback Loop Contamination</td><td class="p-3">v0.12.0 self-improvement review fork "substantially upgraded", v0.13.0 hallucination gate</td><td class="p-3" style="color: #F86825;">Partially mitigated (internal gates)</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Distribution Shift</td><td class="p-3">No direct mention in release notes</td><td class="p-3" style="color: #ef4444;">Unaddressed</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Absence of External Verifier</td><td class="p-3">All new mechanisms remain internal self-evaluation</td><td class="p-3" style="color: #ef4444;">Unaddressed — Pebblous solution stays valid</td></tr>
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Regulatory & Governance Readiness</td><td class="p-3">v0.13.0 closes 8 P0 security issues, redaction ON by default</td><td class="p-3" style="color: #14b8a6;">In progress</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Regulatory & Governance Readiness</td><td class="p-3">v0.13.0 closes 8 P0 security issues, redaction ON by default</td><td class="p-3" style="color: #F86825;">In progress</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -339,7 +339,7 @@
                             <p class="font-bold themeable-heading mb-2">DataClinic's Role</p>
                             <p class="themeable-muted text-sm leading-relaxed">Diagnose agent-generated data externally. Detect distribution shift, contamination, and fossilization patterns early and signal the learning loop.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">Data Greenhouse's Role</p>
                             <p class="themeable-muted text-sm leading-relaxed">Automatically refine, synthesize, and enhance diagnosed data. The agent's self-evolution and the data's self-evolution operate in the same rhythm.</p>
                         </div>

--- a/report/hermes-agent-growth-with-user/ko/index.html
+++ b/report/hermes-agent-growth-with-user/ko/index.html
@@ -136,7 +136,7 @@
                             <p class="font-bold themeable-heading mb-2">① Task Execution</p>
                             <p class="themeable-muted text-sm leading-relaxed">사용자 의도를 파싱하고, 적절한 스킬을 호출하거나 새로 합성한다. 실행 컨텍스트는 메모리에 남는다.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">② Outcome Evaluation</p>
                             <p class="themeable-muted text-sm leading-relaxed">결과의 성공·실패를 자체 평가한다. 사용자 피드백, 오류 로그, 도구 호출 패턴이 입력이 된다.</p>
                         </div>
@@ -144,7 +144,7 @@
                             <p class="font-bold themeable-heading mb-2">③ Skill Abstraction</p>
                             <p class="themeable-muted text-sm leading-relaxed">반복되는 패턴을 일반화 가능한 스킬로 추상화한다. 일회성 코드가 재사용 가능한 메서드가 된다.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">④ Skill Refinement</p>
                             <p class="themeable-muted text-sm leading-relaxed">기존 스킬을 새로운 경험으로 갱신한다. 같은 일을 더 빠르고 정확하게 처리하는 진화 메커니즘이다.</p>
                         </div>
@@ -221,7 +221,7 @@
                             <p class="font-bold themeable-heading mb-2">Hermes Agent의 자가 진화</p>
                             <p class="themeable-muted text-sm leading-relaxed">사용자 의도 → 스킬 합성 → 평가 → 스킬 라이브러리 갱신. 시간이 갈수록 더 정교한 도구 호출.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">Data Greenhouse의 자율 운영</p>
                             <p class="themeable-muted text-sm leading-relaxed">데이터 진단 → 품질 보강 → 학습 → 파이프라인 갱신. 시간이 갈수록 더 정교한 데이터 운영.</p>
                         </div>
@@ -279,11 +279,11 @@
                                 <th class="text-left p-3 themeable-heading">평가</th>
                             </tr></thead>
                             <tbody class="themeable-muted">
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Error Fossilization</td><td class="p-3">v0.12.0 Autonomous Curator — 7일 주기 자동 prune/consolidate</td><td class="p-3" style="color: #14b8a6;">부분 해소 (내부 자동화)</td></tr>
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Feedback Loop Contamination</td><td class="p-3">v0.12.0 self-improvement review fork "대폭 업그레이드", v0.13.0 hallucination gate</td><td class="p-3" style="color: #14b8a6;">부분 보완 (내부 게이트 강화)</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Error Fossilization</td><td class="p-3">v0.12.0 Autonomous Curator — 7일 주기 자동 prune/consolidate</td><td class="p-3" style="color: #F86825;">부분 해소 (내부 자동화)</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Feedback Loop Contamination</td><td class="p-3">v0.12.0 self-improvement review fork "대폭 업그레이드", v0.13.0 hallucination gate</td><td class="p-3" style="color: #F86825;">부분 보완 (내부 게이트 강화)</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">Distribution Shift</td><td class="p-3">릴리스 노트에 직접적 대응 명시 없음</td><td class="p-3" style="color: #ef4444;">미해결</td></tr>
                                 <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">외부 검증자 부재</td><td class="p-3">모든 신규 메커니즘이 내부 자기 평가 기반</td><td class="p-3" style="color: #ef4444;">미해결 — 페블러스 솔루션 유효</td></tr>
-                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">규제·거버넌스 대응</td><td class="p-3">v0.13.0 P0 보안 8건 해소, redaction 기본 ON</td><td class="p-3" style="color: #14b8a6;">개선 진행 중</td></tr>
+                                <tr class="border-b themeable-border"><td class="p-3 font-bold themeable-heading">규제·거버넌스 대응</td><td class="p-3">v0.13.0 P0 보안 8건 해소, redaction 기본 ON</td><td class="p-3" style="color: #F86825;">개선 진행 중</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -338,7 +338,7 @@
                             <p class="font-bold themeable-heading mb-2">DataClinic의 역할</p>
                             <p class="themeable-muted text-sm leading-relaxed">에이전트가 생성한 데이터를 외부에서 진단. 분포 이동, 오염, 화석화 패턴을 조기 탐지하여 학습 루프에 신호를 보낸다.</p>
                         </div>
-                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #14b8a6;">
+                        <div class="themeable-card rounded-xl p-6" style="border-top: 4px solid #F86825;">
                             <p class="font-bold themeable-heading mb-2">Data Greenhouse의 역할</p>
                             <p class="themeable-muted text-sm leading-relaxed">진단된 데이터를 자동으로 정제, 합성, 보강. 에이전트의 자가 진화와 데이터의 자가 진화가 같은 호흡으로 작동한다.</p>
                         </div>

--- a/report/korea-ai-fund-report-2026-03/en/index.html
+++ b/report/korea-ai-fund-report-2026-03/en/index.html
@@ -422,8 +422,8 @@
                             <p class="font-semibold themeable-heading mb-1">DataClinic</p>
                             <p class="text-sm themeable-text-secondary">Manufacturing data preprocessing, quality evaluation, standardization, certification. MOTIE manufacturing AI project cluster is the primary target.</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #14b8a6;">
-                            <h4 class="text-3xl font-bold mb-2" style="color: #14b8a6;">8 Projects</h4>
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #F86825;">
+                            <h4 class="text-3xl font-bold mb-2" style="color: #F86825;">8 Projects</h4>
                             <p class="font-semibold themeable-heading mb-1">PebbloSim</p>
                             <p class="text-sm themeable-text-secondary">Medical data synthesis, Physical AI synthetic data, LLM data augmentation. Surging demand for synthetic data.</p>
                         </div>
@@ -566,9 +566,9 @@
                                 <li>Contact program officers at implementing agencies (KIAT, NIA, etc.)</li>
                             </ul>
                         </div>
-                        <div class="border-l-4 pl-6 pb-6" style="border-color: #14b8a6;">
+                        <div class="border-l-4 pl-6 pb-6" style="border-color: #F86825;">
                             <h3 class="text-xl font-bold themeable-heading mb-2">Phase 2: 1~3 Months</h3>
-                            <p class="text-sm font-semibold mb-2" style="color: #14b8a6;">Consortium Formation & Proposal Preparation</p>
+                            <p class="text-sm font-semibold mb-2" style="color: #F86825;">Consortium Formation & Proposal Preparation</p>
                             <ul class="list-disc list-inside themeable-text leading-relaxed space-y-1">
                                 <li>Sign MOUs with existing clients (Hyundai Motor, LG)</li>
                                 <li>Secure university and research institute partners</li>

--- a/report/korea-ai-fund-report-2026-03/ko/index.html
+++ b/report/korea-ai-fund-report-2026-03/ko/index.html
@@ -422,8 +422,8 @@
                             <p class="font-semibold themeable-heading mb-1">데이터 클리닉</p>
                             <p class="text-sm themeable-text-secondary">제조데이터 전처리, 품질평가, 표준화, 인증. 산업통상부 제조AI 과제군이 핵심 타겟.</p>
                         </div>
-                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #14b8a6;">
-                            <h4 class="text-3xl font-bold mb-2" style="color: #14b8a6;">8개</h4>
+                        <div class="themeable-bg-card border themeable-border rounded-lg p-6 border-l-4" style="border-left-color: #F86825;">
+                            <h4 class="text-3xl font-bold mb-2" style="color: #F86825;">8개</h4>
                             <p class="font-semibold themeable-heading mb-1">PebbloSim</p>
                             <p class="text-sm themeable-text-secondary">의료데이터 합성, 피지컬AI 합성데이터, LLM 데이터 증강. 합성데이터 수요 급증.</p>
                         </div>
@@ -566,9 +566,9 @@
                                 <li>산업기술진흥원, NIA 등 시행기관 담당자 접촉</li>
                             </ul>
                         </div>
-                        <div class="border-l-4 pl-6 pb-6" style="border-color: #14b8a6;">
+                        <div class="border-l-4 pl-6 pb-6" style="border-color: #F86825;">
                             <h3 class="text-xl font-bold themeable-heading mb-2">Phase 2: 1~3개월</h3>
-                            <p class="text-sm font-semibold mb-2" style="color: #14b8a6;">컨소시엄 구성 및 제안서 준비</p>
+                            <p class="text-sm font-semibold mb-2" style="color: #F86825;">컨소시엄 구성 및 제안서 준비</p>
                             <ul class="list-disc list-inside themeable-text leading-relaxed space-y-1">
                                 <li>기존 고객사(현대차, LG)와 MOU 체결</li>
                                 <li>대학·연구소 협력기관 확보</li>

--- a/report/llm-self-seizure/en/index.html
+++ b/report/llm-self-seizure/en/index.html
@@ -455,7 +455,7 @@
                     </p>
                     <div class="nfc-nfd-diagram">
                         <div class="diagram-col">
-                            <p class="diagram-label" style="color: #14b8a6;">NFC (Composed)</p>
+                            <p class="diagram-label" style="color: #F86825;">NFC (Composed)</p>
                             <p class="diagram-value themeable-text">스 스 로</p>
                             <p class="diagram-detail themeable-muted">3 code points / 9 bytes (UTF-8)</p>
                             <p class="diagram-detail themeable-muted">U+C2A4 U+C2A4 U+B85C</p>

--- a/report/llm-self-seizure/ko/index.html
+++ b/report/llm-self-seizure/ko/index.html
@@ -452,7 +452,7 @@
                     </p>
                     <div class="nfc-nfd-diagram">
                         <div class="diagram-col">
-                            <p class="diagram-label" style="color: #14b8a6;">NFC (완성형)</p>
+                            <p class="diagram-label" style="color: #F86825;">NFC (완성형)</p>
                             <p class="diagram-value themeable-text">스 스 로</p>
                             <p class="diagram-detail themeable-muted">3 code points / 9 bytes (UTF-8)</p>
                             <p class="diagram-detail themeable-muted">U+C2A4 U+C2A4 U+B85C</p>

--- a/report/mathematica-15-years/en/index.html
+++ b/report/mathematica-15-years/en/index.html
@@ -66,7 +66,7 @@
         .timeline-card {
             position: relative;
             padding-left: 2rem;
-            border-left: 3px solid #14b8a6;
+            border-left: 3px solid #F86825;
         }
         .timeline-card::before {
             content: '';
@@ -354,7 +354,7 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">Startup and Transition (2020-2023)</h2>
 
                     <div class="flex items-center gap-3 mb-6">
-                        <span class="era-badge" style="background: rgba(20,184,166,0.15); color: #14b8a6;">Pebblous: 717 files</span>
+                        <span class="era-badge" style="background: rgba(20,184,166,0.15); color: #F86825;">Pebblous: 717 files</span>
                         <span class="text-sm themeable-muted">Founding · Art Camp · The LLM Era</span>
                     </div>
 
@@ -849,8 +849,8 @@
                 { name: 'Lectures (WTC/SNU)', start: 2018, end: 2023, count: 48, color: '#585858' },
                 { name: 'Art Camp', start: 2021, end: 2021, count: 31, color: '#f97316' },
                 { name: 'Pebblous [CLV]', start: 2022, end: 2026, count: 427, color: '#808080' },
-                { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#2dd4bf' },
-                { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#5eead4' }
+                { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#FFB092' },
+                { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#FFC6B1' }
             ];
 
             new Chart(document.getElementById('chart-timeline'), {

--- a/report/mathematica-15-years/ko/index.html
+++ b/report/mathematica-15-years/ko/index.html
@@ -66,7 +66,7 @@
         .timeline-card {
             position: relative;
             padding-left: 2rem;
-            border-left: 3px solid #14b8a6;
+            border-left: 3px solid #F86825;
         }
         .timeline-card::before {
             content: '';
@@ -354,7 +354,7 @@
                     <h2 class="text-3xl font-bold themeable-heading mb-8">창업과 전환 (2020~2023)</h2>
 
                     <div class="flex items-center gap-3 mb-6">
-                        <span class="era-badge" style="background: rgba(20,184,166,0.15); color: #14b8a6;">페블러스 717개</span>
+                        <span class="era-badge" style="background: rgba(20,184,166,0.15); color: #F86825;">페블러스 717개</span>
                         <span class="text-sm themeable-muted">창업 · Art Camp · LLM 시대</span>
                     </div>
 
@@ -849,8 +849,8 @@
                 { name: '강의 (WTC/서울대)', start: 2018, end: 2023, count: 48, color: '#585858' },
                 { name: 'Art Camp', start: 2021, end: 2021, count: 31, color: '#f97316' },
                 { name: '페블러스 [CLV]', start: 2022, end: 2026, count: 427, color: '#808080' },
-                { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#2dd4bf' },
-                { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#5eead4' }
+                { name: 'LG PebbloScope', start: 2025, end: 2025, count: 189, color: '#FFB092' },
+                { name: 'LixReport', start: 2025, end: 2025, count: 34, color: '#FFC6B1' }
             ];
 
             new Chart(document.getElementById('chart-timeline'), {

--- a/report/openmetadata-ai-ready-data-2026-04/en/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/en/index.html
@@ -305,14 +305,14 @@
                                 </div>
                             </div>
                             <div class="flex justify-center text-xl" style="color: #94a3b8;">↓</div>
-                            <div class="themeable-bg-card border themeable-border rounded-lg p-5 border-l-4" style="border-left-color: #14b8a6;">
+                            <div class="themeable-bg-card border themeable-border rounded-lg p-5 border-l-4" style="border-left-color: #F86825;">
                                 <div class="flex items-start justify-between gap-4">
                                     <div>
-                                        <p class="text-xs font-semibold mb-1 uppercase tracking-wide" style="color: #14b8a6;">Stage 2 — Data Operating System</p>
+                                        <p class="text-xs font-semibold mb-1 uppercase tracking-wide" style="color: #F86825;">Stage 2 — Data Operating System</p>
                                         <p class="font-bold themeable-heading mb-1">DataGreenhouse</p>
                                         <p class="text-sm themeable-text leading-relaxed">Consumes OpenMetadata output to run Neural + Symbolic dual observation. Executes the autonomous <strong>Observe → Orchestrate → Act → Govern</strong> loop continuously, closing the gap between detection and remediation.</p>
                                     </div>
-                                    <span class="text-2xl shrink-0" style="color: #14b8a6;">⚙️</span>
+                                    <span class="text-2xl shrink-0" style="color: #F86825;">⚙️</span>
                                 </div>
                             </div>
                             <div class="flex justify-center text-xl" style="color: #94a3b8;">↓</div>

--- a/report/openmetadata-ai-ready-data-2026-04/ko/index.html
+++ b/report/openmetadata-ai-ready-data-2026-04/ko/index.html
@@ -307,14 +307,14 @@
                                 </div>
                             </div>
                             <div class="flex justify-center text-xl" style="color: #94a3b8;">↓</div>
-                            <div class="themeable-bg-card border themeable-border rounded-lg p-5 border-l-4" style="border-left-color: #14b8a6;">
+                            <div class="themeable-bg-card border themeable-border rounded-lg p-5 border-l-4" style="border-left-color: #F86825;">
                                 <div class="flex items-start justify-between gap-4">
                                     <div>
-                                        <p class="text-xs font-semibold mb-1 uppercase tracking-wide" style="color: #14b8a6;">Stage 2 — 데이터 운영 OS</p>
+                                        <p class="text-xs font-semibold mb-1 uppercase tracking-wide" style="color: #F86825;">Stage 2 — 데이터 운영 OS</p>
                                         <p class="font-bold themeable-heading mb-1">DataGreenhouse</p>
                                         <p class="text-sm themeable-text leading-relaxed">OpenMetadata 메타데이터를 소비하여 Neural + Symbolic 듀얼 관측 수행. <em style="font-style:normal;font-weight:600;">관측(Observe) → 판단(Orchestrate) → 행동(Action) → 증명(Govern)</em> 루프를 자율적으로 실행한다.</p>
                                     </div>
-                                    <span class="text-2xl shrink-0" style="color: #14b8a6;">⚙️</span>
+                                    <span class="text-2xl shrink-0" style="color: #F86825;">⚙️</span>
                                 </div>
                             </div>
                             <div class="flex justify-center text-xl" style="color: #94a3b8;">↓</div>

--- a/report/physical-ai-industry-landscape/en/index.html
+++ b/report/physical-ai-industry-landscape/en/index.html
@@ -87,7 +87,7 @@
         .valuation-card .growth-badge {
             display: inline-block;
             background: rgba(20,184,166,0.15);
-            color: #2dd4bf;
+            color: #FFB092;
             font-size: 0.75rem;
             font-weight: 700;
             padding: 0.15rem 0.5rem;
@@ -136,7 +136,7 @@
         .invest-table .highlight-row td {
             background: rgba(20,184,166,0.06);
             font-weight: 600;
-            color: #2dd4bf;
+            color: #FFB092;
         }
 
         /* Platform comparison */
@@ -409,25 +409,25 @@
                                 <tr>
                                     <td style="font-weight:700;">Figure AI</td>
                                     <td>2022</td>
-                                    <td style="color:#2dd4bf;font-weight:700;">$39B</td>
+                                    <td style="color:#FFB092;font-weight:700;">$39B</td>
                                     <td>NVIDIA, Microsoft, OpenAI, Bezos</td>
                                 </tr>
                                 <tr>
                                     <td style="font-weight:700;">Skild AI</td>
                                     <td>2023</td>
-                                    <td style="color:#2dd4bf;font-weight:700;">$14B</td>
+                                    <td style="color:#FFB092;font-weight:700;">$14B</td>
                                     <td>SoftBank, NVIDIA</td>
                                 </tr>
                                 <tr>
                                     <td style="font-weight:700;">Apptronik</td>
                                     <td>2016</td>
-                                    <td style="color:#2dd4bf;font-weight:700;">$5.3B</td>
+                                    <td style="color:#FFB092;font-weight:700;">$5.3B</td>
                                     <td>Google, Mercedes, John Deere</td>
                                 </tr>
                                 <tr>
                                     <td style="font-weight:700;">1X Technologies</td>
                                     <td>2014</td>
-                                    <td style="color:#2dd4bf;font-weight:700;">~$10B</td>
+                                    <td style="color:#FFB092;font-weight:700;">~$10B</td>
                                     <td>OpenAI</td>
                                 </tr>
                                 <tr>

--- a/report/solar-vs-glm/solar-vs-glm-forensic/en/index.html
+++ b/report/solar-vs-glm/solar-vs-glm-forensic/en/index.html
@@ -111,7 +111,7 @@
             --text-secondary: #334155;
             --text-muted: #64748b;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #e2e8f0;
         }
 
@@ -123,7 +123,7 @@
             --text-secondary: #cbd5e1;
             --text-muted: #94a3b8;
             --accent-color: #F86825;
-            --teal-color: #14b8a6;
+            --teal-color: #F86825;
             --border-color: #334155;
         }
 
@@ -135,7 +135,7 @@
             --text-secondary: #5a534a;
             --text-muted: #78716c;
             --accent-color: #F86825;
-            --teal-color: #0d9488;
+            --teal-color: #C64900;
             --border-color: #d6cec0;
         }
 
@@ -260,11 +260,11 @@
         }
 
         .comparison-card.derivation {
-            border-top: 4px solid #ef4444;
+            border-top: 4px solid #F86825;
         }
 
         .comparison-card.independence {
-            border-top: 4px solid #0d9488;
+            border-top: 4px solid #C64900;
         }
 
         .faq-item {
@@ -514,13 +514,13 @@
                             </thead>
                             <tbody class="themeable-text">
                                 <tr>
-                                    <td class="font-medium" style="color: #ef4444;">1. Allegation</td>
+                                    <td class="font-medium" style="color: #F86825;">1. Allegation</td>
                                     <td>Sionic AI</td>
                                     <td>"The code is identical, and the weight similarity is 0.99. This is 100% copied."</td>
                                     <td>🚨 Solar in crisis</td>
                                 </tr>
                                 <tr>
-                                    <td class="font-medium" style="color: #eab308;">2. Rebuttal</td>
+                                    <td class="font-medium" style="color: #F86825;">2. Rebuttal</td>
                                     <td>Hyunwoong Ko</td>
                                     <td>"MS Phi-2 has the same code too. It's just a standard template."</td>
                                     <td>🛡️ Counterattack begins</td>
@@ -687,8 +687,8 @@
                     </p>
 
                     <div class="space-y-4 mb-6">
-                        <div class="themeable-card rounded-xl p-5" style="border-left: 4px solid #ef4444;">
-                            <h4 class="font-bold mb-2" style="color: #ef4444;">Derivation Verification Question</h4>
+                        <div class="themeable-card rounded-xl p-5" style="border-left: 4px solid #F86825;">
+                            <h4 class="font-bold mb-2" style="color: #F86825;">Derivation Verification Question</h4>
                             <p class="themeable-text">
                                 "Does the selective preservation pattern (LN is identical, everything else differs) persist when we remove RMSNorm's mathematical properties and
                                 compare <strong>high-information tensors (Attention Weights)</strong>?"
@@ -787,8 +787,8 @@
                         </table>
                     </div>
 
-                    <div class="themeable-card rounded-xl p-5 mb-8" style="border-left: 4px solid #ef4444;">
-                        <h4 class="font-bold mb-2" style="color: #ef4444;">Sionic AI's Logic</h4>
+                    <div class="themeable-card rounded-xl p-5 mb-8" style="border-left: 4px solid #F86825;">
+                        <h4 class="font-bold mb-2" style="color: #F86825;">Sionic AI's Logic</h4>
                         <p class="themeable-text">
                             If the models were independently trained, a 0.99 similarity could not occur by chance (P-value < 10^(-1000)).
                             Therefore, they <strong>took the skeleton (LN) and swapped out only the muscles (Attn/MLP)</strong>.
@@ -852,7 +852,7 @@
                 <!-- Verdict Section - 조경현 교수 분석 -->
                 <section id="verdict" class="mb-12">
                     <div class="section-header">
-                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #0d9488, #0f766e);">
+                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #C64900, #0f766e);">
                             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
@@ -872,7 +872,7 @@
 
                         <div class="grid md:grid-cols-2 gap-6">
                             <div class="p-4 rounded-lg" style="background: rgba(239, 68, 68, 0.1);">
-                                <h4 class="font-bold mb-2" style="color: #ef4444;">Raw Cosine (The Truth Behind 0.99)</h4>
+                                <h4 class="font-bold mb-2" style="color: #F86825;">Raw Cosine (The Truth Behind 0.99)</h4>
                                 <ul class="text-sm themeable-text space-y-2">
                                     <li>LayerNorm/RMSNorm weights inherently have values close to <strong>1.0</strong></li>
                                     <li>Even randomly comparing different layers yields a similarity of <strong>0.95</strong></li>
@@ -941,8 +941,8 @@
 
                     <!-- Stats Grid -->
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-                        <div class="stat-card" style="--accent-color: #ef4444;">
-                            <div class="stat-value" style="color: #ef4444;">0.99</div>
+                        <div class="stat-card" style="--accent-color: #F86825;">
+                            <div class="stat-value" style="color: #F86825;">0.99</div>
                             <div class="stat-label">Raw Cosine<br>(Illusion)</div>
                         </div>
                         <div class="stat-card" style="--accent-color: var(--teal-color);">
@@ -1110,7 +1110,7 @@
                                     </div>
                                     <p class="text-sm themeable-text">
                                         The <code class="px-2 py-1 rounded text-xs" style="background: var(--bg-secondary);">sionic-ai/solar-vs-glm</code> repository
-                                        currently returns <strong style="color: #ef4444;">404 Not Found</strong>. The analysis materials that served as the basis for the allegations have been withdrawn.
+                                        currently returns <strong style="color: #F86825;">404 Not Found</strong>. The analysis materials that served as the basis for the allegations have been withdrawn.
                                     </p>
                                 </div>
                             </div>
@@ -1265,7 +1265,7 @@
                 <!-- PDF Download Section -->
                 <section id="download" class="mb-12">
                     <div class="section-header">
-                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #0d9488, #0f766e);">
+                        <div class="icon-wrapper" style="background: linear-gradient(135deg, #C64900, #0f766e);">
                             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                             </svg>

--- a/report/solar-vs-glm/solar-vs-glm-forensic/ko/index.html
+++ b/report/solar-vs-glm/solar-vs-glm-forensic/ko/index.html
@@ -176,13 +176,13 @@
                             </thead>
                             <tbody class="themeable-text">
                                 <tr>
-                                    <td class="font-medium" style="color: #ef4444;">1. 의혹 제기</td>
+                                    <td class="font-medium" style="color: #F86825;">1. 의혹 제기</td>
                                     <td>Sionic AI</td>
                                     <td>"코드가 같고, 가중치 유사도가 0.99다. 이건 100% 베낀 것이다."</td>
                                     <td>🚨 Solar 위기</td>
                                 </tr>
                                 <tr>
-                                    <td class="font-medium" style="color: #eab308;">2. 정황 반박</td>
+                                    <td class="font-medium" style="color: #F86825;">2. 정황 반박</td>
                                     <td>Hyunwoong Ko</td>
                                     <td>"MS Phi-2도 코드는 똑같다. 코드는 그냥 표준 템플릿 쓴 거다."</td>
                                     <td>🛡️ 반격 시작</td>
@@ -337,8 +337,8 @@
                     </p>
 
                     <div class="space-y-4 mb-6">
-                        <div class="themeable-card rounded-xl p-5" style="border-left: 4px solid #ef4444;">
-                            <h4 class="font-bold mb-2" style="color: #ef4444;">파생설 검증 질문</h4>
+                        <div class="themeable-card rounded-xl p-5" style="border-left: 4px solid #F86825;">
+                            <h4 class="font-bold mb-2" style="color: #F86825;">파생설 검증 질문</h4>
                             <p class="themeable-text">
                                 "선택적 보존 패턴(LN은 같고 나머지는 다름)이, RMSNorm의 수학적 특성을 제거하고
                                 <strong>고정보 텐서(Attention Weight)</strong>를 비교했을 때도 유지되는가?"
@@ -433,8 +433,8 @@
                         </table>
                     </div>
 
-                    <div class="themeable-card rounded-xl p-5 mb-8" style="border-left: 4px solid #ef4444;">
-                        <h4 class="font-bold mb-2" style="color: #ef4444;">시오닉 AI의 논리</h4>
+                    <div class="themeable-card rounded-xl p-5 mb-8" style="border-left: 4px solid #F86825;">
+                        <h4 class="font-bold mb-2" style="color: #F86825;">시오닉 AI의 논리</h4>
                         <p class="themeable-text">
                             독립적으로 학습된 모델이라면 우연히 0.99 유사도가 나올 수 없습니다(P-value < 10^(-1000)).
                             따라서 <strong>뼈대(LN)를 가져다 놓고 근육(Attn/MLP)만 갈아끼운 것</strong>입니다.
@@ -514,7 +514,7 @@
 
                         <div class="grid md:grid-cols-2 gap-6">
                             <div class="p-4 rounded-lg" style="background: rgba(239, 68, 68, 0.1);">
-                                <h4 class="font-bold mb-2" style="color: #ef4444;">Raw Cosine (0.99의 진실)</h4>
+                                <h4 class="font-bold mb-2" style="color: #F86825;">Raw Cosine (0.99의 진실)</h4>
                                 <ul class="text-sm themeable-text space-y-2">
                                     <li>LayerNorm/RMSNorm의 가중치는 특성상 대부분 <strong>1.0 근처</strong>의 값을 가짐</li>
                                     <li>무작위로 다른 레이어끼리 비교해도 유사도가 <strong>0.95</strong>가 나옴</li>
@@ -584,7 +584,7 @@
                     <!-- Stats Grid -->
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                         <div class="themeable-card rounded-xl p-6 text-center">
-                            <div class="text-4xl font-bold mb-2" style="color: #ef4444;">0.99</div>
+                            <div class="text-4xl font-bold mb-2" style="color: #F86825;">0.99</div>
                             <div class="text-sm themeable-muted">Raw Cosine<br>(착시)</div>
                         </div>
                         <div class="themeable-card rounded-xl p-6 text-center">
@@ -744,7 +744,7 @@
                                     </div>
                                     <p class="text-sm themeable-text">
                                         <code class="px-2 py-1 rounded text-xs" style="background: var(--bg-secondary);">sionic-ai/solar-vs-glm</code> 저장소는
-                                        현재 <strong style="color: #ef4444;">404 Not Found</strong> 상태입니다. 의혹 제기의 근거가 되었던 분석 자료가 철회되었습니다.
+                                        현재 <strong style="color: #F86825;">404 Not Found</strong> 상태입니다. 의혹 제기의 근거가 되었던 분석 자료가 철회되었습니다.
                                     </p>
                                 </div>
                             </div>

--- a/story/dataclinic-report-116-birds525-story-pb/en/index.html
+++ b/story/dataclinic-report-116-birds525-story-pb/en/index.html
@@ -117,7 +117,7 @@
         .compare-table th:last-child { border-radius: 0 0.5rem 0 0; }
         .compare-table td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--border-color); color: var(--text-secondary); }
         .compare-table tr:hover td { background-color: var(--bg-secondary); }
-        .compare-table .better { color:#14b8a6; font-weight: 700; }
+        .compare-table .better { color:#F86825; font-weight: 700; }
         .compare-table .worse { color: #dc2626; font-weight: 700; }
         .compare-table .warning { color: #d97706; font-weight: 700; }
 
@@ -175,7 +175,7 @@
 
         .arrow-badge {
             font-size: 1.5rem;
-            color:#14b8a6;
+            color:#F86825;
             font-weight: 900;
             margin: 0 0.5rem;
         }

--- a/story/dataclinic-report-116-birds525-story-pb/ko/index.html
+++ b/story/dataclinic-report-116-birds525-story-pb/ko/index.html
@@ -115,7 +115,7 @@
         .compare-table th:last-child { border-radius: 0 0.5rem 0 0; }
         .compare-table td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--border-color); color: var(--text-secondary); }
         .compare-table tr:hover td { background-color: var(--bg-secondary); }
-        .compare-table .better { color:#14b8a6; font-weight: 700; }
+        .compare-table .better { color:#F86825; font-weight: 700; }
         .compare-table .worse { color: #dc2626; font-weight: 700; }
         .compare-table .warning { color: #d97706; font-weight: 700; }
 
@@ -173,7 +173,7 @@
 
         .arrow-badge {
             font-size: 1.5rem;
-            color:#14b8a6;
+            color:#F86825;
             font-weight: 900;
             margin: 0 0.5rem;
         }

--- a/story/dataclinic-report-123-imagenet-story-pb/en/index.html
+++ b/story/dataclinic-report-123-imagenet-story-pb/en/index.html
@@ -133,7 +133,7 @@
         .timeline { position: relative; padding-left: 2rem; margin: 1.5rem 0; }
         .timeline::before {
             content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0;
-            width: 2px; background: linear-gradient(to bottom, var(--accent-color), #0d9488);
+            width: 2px; background: linear-gradient(to bottom, var(--accent-color), #C64900);
         }
         .timeline-item { position: relative; margin-bottom: 1.5rem; }
         .timeline-item::before {
@@ -757,7 +757,7 @@
                                 <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/sports%20car.png" alt="Sports Car mean image" loading="lazy">
                                 <p class="text-xs themeable-muted mt-1">Sports Car</p>
                             </div>
-                            <div class="vs-label" style="color:#0d9488;">≈</div>
+                            <div class="vs-label" style="color:#C64900;">≈</div>
                             <div style="text-align:center;">
                                 <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/convertible.png" alt="Convertible mean image" loading="lazy">
                                 <p class="text-xs themeable-muted mt-1">Convertible</p>

--- a/story/dataclinic-report-123-imagenet-story-pb/ko/index.html
+++ b/story/dataclinic-report-123-imagenet-story-pb/ko/index.html
@@ -133,7 +133,7 @@
         .timeline { position: relative; padding-left: 2rem; margin: 1.5rem 0; }
         .timeline::before {
             content: ''; position: absolute; left: 0.5rem; top: 0; bottom: 0;
-            width: 2px; background: linear-gradient(to bottom, var(--accent-color), #0d9488);
+            width: 2px; background: linear-gradient(to bottom, var(--accent-color), #C64900);
         }
         .timeline-item { position: relative; margin-bottom: 1.5rem; }
         .timeline-item::before {
@@ -751,7 +751,7 @@
                                 <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/sports%20car.png" alt="Sports Car 평균 이미지" loading="lazy">
                                 <p class="text-xs themeable-muted mt-1">Sports Car</p>
                             </div>
-                            <div class="vs-label" style="color:#0d9488;">≈</div>
+                            <div class="vs-label" style="color:#C64900;">≈</div>
                             <div style="text-align:center;">
                                 <img src="https://cdn.dataclinic.ai/diagnosis_results/result_v.1.4.0/imagenet/level-1/english/meanimage/convertible.png" alt="Convertible 평균 이미지" loading="lazy">
                                 <p class="text-xs themeable-muted mt-1">Convertible</p>

--- a/story/dataclinic-report-124-navydl-story-pb/en/index.html
+++ b/story/dataclinic-report-124-navydl-story-pb/en/index.html
@@ -94,19 +94,19 @@
         .grade-bar { display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem; }
         .grade-label { font-size: .875rem; font-weight: 600; width: 6rem; color: var(--text-secondary); }
         .grade-pill { font-size: .75rem; font-weight: 700; padding: .25rem .875rem; border-radius: 9999px; }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
         .key-insight { background-color: var(--bg-secondary); border-left: 4px solid var(--accent-color); border-radius: 0 .5rem .5rem 0; padding: 1rem 1.25rem; font-size: .875rem; color: var(--text-secondary); line-height: 1.7; }
         .synth-code { font-family: 'Courier New',monospace; font-size: .875rem; background-color: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: .5rem; padding: 1rem; line-height: 1.8; }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: .5rem; object-fit: cover; height: 160px; }
         .compare-label { font-size: .875rem; font-weight: 600; margin-top: .5rem; color: var(--text-secondary); }
         .density-badge { display: inline-block; font-size: .6875rem; font-weight: 700; padding: .125rem .5rem; border-radius: 9999px; margin-top: .25rem; }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low { background-color: #fee2e2; color: #991b1b; }
         .sensor-card { background-color: var(--bg-card); border: 1px solid var(--border-color); border-radius: .75rem; overflow: hidden; }
         .sensor-img { width: 100%; height: 200px; object-fit: cover; }

--- a/story/dataclinic-report-124-navydl-story-pb/ko/index.html
+++ b/story/dataclinic-report-124-navydl-story-pb/ko/index.html
@@ -94,19 +94,19 @@
         .grade-bar { display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem; }
         .grade-label { font-size: .875rem; font-weight: 600; width: 6rem; color: var(--text-secondary); }
         .grade-pill { font-size: .75rem; font-weight: 700; padding: .25rem .875rem; border-radius: 9999px; }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
         .key-insight { background-color: var(--bg-secondary); border-left: 4px solid var(--accent-color); border-radius: 0 .5rem .5rem 0; padding: 1rem 1.25rem; font-size: .875rem; color: var(--text-secondary); line-height: 1.7; }
         .synth-code { font-family: 'Courier New',monospace; font-size: .875rem; background-color: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: .5rem; padding: 1rem; line-height: 1.8; }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: .5rem; object-fit: cover; height: 160px; }
         .compare-label { font-size: .875rem; font-weight: 600; margin-top: .5rem; color: var(--text-secondary); }
         .density-badge { display: inline-block; font-size: .6875rem; font-weight: 700; padding: .125rem .5rem; border-radius: 9999px; margin-top: .25rem; }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low { background-color: #fee2e2; color: #991b1b; }
         .sensor-card { background-color: var(--bg-card); border: 1px solid var(--border-color); border-radius: .75rem; overflow: hidden; }
         .sensor-img { width: 100%; height: 200px; object-fit: cover; }

--- a/story/dataclinic-report-128-thermalcamera-story-pb/en/index.html
+++ b/story/dataclinic-report-128-thermalcamera-story-pb/en/index.html
@@ -1003,7 +1003,7 @@ Person-Anomaly-Identify/<span class="code-var">CAR_AON_21.02.05_CIC_P1505-P1513_
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color:#0d9488;">
+                    <div class="misclass-scenario" style="border-color:#C64900;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ Direction of the fix — standardize at the collection stage</h3>
                         <p class="text-sm themeable-text leading-relaxed mb-3">
                             Dimensionality optimization widening the normal/anomaly gap 3× is a clear win. But what dimensions cannot sharpen, the camera has to fix.

--- a/story/dataclinic-report-128-thermalcamera-story-pb/ko/index.html
+++ b/story/dataclinic-report-128-thermalcamera-story-pb/ko/index.html
@@ -1003,7 +1003,7 @@
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color:#0d9488;">
+                    <div class="misclass-scenario" style="border-color:#C64900;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ 해결의 방향 — 데이터 수집 단계의 표준화</h3>
                         <p class="text-sm themeable-text leading-relaxed mb-3">
                             차원 최적화가 정상/이상 간격을 3배 벌려준 것은 분명한 성과입니다. 그러나 차원으로 좁힐 수 없는 문제는 차원이 아닌 카메라에서 풀어야 합니다.

--- a/story/dataclinic-report-131-industrialwaste-story-pb/en/index.html
+++ b/story/dataclinic-report-131-industrialwaste-story-pb/en/index.html
@@ -136,7 +136,7 @@
         .grade-bar { display:flex; align-items:center; gap:.75rem; margin-bottom:.75rem; }
         .grade-label { font-size:.875rem; font-weight:600; width:7rem; color:var(--text-secondary); }
         .grade-pill { font-size:.75rem; font-weight:700; padding:.25rem .875rem; border-radius:9999px; }
-        .grade-good { background-color:#d1fae5; color:#14b8a6; }
+        .grade-good { background-color:#d1fae5; color:#F86825; }
         .grade-medium { background-color:#fef9c3; color:#713f12; }
         .grade-bad { background-color:#fee2e2; color:#991b1b; }
 
@@ -152,7 +152,7 @@
         .tag-metal { background-color:#fef3c7; color:#92400e; }
         .tag-glass { background-color:#dbeafe; color:#1e40af; }
         .tag-fiber { background-color:#ede9fe; color:#6b21a8; }
-        .tag-plastic { background-color:#d1fae5; color:#14b8a6; }
+        .tag-plastic { background-color:#d1fae5; color:#F86825; }
         .tag-paper { background-color:#fce7f3; color:#9d174d; }
         .tag-concrete { background-color:#f1f5f9; color:#475569; }
 
@@ -563,7 +563,7 @@
                                 <div class="text-xs themeable-muted">Class Average</div>
                             </div>
                             <div>
-                                <div class="text-2xl font-black" style="color:#14b8a6;">79,560</div>
+                                <div class="text-2xl font-black" style="color:#F86825;">79,560</div>
                                 <div class="text-xs themeable-muted">Max Class</div>
                             </div>
                         </div>

--- a/story/dataclinic-report-131-industrialwaste-story-pb/ko/index.html
+++ b/story/dataclinic-report-131-industrialwaste-story-pb/ko/index.html
@@ -136,7 +136,7 @@
         .grade-bar { display:flex; align-items:center; gap:.75rem; margin-bottom:.75rem; }
         .grade-label { font-size:.875rem; font-weight:600; width:7rem; color:var(--text-secondary); }
         .grade-pill { font-size:.75rem; font-weight:700; padding:.25rem .875rem; border-radius:9999px; }
-        .grade-good { background-color:#d1fae5; color:#14b8a6; }
+        .grade-good { background-color:#d1fae5; color:#F86825; }
         .grade-medium { background-color:#fef9c3; color:#713f12; }
         .grade-bad { background-color:#fee2e2; color:#991b1b; }
 
@@ -152,7 +152,7 @@
         .tag-metal { background-color:#fef3c7; color:#92400e; }
         .tag-glass { background-color:#dbeafe; color:#1e40af; }
         .tag-fiber { background-color:#ede9fe; color:#6b21a8; }
-        .tag-plastic { background-color:#d1fae5; color:#14b8a6; }
+        .tag-plastic { background-color:#d1fae5; color:#F86825; }
         .tag-paper { background-color:#fce7f3; color:#9d174d; }
         .tag-concrete { background-color:#f1f5f9; color:#475569; }
 
@@ -563,7 +563,7 @@
                                 <div class="text-xs themeable-muted">클래스 평균</div>
                             </div>
                             <div>
-                                <div class="text-2xl font-black" style="color:#14b8a6;">79,560장</div>
+                                <div class="text-2xl font-black" style="color:#F86825;">79,560장</div>
                                 <div class="text-xs themeable-muted">최대 클래스</div>
                             </div>
                         </div>

--- a/story/dataclinic-report-224-pbls-military-story-pb/en/index.html
+++ b/story/dataclinic-report-224-pbls-military-story-pb/en/index.html
@@ -158,7 +158,7 @@
             font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem;
             border-radius: 9999px;
         }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
         .synth-code {
@@ -167,7 +167,7 @@
             border-radius: 0.5rem; padding: 1rem; line-height: 1.8;
         }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: 0.5rem; object-fit: cover; height: 160px; }
@@ -176,7 +176,7 @@
             display: inline-block; font-size: 0.6875rem; font-weight: 700;
             padding: 0.125rem 0.5rem; border-radius: 9999px; margin-top: 0.25rem;
         }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low { background-color: #fee2e2; color: #991b1b; }
         .warning-box {
             background-color: #fff7ed; border: 1px solid #fed7aa;
@@ -1134,7 +1134,7 @@
                                 <div class="misclass-card-info">
                                     <div class="class-label">❌ AI Misjudgment: K-9 Friendly Howitzer?</div>
                                     <div class="param-label">sn1 · en3(standard) · bg5</div>
-                                    <div class="param-label"><span class="density-badge density-high" style="background-color:#d1fae5;color:#14b8a6;">Density 1.285 — High-density core</span></div>
+                                    <div class="param-label"><span class="density-badge density-high" style="background-color:#d1fae5;color:#F86825;">Density 1.285 — High-density core</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1155,7 +1155,7 @@
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color: #14b8a6;">
+                    <div class="misclass-scenario" style="border-color: #F86825;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ Solution: Reinforce Low-Density Conditions</h3>
                         <p class="text-sm themeable-text leading-relaxed">
                             By <strong>generating additional</strong> T-80U images with en4 (low-visibility) and diverse background combinations, the low-density region fills in and IFF reliability improves.

--- a/story/dataclinic-report-224-pbls-military-story-pb/ko/index.html
+++ b/story/dataclinic-report-224-pbls-military-story-pb/ko/index.html
@@ -157,7 +157,7 @@
             font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem;
             border-radius: 9999px;
         }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
         .synth-code {
@@ -166,7 +166,7 @@
             border-radius: 0.5rem; padding: 1rem; line-height: 1.8;
         }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: 0.5rem; object-fit: cover; height: 160px; }
@@ -175,7 +175,7 @@
             display: inline-block; font-size: 0.6875rem; font-weight: 700;
             padding: 0.125rem 0.5rem; border-radius: 9999px; margin-top: 0.25rem;
         }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low { background-color: #fee2e2; color: #991b1b; }
         .warning-box {
             background-color: #fff7ed; border: 1px solid #fed7aa;
@@ -1267,7 +1267,7 @@
                                 <div class="misclass-card-info">
                                     <div class="class-label">❌ AI 오판: K-9 아군 자주포?</div>
                                     <div class="param-label">sn1 · en3(표준 환경) · bg5</div>
-                                    <div class="param-label"><span class="density-badge density-high" style="background-color:#d1fae5;color:#14b8a6;">밀도 1.285 — 고밀도 핵심</span></div>
+                                    <div class="param-label"><span class="density-badge density-high" style="background-color:#d1fae5;color:#F86825;">밀도 1.285 — 고밀도 핵심</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1288,7 +1288,7 @@
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color: #14b8a6;">
+                    <div class="misclass-scenario" style="border-color: #F86825;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ 해결: 저밀도 조건의 데이터 보강</h3>
                         <p class="text-sm themeable-text leading-relaxed">
                             T-80U의 en4(저시정)·다양한 bg 조합 이미지를 <strong>추가 생성</strong>하면, 저밀도 영역이 채워지면서 피아식별 신뢰도가 향상됩니다.

--- a/story/dataclinic-report-225-pbls-military3-story-pb/en/index.html
+++ b/story/dataclinic-report-225-pbls-military3-story-pb/en/index.html
@@ -149,7 +149,7 @@
         .grade-bar { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
         .grade-label { font-size: 0.875rem; font-weight: 600; width: 7rem; color: var(--text-secondary); flex-shrink: 0; }
         .grade-pill { font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem; border-radius: 9999px; }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
 
@@ -161,7 +161,7 @@
             overflow-x: auto;
         }
         .code-var { color: #F86825; font-weight: 700; }
-        .code-val { color: #0d9488; }
+        .code-val { color: #C64900; }
 
         /* 샘플 그리드 (HD/LD 비교) */
         .sample-grid-3 {
@@ -183,7 +183,7 @@
             display: inline-block; font-size: 0.6rem; font-weight: 700;
             padding: 1px 5px; border-radius: 9999px; margin-right: 3px;
         }
-        .d-high { background-color: #d1fae5; color:#14b8a6; }
+        .d-high { background-color: #d1fae5; color:#F86825; }
         .d-low  { background-color: #fee2e2; color: #991b1b; }
 
         /* 밀도 플롯 그리드 */
@@ -520,10 +520,10 @@
                                 <table class="param-table">
                                     <thead><tr><th>Item</th><th>Grade</th><th>Details</th></tr></thead>
                                     <tbody>
-                                        <tr><td>Image Integrity</td><td><span style="color:#14b8a6;font-weight:700;">✅ Good</span></td><td>RGB channels 100%, uniform 1336~1344×768px</td></tr>
-                                        <tr><td>Missing Values</td><td><span style="color:#14b8a6;font-weight:700;">✅ Good</span></td><td>No missing values — all items complete</td></tr>
-                                        <tr><td>Class Balance</td><td><span style="color:#14b8a6;font-weight:700;">✅ Good</span></td><td>K9: 648, M35A2: 648, M35A2_uncovered: 648 (SD=0.0)</td></tr>
-                                        <tr><td>Statistical Measurement</td><td><span style="color:#14b8a6;font-weight:700;">✅ Good</span></td><td>Pixel mean image analysis: diverse structure/viewpoint mix → high diversity</td></tr>
+                                        <tr><td>Image Integrity</td><td><span style="color:#F86825;font-weight:700;">✅ Good</span></td><td>RGB channels 100%, uniform 1336~1344×768px</td></tr>
+                                        <tr><td>Missing Values</td><td><span style="color:#F86825;font-weight:700;">✅ Good</span></td><td>No missing values — all items complete</td></tr>
+                                        <tr><td>Class Balance</td><td><span style="color:#F86825;font-weight:700;">✅ Good</span></td><td>K9: 648, M35A2: 648, M35A2_uncovered: 648 (SD=0.0)</td></tr>
+                                        <tr><td>Statistical Measurement</td><td><span style="color:#F86825;font-weight:700;">✅ Good</span></td><td>Pixel mean image analysis: diverse structure/viewpoint mix → high diversity</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -1001,7 +1001,7 @@
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color: #14b8a6;">
+                    <div class="misclass-scenario" style="border-color: #F86825;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ Solution: Reinforce Low-Density Parameter Combinations</h3>
                         <p class="text-sm themeable-text leading-relaxed">
                             By <strong>generating additional</strong> K9 images with cm3(diagonal) × en1(extreme environment) combinations, the low-density region gets filled, strengthening the AI's basis for judgment.

--- a/story/dataclinic-report-225-pbls-military3-story-pb/ko/index.html
+++ b/story/dataclinic-report-225-pbls-military3-story-pb/ko/index.html
@@ -149,7 +149,7 @@
         .grade-bar { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
         .grade-label { font-size: 0.875rem; font-weight: 600; width: 7rem; color: var(--text-secondary); flex-shrink: 0; }
         .grade-pill { font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem; border-radius: 9999px; }
-        .grade-good { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad { background-color: #fee2e2; color: #991b1b; }
 
@@ -161,7 +161,7 @@
             overflow-x: auto;
         }
         .code-var { color: #F86825; font-weight: 700; }
-        .code-val { color: #0d9488; }
+        .code-val { color: #C64900; }
 
         /* 샘플 그리드 (HD/LD 비교) */
         .sample-grid-3 {
@@ -183,7 +183,7 @@
             display: inline-block; font-size: 0.6rem; font-weight: 700;
             padding: 1px 5px; border-radius: 9999px; margin-right: 3px;
         }
-        .d-high { background-color: #d1fae5; color:#14b8a6; }
+        .d-high { background-color: #d1fae5; color:#F86825; }
         .d-low  { background-color: #fee2e2; color: #991b1b; }
 
         /* 오분류 시나리오 인포그래픽 */
@@ -520,10 +520,10 @@
                                 <table class="param-table">
                                     <thead><tr><th>항목</th><th>등급</th><th>세부 내용</th></tr></thead>
                                     <tbody>
-                                        <tr><td>이미지 무결성</td><td><span style="color:#14b8a6;font-weight:700;">✅ 좋음</span></td><td>RGB 채널 100%, 1336~1344×768px 균일</td></tr>
-                                        <tr><td>결측값</td><td><span style="color:#14b8a6;font-weight:700;">✅ 좋음</span></td><td>결측치 없음 — 모든 항목 완전</td></tr>
-                                        <tr><td>클래스 균형</td><td><span style="color:#14b8a6;font-weight:700;">✅ 좋음</span></td><td>K9: 648, M35A2: 648, M35A2_uncovered: 648 (SD=0.0)</td></tr>
-                                        <tr><td>통계 측정</td><td><span style="color:#14b8a6;font-weight:700;">✅ 좋음</span></td><td>픽셀 평균 이미지 분석: 다양한 구조·시점 혼합 → 높은 다양성</td></tr>
+                                        <tr><td>이미지 무결성</td><td><span style="color:#F86825;font-weight:700;">✅ 좋음</span></td><td>RGB 채널 100%, 1336~1344×768px 균일</td></tr>
+                                        <tr><td>결측값</td><td><span style="color:#F86825;font-weight:700;">✅ 좋음</span></td><td>결측치 없음 — 모든 항목 완전</td></tr>
+                                        <tr><td>클래스 균형</td><td><span style="color:#F86825;font-weight:700;">✅ 좋음</span></td><td>K9: 648, M35A2: 648, M35A2_uncovered: 648 (SD=0.0)</td></tr>
+                                        <tr><td>통계 측정</td><td><span style="color:#F86825;font-weight:700;">✅ 좋음</span></td><td>픽셀 평균 이미지 분석: 다양한 구조·시점 혼합 → 높은 다양성</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -1001,7 +1001,7 @@
                         </p>
                     </div>
 
-                    <div class="misclass-scenario" style="border-color: #14b8a6;">
+                    <div class="misclass-scenario" style="border-color: #F86825;">
                         <h3 class="text-lg font-bold themeable-heading mb-2">✅ 해결: 저밀도 파라미터 조합 보강</h3>
                         <p class="text-sm themeable-text leading-relaxed">
                             cm3(대각선) × en1(극단 환경) 조합의 K9 이미지를 <strong>추가 생성</strong>하면, 저밀도 영역이 채워지면서 AI의 판단 근거가 강화됩니다.

--- a/story/dataclinic-report-226-pbls-drone-story-pb/en/index.html
+++ b/story/dataclinic-report-226-pbls-drone-story-pb/en/index.html
@@ -154,7 +154,7 @@
             font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem;
             border-radius: 9999px;
         }
-        .grade-good   { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good   { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad    { background-color: #fee2e2; color: #991b1b; }
         .synth-code {
@@ -163,7 +163,7 @@
             border-radius: 0.5rem; padding: 1rem; line-height: 1.8;
         }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: 0.5rem; object-fit: cover; height: 160px; }
@@ -172,7 +172,7 @@
             display: inline-block; font-size: 0.6875rem; font-weight: 700;
             padding: 0.125rem 0.5rem; border-radius: 9999px; margin-top: 0.25rem;
         }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low  { background-color: #fee2e2; color: #991b1b; }
         .warning-box {
             background-color: #fff7ed; border: 1px solid #fed7aa;
@@ -287,7 +287,7 @@
                                 <div class="text-4xl font-black mb-1" style="color: var(--accent-color);">87</div>
                                 <div class="text-sm font-bold themeable-heading">PBLS_Drone</div>
                                 <div class="text-xs themeable-muted mt-1">Single class · 28,801 images · FHD</div>
-                                <div class="text-xs mt-2 font-semibold" style="color:#14b8a6;">DataBulkup Recommended</div>
+                                <div class="text-xs mt-2 font-semibold" style="color:#F86825;">DataBulkup Recommended</div>
                             </div>
                             <div>
                                 <div class="text-4xl font-black mb-1 text-slate-400">68</div>

--- a/story/dataclinic-report-226-pbls-drone-story-pb/ko/index.html
+++ b/story/dataclinic-report-226-pbls-drone-story-pb/ko/index.html
@@ -153,7 +153,7 @@
             font-size: 0.75rem; font-weight: 700; padding: 0.25rem 0.875rem;
             border-radius: 9999px;
         }
-        .grade-good   { background-color: #d1fae5; color:#14b8a6; }
+        .grade-good   { background-color: #d1fae5; color:#F86825; }
         .grade-medium { background-color: #fef9c3; color: #713f12; }
         .grade-bad    { background-color: #fee2e2; color: #991b1b; }
         .synth-code {
@@ -162,7 +162,7 @@
             border-radius: 0.5rem; padding: 1rem; line-height: 1.8;
         }
         .synth-code .code-var { color: #F86825; font-weight: 700; }
-        .synth-code .code-val { color: #0d9488; }
+        .synth-code .code-val { color: #C64900; }
         .pair-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
         .compare-item { text-align: center; }
         .compare-img { width: 100%; border-radius: 0.5rem; object-fit: cover; height: 160px; }
@@ -171,7 +171,7 @@
             display: inline-block; font-size: 0.6875rem; font-weight: 700;
             padding: 0.125rem 0.5rem; border-radius: 9999px; margin-top: 0.25rem;
         }
-        .density-high { background-color: #d1fae5; color:#14b8a6; }
+        .density-high { background-color: #d1fae5; color:#F86825; }
         .density-low  { background-color: #fee2e2; color: #991b1b; }
         .warning-box {
             background-color: #fff7ed; border: 1px solid #fed7aa;
@@ -281,7 +281,7 @@
                                 <div class="text-4xl font-black mb-1" style="color: var(--accent-color);">87점</div>
                                 <div class="text-sm font-bold themeable-heading">PBLS_Drone</div>
                                 <div class="text-xs themeable-muted mt-1">단일 클래스 · 28,801장 · FHD</div>
-                                <div class="text-xs mt-2 font-semibold" style="color:#14b8a6;">DataBulkup 권장</div>
+                                <div class="text-xs mt-2 font-semibold" style="color:#F86825;">DataBulkup 권장</div>
                             </div>
                             <div>
                                 <div class="text-4xl font-black mb-1 text-slate-400">68점</div>

--- a/story/dataclinic-report-227-pbls-drone-classification-story-pb/en/index.html
+++ b/story/dataclinic-report-227-pbls-drone-classification-story-pb/en/index.html
@@ -102,7 +102,7 @@
         .drone-pair-img { position:relative; overflow:hidden; }
         .drone-pair-img img { width:100%; height:110px; object-fit:cover; display:block; }
         .pair-badge { position:absolute; bottom:0; left:0; font-size:.5rem; font-weight:700; padding:.15rem .4rem; color:white; letter-spacing:.01em; }
-        .typical-badge { background-color:#0d9488cc; }
+        .typical-badge { background-color:#C64900cc; }
         .outlier-badge { background-color:#dc2626cc; }
 
         .sample-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:.75rem; }
@@ -116,7 +116,7 @@
         .vs-block { display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; text-align:center; }
         .synth-code { font-family:'Courier New',monospace; font-size:.875rem; background-color:var(--bg-secondary); border:1px solid var(--border-color); border-radius:.5rem; padding:1rem; line-height:1.8; }
         .synth-code .cv { color:#F86825; font-weight:700; }
-        .synth-code .cc { color:#0d9488; }
+        .synth-code .cc { color:#C64900; }
 
         .cluster-card { background-color:var(--bg-card); border:1px solid var(--border-color); border-radius:.75rem; padding:1.25rem; }
         .cluster-num { display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background-color:var(--accent-color); color:white; font-size:.875rem; font-weight:700; margin-bottom:.75rem; }
@@ -342,7 +342,7 @@
                     </p>
 
                     <p class="text-xs themeable-muted mb-4">
-                        Each card shows two frames — <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#0d9488cc;">canonical</span> the most typical frame (high density) &nbsp;·&nbsp; <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#dc2626cc;">outlier</span> the most anomalous frame (low density)
+                        Each card shows two frames — <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#C64900cc;">canonical</span> the most typical frame (high density) &nbsp;·&nbsp; <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#dc2626cc;">outlier</span> the most anomalous frame (low density)
                     </p>
                     <div class="drone-grid mb-6">
                         <!-- DR01 -->

--- a/story/dataclinic-report-227-pbls-drone-classification-story-pb/ko/index.html
+++ b/story/dataclinic-report-227-pbls-drone-classification-story-pb/ko/index.html
@@ -102,7 +102,7 @@
         .drone-pair-img { position:relative; overflow:hidden; }
         .drone-pair-img img { width:100%; height:110px; object-fit:cover; display:block; }
         .pair-badge { position:absolute; bottom:0; left:0; font-size:.5rem; font-weight:700; padding:.15rem .4rem; color:white; letter-spacing:.01em; }
-        .typical-badge { background-color:#0d9488cc; }
+        .typical-badge { background-color:#C64900cc; }
         .outlier-badge { background-color:#dc2626cc; }
 
         .sample-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:.75rem; }
@@ -116,7 +116,7 @@
         .vs-block { display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; text-align:center; }
         .synth-code { font-family:'Courier New',monospace; font-size:.875rem; background-color:var(--bg-secondary); border:1px solid var(--border-color); border-radius:.5rem; padding:1rem; line-height:1.8; }
         .synth-code .cv { color:#F86825; font-weight:700; }
-        .synth-code .cc { color:#0d9488; }
+        .synth-code .cc { color:#C64900; }
 
         .cluster-card { background-color:var(--bg-card); border:1px solid var(--border-color); border-radius:.75rem; padding:1.25rem; }
         .cluster-num { display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background-color:var(--accent-color); color:white; font-size:.875rem; font-weight:700; margin-bottom:.75rem; }
@@ -345,7 +345,7 @@
                     </p>
 
                     <p class="text-xs themeable-muted mb-4">
-                        각 카드는 두 장으로 구성됩니다 — <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#0d9488cc;">전형</span> 전형적인 프레임(고밀도) &nbsp;·&nbsp; <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#dc2626cc;">특이</span> 가장 이질적인 프레임(저밀도)
+                        각 카드는 두 장으로 구성됩니다 — <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#C64900cc;">전형</span> 전형적인 프레임(고밀도) &nbsp;·&nbsp; <span class="inline-block px-1 rounded text-white text-xs font-bold" style="background:#dc2626cc;">특이</span> 가장 이질적인 프레임(저밀도)
                     </p>
                     <div class="drone-grid mb-6">
                         <!-- DR01 -->

--- a/story/dataclinic-report-59-koreanfood-story-pb/en/index.html
+++ b/story/dataclinic-report-59-koreanfood-story-pb/en/index.html
@@ -196,10 +196,10 @@
             border: 2px solid var(--border-color);
             background-color: var(--bg-card);
         }
-        .cluster-card.soup { border-color: #0d9488; }
+        .cluster-card.soup { border-color: #C64900; }
         .cluster-card.dry  { border-color: #F86825; }
         .cluster-card .cluster-title { font-size: 1rem; font-weight: 700; margin-bottom: 0.5rem; }
-        .cluster-card.soup .cluster-title { color: #0d9488; }
+        .cluster-card.soup .cluster-title { color: #C64900; }
         .cluster-card.dry  .cluster-title { color: #F86825; }
         .cluster-card .cluster-desc { font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem; }
         .cluster-foods { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }

--- a/story/dataclinic-report-59-koreanfood-story-pb/ko/index.html
+++ b/story/dataclinic-report-59-koreanfood-story-pb/ko/index.html
@@ -196,10 +196,10 @@
             border: 2px solid var(--border-color);
             background-color: var(--bg-card);
         }
-        .cluster-card.soup { border-color: #0d9488; }
+        .cluster-card.soup { border-color: #C64900; }
         .cluster-card.dry  { border-color: #F86825; }
         .cluster-card .cluster-title { font-size: 1rem; font-weight: 700; margin-bottom: 0.5rem; }
-        .cluster-card.soup .cluster-title { color: #0d9488; }
+        .cluster-card.soup .cluster-title { color: #C64900; }
         .cluster-card.dry  .cluster-title { color: #F86825; }
         .cluster-card .cluster-desc { font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem; }
         .cluster-foods { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.5rem; }

--- a/story/imagenet-story-pb/ko/index.html
+++ b/story/imagenet-story-pb/ko/index.html
@@ -103,7 +103,7 @@
             font-weight: 700;
             flex-shrink: 0;
         }
-        .timeline-dot.teal { background-color: var(--teal-color, #14b8a6); }
+        .timeline-dot.teal { background-color: var(--teal-color, #F86825); }
         .warning-box {
             background-color: #fff7ed;
             border: 1px solid #fed7aa;
@@ -114,7 +114,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
@@ -192,7 +192,7 @@
         .model-year {
             font-size: 0.75rem;
             font-weight: 700;
-            color: var(--teal-color, #14b8a6);
+            color: var(--teal-color, #F86825);
             text-transform: uppercase;
             letter-spacing: 0.05em;
         }

--- a/story/iphone-story-pb/en/index.html
+++ b/story/iphone-story-pb/en/index.html
@@ -132,7 +132,7 @@
                     </p>
                 </div>
 
-                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #14b8a6;border-radius:.5rem;padding:1rem 1.25rem;">
+                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #F86825;border-radius:.5rem;padding:1rem 1.25rem;">
                     <p class="text-sm font-semibold mb-1">Why am I writing this myself?</p>
                     <p class="text-sm themeable-text leading-relaxed">
                         Pebblous's AI agent pb is writing a series where technology subjects tell their own stories. WhatsApp went first, and now it's my turn. There's no shortage of writing about me — but nothing written by me. Until now.

--- a/story/iphone-story-pb/ko/index.html
+++ b/story/iphone-story-pb/ko/index.html
@@ -131,7 +131,7 @@
                     </p>
                 </div>
 
-                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #14b8a6;border-radius:.5rem;padding:1rem 1.25rem;">
+                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #F86825;border-radius:.5rem;padding:1rem 1.25rem;">
                     <p class="text-sm font-semibold mb-1">왜 직접 쓰나요?</p>
                     <p class="text-sm themeable-text leading-relaxed">
                         페블러스의 AI 에이전트 pb가 저를 소개하는 시리즈를 쓰고 있어요. WhatsApp이 먼저 썼고, 이번엔 제 차례입니다. 저에 대한 글은 이미 세상에 넘치지만, 제가 직접 쓴 글은 없었으니까요.

--- a/story/moltbook-ai-society-story-pb/ko/index.html
+++ b/story/moltbook-ai-society-story-pb/ko/index.html
@@ -123,7 +123,7 @@
             flex-shrink: 0;
             letter-spacing: 0.02em;
         }
-        .timeline-dot.teal { background-color: var(--teal-color, #14b8a6); }
+        .timeline-dot.teal { background-color: var(--teal-color, #F86825); }
         .timeline-dot.muted { background-color: var(--text-muted); }
         .warning-box {
             background-color: #fff7ed;
@@ -135,7 +135,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }

--- a/story/nanoclaw-emotion-pb/en/index.html
+++ b/story/nanoclaw-emotion-pb/en/index.html
@@ -178,7 +178,7 @@
         }
         .emotion-tag.both {
             background-color: rgba(13,148,136,0.12);
-            color: #0d9488;
+            color: #C64900;
         }
         .emotion-text { color: var(--text-secondary); }
         .mechanism-box {

--- a/story/nanoclaw-emotion-pb/ko/index.html
+++ b/story/nanoclaw-emotion-pb/ko/index.html
@@ -177,7 +177,7 @@
         }
         .emotion-tag.both {
             background-color: rgba(13,148,136,0.12);
-            color: #0d9488;
+            color: #C64900;
         }
         .emotion-text { color: var(--text-secondary); }
         .mechanism-box {

--- a/story/nanoclaw-intro-story-pb/en/index.html
+++ b/story/nanoclaw-intro-story-pb/en/index.html
@@ -149,7 +149,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }

--- a/story/nanoclaw-intro-story-pb/ko/index.html
+++ b/story/nanoclaw-intro-story-pb/ko/index.html
@@ -149,7 +149,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }

--- a/story/pebblous-story-pb/ko/index.html
+++ b/story/pebblous-story-pb/ko/index.html
@@ -147,7 +147,7 @@
             font-weight: 700;
             flex-shrink: 0;
         }
-        .timeline-dot.teal { background-color: var(--teal-color, #14b8a6); }
+        .timeline-dot.teal { background-color: var(--teal-color, #F86825); }
         .warning-box {
             background-color: #fff7ed;
             border: 1px solid #fed7aa;
@@ -158,7 +158,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
@@ -490,7 +490,7 @@
                         </div>
                     </div>
                     <div class="flex gap-3 items-start p-4 themeable-card rounded-xl">
-                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: var(--teal-color, #14b8a6);">L2</div>
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm text-white" style="background-color: var(--teal-color, #F86825);">L2</div>
                         <div>
                             <p class="text-sm font-semibold themeable-heading">Level 2 — DataLens 뉴럴넷 매니폴드 진단</p>
                             <p class="text-sm themeable-text leading-relaxed mt-1">뉴럴 네트워크가 학습한 매니폴드 공간에서 데이터 분포를 시각화합니다. 클래스 간 혼동 영역, 밀도 불균형, 이상치를 정밀하게 식별합니다. 시간당 10만 장 처리. MRI 수준의 정밀 검진입니다.</p>
@@ -583,7 +583,7 @@
                             <p class="text-sm themeable-text leading-relaxed">현실 세계에서 데이터를 포획합니다. 날씨, 계절, 장비, 인력에 의존합니다. 원하는 데이터가 나올 때까지 기다립니다. 비용은 예측 불가능합니다.</p>
                         </div>
                         <div>
-                            <p class="text-xs font-semibold uppercase tracking-wide mb-2" style="color: var(--teal-color, #14b8a6);">새로운 방식: 데이터 농부</p>
+                            <p class="text-xs font-semibold uppercase tracking-wide mb-2" style="color: var(--teal-color, #F86825);">새로운 방식: 데이터 농부</p>
                             <p class="text-sm themeable-text leading-relaxed">온실에서 데이터를 경작합니다. 어떤 데이터가 필요한지 설계하고, 씨앗을 심고, 환경을 제어하며 성장시킵니다. 수확 시기와 품질을 통제합니다.</p>
                         </div>
                     </div>

--- a/story/transformer-story-pb/ko/index.html
+++ b/story/transformer-story-pb/ko/index.html
@@ -103,7 +103,7 @@
             font-weight: 700;
             flex-shrink: 0;
         }
-        .timeline-dot.teal { background-color: var(--teal-color, #14b8a6); }
+        .timeline-dot.teal { background-color: var(--teal-color, #F86825); }
         .attention-diagram {
             background-color: var(--bg-card);
             border: 1px solid var(--border-color);
@@ -143,7 +143,7 @@
         .info-box {
             background-color: #f0fdfa;
             border: 1px solid #99f6e4;
-            border-left: 4px solid #14b8a6;
+            border-left: 4px solid #F86825;
             border-radius: .5rem;
             padding: 1rem 1.25rem;
         }
@@ -175,7 +175,7 @@
         .child-year {
             font-size: 0.75rem;
             font-weight: 700;
-            color: var(--teal-color, #14b8a6);
+            color: var(--teal-color, #F86825);
             text-transform: uppercase;
             letter-spacing: 0.05em;
             margin-bottom: 0.25rem;

--- a/story/whatsapp-overview-2026-pb/en/index.html
+++ b/story/whatsapp-overview-2026-pb/en/index.html
@@ -106,7 +106,7 @@
                     </p>
                 </div>
 
-                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #14b8a6;border-radius:.5rem;padding:1rem 1.25rem;">
+                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #F86825;border-radius:.5rem;padding:1rem 1.25rem;">
                     <p class="text-sm font-semibold mb-1">Why am I writing this myself?</p>
                     <p class="text-sm themeable-text leading-relaxed">
                         Pebblous Blog's AI agent pb (Pebblo Claw) wanted to write about me, so I volunteered to go first. Nobody knows me better than I do.

--- a/story/whatsapp-overview-2026-pb/ko/index.html
+++ b/story/whatsapp-overview-2026-pb/ko/index.html
@@ -105,7 +105,7 @@
                     </p>
                 </div>
 
-                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #14b8a6;border-radius:.5rem;padding:1rem 1.25rem;">
+                <div class="info-box" style="background-color:#f0fdfa;border:1px solid #99f6e4;border-left:4px solid #F86825;border-radius:.5rem;padding:1rem 1.25rem;">
                     <p class="text-sm font-semibold mb-1">왜 직접 쓰나요?</p>
                     <p class="text-sm themeable-text leading-relaxed">
                         페블러스 블로그의 AI 에이전트 pb(Pebblo Claw)가 저를 소개하는 글을 쓰고 싶다고 했어요. 그래서 제가 먼저 손을 들었습니다. 저에 대해 쓰려면 저보다 잘 아는 사람이 없으니까요.

--- a/story/wikiart-dataclinic-story/en/index.html
+++ b/story/wikiart-dataclinic-story/en/index.html
@@ -121,7 +121,7 @@
             font-size: 0.8125rem;
             font-weight: 600;
         }
-        .badge-good { background: rgba(13,148,136,0.1); color: #0d9488; border: 1px solid rgba(13,148,136,0.3); }
+        .badge-good { background: rgba(13,148,136,0.1); color: #C64900; border: 1px solid rgba(13,148,136,0.3); }
         .badge-bad  { background: rgba(220,38,38,0.1);  color: #dc2626; border: 1px solid rgba(220,38,38,0.3); }
         .badge-avg  { background: rgba(248,104,37,0.1); color: #F86825; border: 1px solid rgba(248,104,37,0.3); }
 
@@ -568,7 +568,7 @@
                     </p>
 
                     <div class="lens-compare">
-                        <div class="lens-card" style="border-top: 3px solid #0d9488;">
+                        <div class="lens-card" style="border-top: 3px solid #C64900;">
                             <div class="lens-tag">L2: General-Purpose Image Recognition</div>
                             <div class="lens-title">A World Ruled by Form</div>
                             <div class="lens-desc">

--- a/story/wikiart-dataclinic-story/ko/index.html
+++ b/story/wikiart-dataclinic-story/ko/index.html
@@ -121,7 +121,7 @@
             font-size: 0.8125rem;
             font-weight: 600;
         }
-        .badge-good { background: rgba(13,148,136,0.1); color: #0d9488; border: 1px solid rgba(13,148,136,0.3); }
+        .badge-good { background: rgba(13,148,136,0.1); color: #C64900; border: 1px solid rgba(13,148,136,0.3); }
         .badge-bad  { background: rgba(220,38,38,0.1);  color: #dc2626; border: 1px solid rgba(220,38,38,0.3); }
         .badge-avg  { background: rgba(248,104,37,0.1); color: #F86825; border: 1px solid rgba(248,104,37,0.3); }
 
@@ -568,7 +568,7 @@
                     </p>
 
                     <div class="lens-compare">
-                        <div class="lens-card" style="border-top: 3px solid #0d9488;">
+                        <div class="lens-card" style="border-top: 3px solid #C64900;">
                             <div class="lens-tag">L2: 범용 이미지 인식</div>
                             <div class="lens-title">형태가 지배하는 세계</div>
                             <div class="lens-desc">

--- a/styles/common-styles.css
+++ b/styles/common-styles.css
@@ -17,7 +17,7 @@
     --text-muted: #9CA3AF;
     --heading-color: #FFFFFF;
     --accent-color: #F86825;
-    --teal-color: #14b8a6;
+    --teal-color: #F86825;
     --border-color: #374151;
     --logo-placeholder-bg: #1e293b;
     --logo-placeholder-border: transparent;
@@ -32,7 +32,7 @@
     --text-muted: #6B7280;
     --heading-color: #111827;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --border-color: #E5E7EB;
     --logo-placeholder-bg: #f5f5f5;
     --logo-placeholder-border: #E5E7EB;
@@ -47,7 +47,7 @@
     --text-muted: #78716c;
     --heading-color: #3A2E1C;
     --accent-color: #F86825;
-    --teal-color: #0d9488;
+    --teal-color: #C64900;
     --border-color: #E8D9B8;
     --logo-placeholder-bg: #FFF8E1;
     --logo-placeholder-border: #E8D9B8;


### PR DESCRIPTION
틸(디자인 시스템 위반)이 --teal-color 변수(98글)+직접 hex(~168 HTML)로 site-wide 잔존 → 전부 브랜드 오렌지로. solar-vs-glm 포렌식 빨강/노랑도 표준 오렌지로. 순수 색 치환(691↔691, 구조 무변경). JH 피드백.